### PR TITLE
Specialize less

### DIFF
--- a/myia/abstract/data.py
+++ b/myia/abstract/data.py
@@ -178,17 +178,12 @@ class AbstractValue(AbstractBase):
         values: A dictionary mapping a Track like VALUE or TYPE
             to a value for that track. Different abstract structures
             may have different tracks, e.g. SHAPE for arrays.
-        count: A "depth" count tracking the constant propagation
-            depth. The inference engine can be configured to broaden
-            an abstract value past a certain depth. Note that the count
-            is ignored for equality purposes.
 
     """
 
-    def __init__(self, values, count=0):
+    def __init__(self, values):
         """Initialize an AbstractValue."""
         self.values = TrackDict(values)
-        self.count = count
 
     def _make_key(self):
         return tuple(sorted(self.values.items()))

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -8,7 +8,8 @@ from dataclasses import is_dataclass, replace as dc_replace
 from .. import dtype
 from ..ir import Graph, MetaGraph, GraphGenerationError
 from ..prim import Primitive, ops as P
-from ..utils import Overload, Partializable, is_dataclass_type
+from ..utils import Overload, Partializable, is_dataclass_type, \
+    SymbolicKeyInstance
 
 from .loop import Pending, force_pending, InferenceLoop
 from .ref import VirtualReference, Context, EvaluationCache, Reference
@@ -347,6 +348,9 @@ def to_abstract(v, context=None, ref=None, loop=None):
 
     elif isinstance(v, Primitive):
         return AbstractFunction(PrimitiveFunction(v, tracking_id=ref))
+
+    elif isinstance(v, SymbolicKeyInstance):
+        return AbstractScalar({VALUE: v, TYPE: dtype.SymbolicKeyType})
 
     elif is_dataclass_type(v):
         typ = dtype.pytype_to_myiatype(v)

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -540,6 +540,13 @@ class GraphInferrer(BaseGraphInferrer):
         assert context is not None
         super().__init__(context.filter(graph))
 
+    def normalize_args(self, args):
+        """Broaden args if flag ignore_values is True."""
+        if self._graph.flags.get('ignore_values', False):
+            return tuple(_broaden(a, None) for a in args)
+        else:
+            return args
+
     def get_graph(self, engine, args):
         """Return the graph."""
         return self._graph

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -423,6 +423,13 @@ class Inferrer(Partializable):
         """Initialize the Inferrer."""
         self.cache = {}
 
+    def normalize_args(self, args):
+        """Return normalized versions of the arguments.
+
+        By default, this returns args unchanged.
+        """
+        return args
+
     async def run(self, engine, outref, argrefs):
         """Run inference.
 
@@ -436,6 +443,7 @@ class Inferrer(Partializable):
             argrefs: A tuple of References to the arguments
         """
         args = tuple([await ref.get() for ref in argrefs])
+        args = self.normalize_args(args)
         if args not in self.cache:
             self.cache[args] = await self.infer(engine, *args)
         return self.cache[args]
@@ -491,6 +499,7 @@ class BaseGraphInferrer(Inferrer):
 
     def make_context(self, engine, args):
         """Create a Context object using the given args."""
+        args = self.normalize_args(args)
         _, ctx = self._make_argkey_and_context(engine, args)
         return ctx
 
@@ -546,6 +555,10 @@ class MetaGraphInferrer(BaseGraphInferrer):
         super().__init__(Context.empty())
         self.metagraph = metagraph
         self.graph_cache = {}
+
+    def normalize_args(self, args):
+        """Return normalized versions of the arguments."""
+        return self.metagraph.normalize_args(args)
 
     def get_graph(self, engine, args):
         """Generate the graph for the given args."""

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -33,7 +33,6 @@ class InferenceEngine:
         constructors: As an argument to __init__, a map from primitives
             to inferrer classes, which will be instantiated automatically
             by the InferenceEngine.
-        max_depth: Depth for constant propagation.
         context_class: The class to use to instantiate contexts.
 
     """
@@ -42,7 +41,6 @@ class InferenceEngine:
                  pipeline,
                  *,
                  constructors,
-                 max_depth=1,
                  context_class=Context):
         """Initialize the InferenceEngine."""
         self.loop = InferenceLoop(InferenceError)
@@ -52,7 +50,6 @@ class InferenceEngine:
             prim: cons()
             for prim, cons in constructors.items()
         }
-        self.max_depth = max_depth
         self.cache = EvaluationCache(loop=self.loop, keycalc=self.compute_ref)
         self.errors = []
         self.context_class = context_class

--- a/myia/abstract/prim.py
+++ b/myia/abstract/prim.py
@@ -97,16 +97,15 @@ class WithImplInferrer(Inferrer):
 
     Arguments:
         impl: The implementation.
-        nolimit: Whether constant propagation through this implementation
-            should be limited by the max_depth parameter to an
-            InferenceEngine.
+        infer_value: Whether to do constant propagation through this
+            implementation.
     """
 
-    def __init__(self, impl, nolimit=False):
+    def __init__(self, impl, infer_value=False):
         """Initialize a WithImplInferrer."""
         super().__init__()
         self.impl = impl
-        self.nolimit = nolimit
+        self.infer_value = infer_value
         data = inspect.getfullargspec(impl)
         assert data.varargs is None
         assert data.varkw is None
@@ -119,15 +118,13 @@ class WithImplInferrer(Inferrer):
     def run_impl(self, engine, args, outtype):
         """Run the implementation on abstract data.
 
-        If nolimit is False, this takes into account engine.max_depth.
+        If infer_value is False, this returns an AbstractScalar with value
+        ANYTHING.
 
-        Arguments:
-            engine: The InferenceEngine
-            args: The abstract arguments
+        Arguments: engine: The InferenceEngine args: The abstract arguments
             outtype: The output type to give to the result
         """
-        depth = max((arg.count for arg in args), default=0)
-        if not self.nolimit and depth >= engine.max_depth:
+        if not self.infer_value:
             outval = ANYTHING
         else:
             values = [arg.values[VALUE] for arg in args]
@@ -136,14 +133,10 @@ class WithImplInferrer(Inferrer):
             else:
                 outval = self.impl(*values)
 
-        if outval is ANYTHING:
-            depth = engine.max_depth
-        rval = AbstractScalar({
+        return AbstractScalar({
             VALUE: outval,
             TYPE: outtype,
         })
-        rval.count = min(depth + 1, engine.max_depth)
-        return rval
 
 
 class UniformPrimitiveInferrer(WithImplInferrer):
@@ -154,25 +147,24 @@ class UniformPrimitiveInferrer(WithImplInferrer):
 
     Arguments:
         impl: The implementation.
-        nolimit: Whether constant propagation through this implementation
-            should be limited by the max_depth parameter to an
-            InferenceEngine.
+        infer_value: Whether to do constant propagation through this
+            implementation.
     """
 
-    def __init__(self, impl, nolimit=False):
+    def __init__(self, impl, infer_value=False):
         """Initialize a UniformPrimitiveInferrer."""
-        super().__init__(impl, nolimit)
+        super().__init__(impl, infer_value)
         data = self.impl_data
         self.typemap = defaultdict(list)
         # We group the arguments with the same types together.
         for i, arg in enumerate(data.args):
             self.typemap[data.annotations[arg]].append(i)
         self.outtype = data.annotations['return']
-        self.nolimit = nolimit
+        self.infer_value = infer_value
 
     def normalize_args(self, args):
-        """If nolimit is False, return broadened arguments."""
-        if not self.nolimit:
+        """If infer_value is False, return broadened arguments."""
+        if not self.infer_value:
             args = tuple(broaden(a, None) for a in args)
         return args
 
@@ -193,16 +185,19 @@ class UniformPrimitiveInferrer(WithImplInferrer):
         return self.run_impl(engine, args, outtype)
 
 
-def uniform_prim(prim, nolimit=False):
+def uniform_prim(prim, infer_value=False):
     """Decorator to define and register a UniformPrimitiveInferrer.
 
     Arguments:
         prim: The primitive for which the inferrer is defined.
-        nolimit: Whether to limit constant propagation through this
+        infer_value: Whether to limit constant propagation through this
             operation or not.
     """
     def deco(fn):
-        xinf = UniformPrimitiveInferrer.partial(impl=fn, nolimit=nolimit)
+        xinf = UniformPrimitiveInferrer.partial(
+            impl=fn,
+            infer_value=infer_value
+        )
         abstract_inferrer_constructors[prim] = xinf
     return deco
 
@@ -422,8 +417,8 @@ uniform_prim(P.scalar_mod)(py.scalar_mod)
 uniform_prim(P.scalar_pow)(py.scalar_pow)
 uniform_prim(P.scalar_trunc)(py.scalar_trunc)
 uniform_prim(P.scalar_floor)(py.scalar_floor)
-uniform_prim(P.scalar_uadd, nolimit=True)(py.scalar_uadd)
-uniform_prim(P.scalar_usub, nolimit=True)(py.scalar_usub)
+uniform_prim(P.scalar_uadd, infer_value=True)(py.scalar_uadd)
+uniform_prim(P.scalar_usub, infer_value=True)(py.scalar_usub)
 uniform_prim(P.scalar_exp)(py.scalar_exp)
 uniform_prim(P.scalar_log)(py.scalar_log)
 uniform_prim(P.scalar_sin)(py.scalar_sin)
@@ -436,16 +431,16 @@ uniform_prim(P.scalar_tan)(py.scalar_tan)
 ###############
 
 
-uniform_prim(P.scalar_eq, nolimit=True)(py.scalar_eq)
-uniform_prim(P.scalar_lt, nolimit=True)(py.scalar_lt)
-uniform_prim(P.scalar_gt, nolimit=True)(py.scalar_gt)
-uniform_prim(P.scalar_ne, nolimit=True)(py.scalar_ne)
-uniform_prim(P.scalar_le, nolimit=True)(py.scalar_le)
-uniform_prim(P.scalar_ge, nolimit=True)(py.scalar_ge)
-uniform_prim(P.bool_not, nolimit=True)(py.bool_not)
-uniform_prim(P.bool_and, nolimit=True)(py.bool_and)
-uniform_prim(P.bool_or, nolimit=True)(py.bool_or)
-uniform_prim(P.bool_eq, nolimit=True)(py.bool_eq)
+uniform_prim(P.scalar_eq, infer_value=True)(py.scalar_eq)
+uniform_prim(P.scalar_lt, infer_value=True)(py.scalar_lt)
+uniform_prim(P.scalar_gt, infer_value=True)(py.scalar_gt)
+uniform_prim(P.scalar_ne, infer_value=True)(py.scalar_ne)
+uniform_prim(P.scalar_le, infer_value=True)(py.scalar_le)
+uniform_prim(P.scalar_ge, infer_value=True)(py.scalar_ge)
+uniform_prim(P.bool_not, infer_value=True)(py.bool_not)
+uniform_prim(P.bool_and, infer_value=True)(py.bool_and)
+uniform_prim(P.bool_or, infer_value=True)(py.bool_or)
+uniform_prim(P.bool_eq, infer_value=True)(py.bool_eq)
 
 
 ######################

--- a/myia/abstract/prim.py
+++ b/myia/abstract/prim.py
@@ -35,7 +35,7 @@ from .data import (
 )
 from .loop import Pending, find_coherent_result, force_pending
 from .ref import Context
-from .utils import sensitivity_transform, build_value, build_type
+from .utils import sensitivity_transform, build_value, build_type, broaden
 from .infer import Inferrer, to_abstract
 
 
@@ -169,6 +169,12 @@ class UniformPrimitiveInferrer(WithImplInferrer):
             self.typemap[data.annotations[arg]].append(i)
         self.outtype = data.annotations['return']
         self.nolimit = nolimit
+
+    def normalize_args(self, args):
+        """If nolimit is False, return broadened arguments."""
+        if not self.nolimit:
+            args = tuple(broaden(a, None) for a in args)
+        return args
 
     async def infer(self, engine, *args):
         """Infer the abstract result given the abstract arguments."""
@@ -416,8 +422,8 @@ uniform_prim(P.scalar_mod)(py.scalar_mod)
 uniform_prim(P.scalar_pow)(py.scalar_pow)
 uniform_prim(P.scalar_trunc)(py.scalar_trunc)
 uniform_prim(P.scalar_floor)(py.scalar_floor)
-uniform_prim(P.scalar_uadd)(py.scalar_uadd)
-uniform_prim(P.scalar_usub)(py.scalar_usub)
+uniform_prim(P.scalar_uadd, nolimit=True)(py.scalar_uadd)
+uniform_prim(P.scalar_usub, nolimit=True)(py.scalar_usub)
 uniform_prim(P.scalar_exp)(py.scalar_exp)
 uniform_prim(P.scalar_log)(py.scalar_log)
 uniform_prim(P.scalar_sin)(py.scalar_sin)
@@ -430,12 +436,12 @@ uniform_prim(P.scalar_tan)(py.scalar_tan)
 ###############
 
 
-uniform_prim(P.scalar_eq)(py.scalar_eq)
-uniform_prim(P.scalar_lt)(py.scalar_lt)
-uniform_prim(P.scalar_gt)(py.scalar_gt)
-uniform_prim(P.scalar_ne)(py.scalar_ne)
-uniform_prim(P.scalar_le)(py.scalar_le)
-uniform_prim(P.scalar_ge)(py.scalar_ge)
+uniform_prim(P.scalar_eq, nolimit=True)(py.scalar_eq)
+uniform_prim(P.scalar_lt, nolimit=True)(py.scalar_lt)
+uniform_prim(P.scalar_gt, nolimit=True)(py.scalar_gt)
+uniform_prim(P.scalar_ne, nolimit=True)(py.scalar_ne)
+uniform_prim(P.scalar_le, nolimit=True)(py.scalar_le)
+uniform_prim(P.scalar_ge, nolimit=True)(py.scalar_ge)
 uniform_prim(P.bool_not, nolimit=True)(py.bool_not)
 uniform_prim(P.bool_and, nolimit=True)(py.bool_and)
 uniform_prim(P.bool_or, nolimit=True)(py.bool_or)

--- a/myia/abstract/utils.py
+++ b/myia/abstract/utils.py
@@ -152,7 +152,7 @@ def build_type(self, x: AbstractType):
 @overload(bootstrap=True)
 def abstract_clone(self, x: AbstractScalar, *args):
     """Clone an abstract value."""
-    return AbstractScalar(self(x.values, *args), count=x.count)
+    return AbstractScalar(self(x.values, *args))
 
 
 @overload  # noqa: F811
@@ -219,7 +219,7 @@ def abstract_clone(self, x: object, *args):
 @overload(bootstrap=True)
 async def abstract_clone_async(self, x: AbstractScalar):
     """Clone an abstract value (asynchronous)."""
-    return AbstractScalar(await self(x.values), count=x.count)
+    return AbstractScalar(await self(x.values))
 
 
 @overload  # noqa: F811
@@ -409,7 +409,7 @@ def _amerge(x1: AbstractScalar, x2, loop, forced):
     values = amerge(x1.values, x2.values, loop, forced)
     if forced or values is x1.values:
         return x1
-    return AbstractScalar(values, count=max(x1.count, x2.count))
+    return AbstractScalar(values)
 
 
 @overload  # noqa: F811

--- a/myia/composite.py
+++ b/myia/composite.py
@@ -9,7 +9,7 @@ from .abstract import AbstractArray, SHAPE, ANYTHING, MyiaShapeError, \
 from .dtype import Array, Object, Int, UInt, Float, Number, Bool, Tuple, \
     List, Class, EnvType, Function
 from .hypermap import HyperMap
-from .abstract import MyiaTypeError
+from .abstract import MyiaTypeError, broaden
 from .info import About
 from .ir import Graph, MetaGraph, MultitypeGraph, Constant
 from .prim import ops as P
@@ -48,12 +48,19 @@ class Elemwise(MetaGraph):
     * Otherwise, we return getattr(arg1, mname)(arg2, ...)
     """
 
-    def __init__(self, mname, scalar_op=None):
+    def __init__(self, mname, scalar_op=None, infer_value=False):
         """Initialize Elemwise."""
         super().__init__(mname)
         self.mname = mname
         self.scalar_op = scalar_op
+        self.infer_value = infer_value
         self.cache = {}
+
+    def normalize_args(self, args):
+        """If infer_value is False, return broadened arguments."""
+        if not self.infer_value:
+            args = tuple(broaden(a, None) for a in args)
+        return args
 
     def generate_graph(self, args):
         """Generate the graph."""
@@ -193,12 +200,12 @@ def _tan(x):
     return scalar_tan(x)
 
 
-eq = Elemwise('__eq__', P.scalar_eq)
-lt = Elemwise('__lt__', P.scalar_lt)
-gt = Elemwise('__gt__', P.scalar_gt)
-ne = Elemwise('__ne__', P.scalar_ne)
-le = Elemwise('__le__', P.scalar_le)
-ge = Elemwise('__ge__', P.scalar_ge)
+eq = Elemwise('__eq__', P.scalar_eq, infer_value=True)
+lt = Elemwise('__lt__', P.scalar_lt, infer_value=True)
+gt = Elemwise('__gt__', P.scalar_gt, infer_value=True)
+ne = Elemwise('__ne__', P.scalar_ne, infer_value=True)
+le = Elemwise('__le__', P.scalar_le, infer_value=True)
+ge = Elemwise('__ge__', P.scalar_ge, infer_value=True)
 
 
 @core

--- a/myia/composite.py
+++ b/myia/composite.py
@@ -27,17 +27,12 @@ def core(fn=None, **flags):
     The following flags can be set:
         core: (default: True) Indicates that this is a core function
             (only informative at the moment).
-        flatten_inference: (default: True) Tells the InferenceEngine to
-            infer through this function as if it was inlined, disregarding
-            depth limitations.
         ignore_values: (default: False) Make the inferrer ignore argument
             values for the parameters (leads to less specialization).
     """
     flags = {
         # This is a function defined in Myia's core
         'core': True,
-        # Inference should not broaden context when entering this function
-        'flatten_inference': True,
         **flags,
     }
 
@@ -404,7 +399,6 @@ class Tail(MetaGraph):
             raise MyiaTypeError('tail requires a non-empty Tuple')
         g = Graph()
         g.flags['core'] = True
-        g.flags['flatten_inference'] = True
         tup = g.add_parameter()
         tup.debug.name = "tup"
         elems = [g.apply(P.tuple_getitem, tup, i)
@@ -562,7 +556,6 @@ class ListMap(MetaGraph):
 
         g = Graph()
         g.flags['core'] = True
-        g.flags['flatten_inference'] = True
         g.debug.name = 'list_map'
         fn = g.add_parameter()
         lists = [g.add_parameter() for _ in args[1:]]
@@ -586,12 +579,10 @@ class ListMap(MetaGraph):
             gtrue = Graph()
             gtrue.debug.name = 'ftrue'
             gtrue.flags['core'] = True
-            gtrue.flags['flatten_inference'] = True
             gtrue.output = gtrue.apply(gnext, fn, resl, *iters)
             gfalse = Graph()
             gfalse.debug.name = 'ffalse'
             gfalse.flags['core'] = True
-            gfalse.flags['flatten_inference'] = True
             gfalse.output = resl
             g.output = g.apply(g.apply(P.switch, cond, gtrue, gfalse))
 

--- a/myia/hypermap.py
+++ b/myia/hypermap.py
@@ -2,7 +2,7 @@
 
 
 from . import operations, composite as C
-from .abstract import InferenceError
+from .abstract import InferenceError, broaden
 from .ir import MetaGraph, Graph
 from .dtype import Array, List, Tuple, Class, tag_to_dataclass, \
     pytype_to_myiatype
@@ -47,6 +47,10 @@ class HyperMap(MetaGraph):
         for t in (*nonleaf, object):
             self.make_map[t] = self._full_make.map[t]
         self.nonleaf = nonleaf
+
+    def normalize_args(self, args):
+        """Return broadened arguments."""
+        return tuple(broaden(a, None) for a in args)
 
     _full_make = Overload()
 

--- a/myia/ir/metagraph.py
+++ b/myia/ir/metagraph.py
@@ -21,6 +21,13 @@ class MetaGraph:
         self.name = name
         self.cache = {}
 
+    def normalize_args(self, args):
+        """Return normalized versions of the arguments.
+
+        By default, this returns args unchanged.
+        """
+        return args
+
     def generate_graph(self, args):
         """Generate a Graph for the given abstract arguments."""
         from ..abstract.utils import build_type

--- a/myia/parser.py
+++ b/myia/parser.py
@@ -193,12 +193,12 @@ class Parser:
     def make_condition_blocks(self, block):
         """Make two blocks for an if statement or expression."""
         with About(block.graph.debug, 'if_true'):
-            true_block = Block(self, auxiliary=True, flatten_inference=True)
+            true_block = Block(self, auxiliary=True)
         true_block.preds.append(block)
         true_block.mature()
 
         with About(block.graph.debug, 'if_false'):
-            false_block = Block(self, auxiliary=True, flatten_inference=True)
+            false_block = Block(self, auxiliary=True)
         false_block.preds.append(block)
         false_block.mature()
 
@@ -509,7 +509,7 @@ class Parser:
 
         # Create the continuation
         with About(block.graph.debug, 'if_after'):
-            after_block = Block(self, auxiliary=True, flatten_inference=True)
+            after_block = Block(self, auxiliary=True)
 
         # Process the first branch
         true_end = self.process_statements(true_block, node.body)

--- a/myia/pipeline/resources.py
+++ b/myia/pipeline/resources.py
@@ -339,18 +339,15 @@ class InferenceResource(PipelineResource):
     def __init__(self,
                  pipeline_init,
                  constructors,
-                 max_depth,
                  context_class):
         """Initialize an InferenceResource."""
         super().__init__(pipeline_init)
         self.manager = self.resources.manager
         self.context_class = context_class
         self.constructors = constructors
-        self.max_depth = max_depth
         self.engine = InferenceEngine(
             self.pipeline,
             constructors=self.constructors,
-            max_depth=self.max_depth,
             context_class=self.context_class,
         )
 

--- a/myia/pipeline/standard.py
+++ b/myia/pipeline/standard.py
@@ -25,7 +25,6 @@ standard_resources = dict(
     ),
     inferrer=InferenceResource.partial(
         constructors=abstract_inferrer_constructors,
-        max_depth=1,
         context_class=Context,
     )
 )

--- a/myia/prim/grad_implementations.py
+++ b/myia/prim/grad_implementations.py
@@ -26,10 +26,10 @@ parse = standard_pipeline \
     .make_transformer('input', 'graph')
 
 
-_flags = {}
+_flags = {'ignore_values': True}
 
 
-def bprop_to_augm(prim, fn):
+def bprop_to_augm(prim, fn, flags):
     """Given a function for the bprop, make the augmented function."""
     info = NamedDebugInfo(prim=prim, name=prim.name)
 
@@ -48,6 +48,7 @@ def bprop_to_augm(prim, fn):
     with About(info, 'grad_fprop'):
         outer = Graph()
         outer.flags.update(_flags)
+        outer.flags.update(flags)
         outer.transforms['primal'] = prim
         outer.output = Constant(None)
 
@@ -86,10 +87,10 @@ augmented_graphs = Registry()
 register = augmented_graphs.register
 
 
-def register_bprop(prim):
+def register_bprop(prim, **flags):
     """Register an augmented function for prim, given a backpropagator."""
     def deco(fn):
-        g = bprop_to_augm(prim, fn)
+        g = bprop_to_augm(prim, fn, flags)
         return register(prim)(g)
     return deco
 
@@ -188,7 +189,7 @@ def bprop_scalar_cast(x, t, out, dout):
     return (scalar_cast(dout, typeof(x)), t)
 
 
-@register_bprop(primops.tuple_getitem)
+@register_bprop(primops.tuple_getitem, ignore_values=False)
 def bprop_tuple_getitem(data, idx, out, dout):
     """Backpropagator for primitive `tuple_getitem`."""
     return (tuple_setitem(zeros_like(data), idx, dout),
@@ -397,7 +398,7 @@ class ArrayReduceGradient(MetaGraph):
         fn = jf.get_unique()
         assert isinstance(fn, GraphFunction) and fn.graph.parent is None
         assert fn.graph.transforms['primal'] is primops.scalar_add
-        return bprop_to_augm(primops.array_reduce, bprop_sum)
+        return bprop_to_augm(primops.array_reduce, bprop_sum, {})
 
 
 register(primops.array_reduce)(

--- a/myia/prim/grad_implementations.py
+++ b/myia/prim/grad_implementations.py
@@ -26,9 +26,7 @@ parse = standard_pipeline \
     .make_transformer('input', 'graph')
 
 
-_flags = {
-    'flatten_inference': True,
-}
+_flags = {}
 
 
 def bprop_to_augm(prim, fn):

--- a/myia/specialize.py
+++ b/myia/specialize.py
@@ -66,13 +66,12 @@ class TypeSpecializer:
         return await self._specialize(g, ctx, argrefs)
 
     async def _specialize(self, g, ctx, argrefs):
-        ctxkey = ctx  # TODO: Reify ctx to collapse multiple ctx into one
-        if ctxkey in self.specializations:
-            return self.specializations[ctxkey].new_graph
+        if ctx in self.specializations:
+            return self.specializations[ctx].new_graph
 
         gspec = _GraphSpecializer(self, g, await concretize_abstract(ctx))
         g2 = gspec.new_graph
-        self.specializations[ctxkey] = gspec
+        self.specializations[ctx] = gspec
         await gspec.run()
         return g2
 
@@ -127,6 +126,7 @@ class _GraphSpecializer:
             return _const(fn.prim, a)
 
         inf = self.specializer.engine.get_inferrer_for(fn)
+        argvals = argvals and inf.normalize_args(argvals)
         argvals, outval = await self._find_unique_argvals(a, inf, argvals)
 
         if isinstance(inf, TrackedInferrer):

--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -8,10 +8,12 @@ from myia.abstract import (
     ANYTHING, MyiaTypeError,
     AbstractScalar as _S, AbstractTuple as T,
     AbstractJTagged, AbstractError, AbstractFunction,
-    InferenceLoop, build_value, amerge,
+    InferenceLoop, to_abstract, build_value, amerge,
     Possibilities as _Poss,
     VALUE, TYPE, DEAD
 )
+from myia.utils import SymbolicKeyInstance
+from myia.ir import Constant
 
 from .common import Point, to_abstract_test, f32, Ty, af32_of
 
@@ -28,6 +30,11 @@ def Poss(*things):
         VALUE: _Poss(things),
         TYPE: typeof(things[0]),
     })
+
+
+def test_to_abstract():
+    inst = SymbolicKeyInstance(Constant(123), 456)
+    assert to_abstract(inst) == _S({VALUE: inst, TYPE: ty.SymbolicKeyType})
 
 
 def test_build_value():

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -69,8 +69,6 @@ grad_pipeline = PipelineDefinition(
         validate=step_grad_validate,
         export=steps.step_debug_export,
     )
-).configure(
-    {'inferrer.max_depth': 1}
 )
 
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -160,27 +160,27 @@ def test_identity(x):
     return x
 
 
-@infer((16,))
+@infer((i64,))
 def test_constants_int():
     return 2 * 8
 
 
-@infer((12.0,))
+@infer((f64,))
 def test_constants_float():
     return 1.5 * 8.0
 
 
-@infer((12.0,))
+@infer((f64,))
 def test_constants_intxfloat():
     return 8 * 1.5
 
 
-@infer((12.0,))
+@infer((f64,))
 def test_constants_floatxint():
     return 1.5 * 8
 
 
-@infer((60.0,))
+@infer((f64,))
 def test_constants_floatxint2():
     return (8 * 7) + 4.0
 
@@ -230,8 +230,8 @@ def test_prim_log(x):
     # so the following is an InferenceError even though it
     # will work with the standard_pipeline
     (i64, f64, f64, InferenceError),
-    (True, 7, 4, 49),
-    (False, 7, 4, 16),
+    (True, 7, 4, i64),
+    (False, 7, 4, i64),
     (B, 7, 4, i64),
 )
 def test_if(c, x, y):
@@ -253,8 +253,6 @@ def test_if2(x, y):
     (i64, i64, i64),
     (i64, f64, f64),
     (f64, f64, f64),
-    (1_000_000, i64, i64),
-    (2, 3, 27),
     (1_000_000, 3, i64)
 )
 def test_while(x, y):
@@ -616,8 +614,6 @@ def test_hof(x):
 @infer(
     (i64, i64, i64),
     (i64, f64, InferenceError),
-    (-1, 3, 36),
-    (1, 3, 6),
     (i64, 3, i64),
 )
 def test_hof_2(c, x):
@@ -762,7 +758,7 @@ def test_func_arg4(x):
     return g(t, x)
 
 
-@infer((4,))
+@infer((i64,))
 def test_closure_deep():
     def g(x):
         def h():
@@ -773,7 +769,6 @@ def test_closure_deep():
 
 @infer(
     (i64, i64, i64),
-    (5, 7, 15),
 )
 def test_closure_passing(x, y):
     def adder(x):
@@ -790,16 +785,6 @@ def test_closure_passing(x, y):
 @infer((B, B), (i64, InferenceError))
 def test_not(x):
     return not x
-
-
-# TODO: does this matter?
-@infer((2, 2, 8), (2, 3, 13))
-def test_cover_limitedvalue_eq(x, y):
-
-    def square(x):
-        return x * x
-
-    return square(x) + square(y)
 
 
 @infer(
@@ -877,9 +862,6 @@ Tf4 = T[f64, f64, f64, f64]
     # (Thing_f, i64),
 
     (5, 5),
-    (6.0, 6),
-    ((5, 7, (3.2, 1.8)), 16),
-    (Point(5, 7), 35),
     (Point3D(5, 7, 9), 0),
 )
 def test_hastype_2(x):
@@ -957,7 +939,6 @@ class data:
 @infer(
     (i64, i64, (i64, i64)),
     (i64, f64, InferenceError),
-    (2, 3, (5, 36)),
 )
 def test_getattr(x, y):
     a = helpers.add(x, y)
@@ -1195,7 +1176,7 @@ def test_list_reduce(lst, dflt):
     return list_reduce(f, lst, dflt)
 
 
-@infer((i64, i64), (40, 42))
+@infer((i64, i64))
 def test_partial_1(x):
     def f(a, b):
         return a + b
@@ -1341,7 +1322,6 @@ def test_call_nonfunc(x, y):
 
 
 @infer(
-    (2, 3, 4, 90),
     (i64, i64, i64, i64),
     (f64, f64, f64, InferenceError),
 )
@@ -1525,7 +1505,6 @@ def test_hastype_interference(x, y, z):
 @infer(
     (Point(i64, i64), i64),
     (Point(f64, f64), f64),
-    (Point(3, 4), 7),
 )
 def test_class(pt):
     return pt.x + pt.y
@@ -1534,7 +1513,6 @@ def test_class(pt):
 @infer(
     (Point(i64, i64), i64),
     (Point(f64, f64), f64),
-    (Point(3, 4), 5),
 )
 def test_dataclass_method(pt):
     return pt.abs()
@@ -1543,7 +1521,6 @@ def test_dataclass_method(pt):
 @infer(
     (i64, i64, i64, i64, Point(i64, i64)),
     (f64, f64, f64, f64, InferenceError),
-    (1, 2, 3, 4, Point(4, 6)),
 )
 def test_dataclass_inst(x1, y1, x2, y2):
     pt1 = Point(x1, y1)
@@ -1586,9 +1563,6 @@ hyper_map_nobroadcast = HyperMap(broadcast=False)
     (i64, f64, InferenceError),
     ([f64], f64, InferenceError),
     (ai64_of(2, 5), af64_of(2, 5), InferenceError),
-    (1, 2, 3),
-    (4.5, 7.5, 12.0),
-    (Point(1, 2), Point(3, 4), Point(4, 6)),
 )
 def test_hyper_map(x, y):
     return hyper_map(scalar_add, x, y)
@@ -1617,9 +1591,6 @@ def test_hyper_map_nobroadcast(x, y):
     (ai64_of(2, 5), ai64_of(2, 5), ai64_of(2, 5)),
     (ai64_of(2, 1), ai64_of(1, 5), ai64_of(2, 5)),
     (Env, Env, Env),
-    (1, 2, 3),
-    (4.5, 7.5, 12.0),
-    (Point(1, 2), Point(3, 4), Point(4, 6)),
 )
 def test_hyper_add(x, y):
     return hyper_add(x, y)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -63,7 +63,6 @@ infer_pipeline = scalar_pipeline.select(
 ).configure({
     'py_implementations': pyimpl_test,
     'inferrer.constructors': abstract_inferrer_cons_test,
-    'inferrer.max_depth': 10,
 })
 
 
@@ -72,7 +71,6 @@ infer_pipeline_std = standard_pipeline.select(
 ).configure({
     'py_implementations': pyimpl_test,
     'inferrer.constructors': abstract_inferrer_cons_test,
-    'inferrer.max_depth': 10,
 })
 
 

--- a/tests/test_specialize.py
+++ b/tests/test_specialize.py
@@ -20,19 +20,13 @@ from .common import mysum, i64, f64, Point
 specialize_pipeline = scalar_debug_pipeline \
     .select('parse', 'infer', 'specialize',
             'erase_class', 'erase_tuple',
-            'validate', 'export', 'wrap') \
-    .configure(
-        {'inferrer.max_depth': 1}
-    )
+            'validate', 'export', 'wrap')
 
 
 specialize_pipeline_std = standard_debug_pipeline \
     .select('parse', 'infer', 'specialize',
             'erase_class', 'opt', 'erase_tuple',
-            'validate', 'export', 'wrap') \
-    .configure(
-        {'inferrer.max_depth': 1}
-    )
+            'validate', 'export', 'wrap')
 
 
 @overload


### PR DESCRIPTION
This modifies the inferrer to do less constant propagation and create less specialized graphs, which means we have to process less nodes. This seems to cut about 10% of the total test runtime.

Removed `InferenceEngine.max_depth`, `AbstractValue.count` and all associated configuration. This is probably more robust, because the count was not considered in hash/eq for `AbstractValue` and I suspect this would have caused a few problems in the future.

The `ignore_values` flag can be set on a graph to ignore parameter values in inference and specialization. `normalize_args` can be defined on an inferrer to return equivalent args that may be broader.
