### PR TITLE
Union types

### DIFF
--- a/debug/gprint.py
+++ b/debug/gprint.py
@@ -226,12 +226,10 @@ class MyiaGraphPrinter(GraphPrinter):
         graphs = set()
         parents = mng.parents
         g = graph
-        clone = GraphCloner(total=True, relation='cosmetic')
         while g:
-            clone.add_clone(g)
             graphs.add(g)
             g = parents[g]
-
+        clone = GraphCloner(*graphs, total=True, relation='cosmetic')
         self.graphs |= {clone[g] for g in graphs}
         self.focus.add(clone[graph])
 

--- a/myia/abstract/__init__.py
+++ b/myia/abstract/__init__.py
@@ -66,6 +66,7 @@ from .data import (  # noqa
 
 from .ref import (  # noqa
     Context,
+    ConditionalContext,
     Contextless,
     CONTEXTLESS,
     AbstractReference,

--- a/myia/abstract/__init__.py
+++ b/myia/abstract/__init__.py
@@ -49,6 +49,8 @@ from .data import (  # noqa
     AbstractList,
     AbstractClass,
     AbstractJTagged,
+    AbstractUnion,
+    abstract_union,
     TrackDict,
     Track,
     VALUE,

--- a/myia/abstract/data.py
+++ b/myia/abstract/data.py
@@ -378,6 +378,41 @@ class AbstractJTagged(AbstractStructure):
         return f'J({self.element})'
 
 
+class AbstractUnion(AbstractValue):
+    """Represents the union of several possible abstract types."""
+
+    def __init__(self, options):
+        """Initialize an AbstractUnion."""
+        super().__init__({})
+        self.options = frozenset(options)
+
+    def _make_key(self):
+        opts = tuple(opt._make_key() for opt in self.options)
+        return (super()._make_key(), opts)
+
+    def __repr__(self):
+        return f'U({", ".join(map(repr, self.options))})'
+
+
+def abstract_union(options):
+    """Create a union if necessary.
+
+    If only one opt is given in the options list, return that option.
+    """
+    opts = []
+    for option in options:
+        if isinstance(option, AbstractUnion):
+            opts += option.options
+        else:
+            opts.append(option)
+    opts = frozenset(opts)
+    if len(opts) == 1:
+        opt, = opts
+        return opt
+    else:
+        return AbstractUnion(opts)
+
+
 ##########
 # Tracks #
 ##########

--- a/myia/abstract/data.py
+++ b/myia/abstract/data.py
@@ -378,7 +378,7 @@ class AbstractJTagged(AbstractStructure):
         return f'J({self.element})'
 
 
-class AbstractUnion(AbstractValue):
+class AbstractUnion(AbstractStructure):
     """Represents the union of several possible abstract types."""
 
     def __init__(self, options):
@@ -386,9 +386,9 @@ class AbstractUnion(AbstractValue):
         super().__init__({})
         self.options = frozenset(options)
 
-    def _make_key(self):
-        opts = tuple(opt._make_key() for opt in self.options)
-        return (super()._make_key(), opts)
+    def children(self):
+        """Return the set of options."""
+        return self.options
 
     def __repr__(self):
         return f'U({", ".join(map(repr, self.options))})'

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -98,6 +98,10 @@ class InferenceEngine:
 
     def ref(self, node, context):
         """Return a Reference to the node in the given context."""
+        if node.is_constant_graph():
+            context = context.filter(node.value.parent)
+        else:
+            context = context.filter(node.graph)
         return Reference(self, node, context)
 
     async def compute_ref(self, ref):

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -136,6 +136,12 @@ class InferenceEngine:
         """Return the replacement reference for ref, or ref itself."""
         while ref in self.reference_map:
             ref = self.reference_map[ref]
+        ctx = ref.context
+        if not ref.node.is_constant_graph():
+            while (isinstance(ctx, ConditionalContext)
+                   and ref not in self.cache.cache):
+                ctx = ctx.context
+                ref = self.ref(ref.node, ctx)
         return ref
 
     def run_coroutine(self, coro, throw=True):

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -13,7 +13,8 @@ from ..utils import Overload, Partializable, is_dataclass_type, \
     SymbolicKeyInstance, overload
 
 from .loop import Pending, force_pending, InferenceLoop
-from .ref import VirtualReference, Context, EvaluationCache, Reference
+from .ref import VirtualReference, Context, EvaluationCache, Reference, \
+    ConditionalContext
 from .data import infer_trace, MyiaTypeError, ANYTHING, AbstractScalar, \
     GraphFunction, PartialApplication, \
     JTransformedFunction, AbstractJTagged, AbstractTuple, \

--- a/myia/abstract/prim.py
+++ b/myia/abstract/prim.py
@@ -274,9 +274,8 @@ async def static_getter(engine, data, item, fetch, on_dcattr, chk=None,
             fn = _prim_or_graph(inferrer)
             g = outref.node.graph
             eng = outref.engine
-            ref = Reference(outref.engine,
-                            g.apply(P.partial, fn, dataref.node),
-                            outref.context)
+            ref = eng.ref(g.apply(P.partial, fn, dataref.node),
+                          outref.context)
             return await eng.reroute(outref, ref)
         else:
             raise InferenceError(f'Unknown field in {data_t}: {item_v}')
@@ -288,9 +287,8 @@ async def static_getter(engine, data, item, fetch, on_dcattr, chk=None,
         fn = _prim_or_graph(inferrer)
         g = outref.node.graph
         eng = outref.engine
-        ref = Reference(outref.engine,
-                        g.apply(P.partial, fn, dataref.node),
-                        outref.context)
+        ref = eng.ref(g.apply(P.partial, fn, dataref.node),
+                      outref.context)
         return await eng.reroute(outref, ref)
 
     elif case == 'no_method':
@@ -320,9 +318,8 @@ async def static_getter(engine, data, item, fetch, on_dcattr, chk=None,
             typ = dtype.pytype_to_myiatype(value)
             g = outref.node.graph
             eng = outref.engine
-            ref = Reference(outref.engine,
-                            g.apply(P.partial, P.make_record, typ),
-                            outref.context)
+            ref = eng.ref(g.apply(P.partial, P.make_record, typ),
+                          outref.context)
             return await eng.reroute(outref, ref)
         else:
             return to_abstract(value, Context.empty(), ref=outref)

--- a/myia/abstract/prim.py
+++ b/myia/abstract/prim.py
@@ -37,7 +37,7 @@ from .data import (
     infer_trace
 )
 from .loop import Pending, find_coherent_result, force_pending
-from .ref import Context
+from .ref import Context, ConditionalContext, Reference
 from .utils import sensitivity_transform, build_value, build_type, broaden
 from .infer import Inferrer, to_abstract
 

--- a/myia/abstract/prim.py
+++ b/myia/abstract/prim.py
@@ -925,7 +925,9 @@ class _SwitchInferrer(Inferrer):
             elif isinstance(op, GraphFunction):
                 op = op.graph
 
-            if op is engine.pipeline.resources.convert(bool):
+            converter = engine.pipeline.resources.convert
+            converted_bool = converter.object_map.get(bool, None)
+            if op is converted_bool:
                 return await self._find_op(engine, engine.ref(args[0], ctx))
             elif isinstance(op, Primitive):
                 return op, [engine.ref(a, ctx) for a in args]

--- a/myia/abstract/prim.py
+++ b/myia/abstract/prim.py
@@ -911,7 +911,7 @@ class _SwitchInferrer(Inferrer):
 
     async def _find_op(self, engine, condref):
         """Find a primitive operator to use for the condition.
-        
+
         This skips over the bool primitive or composite used for this
         pipeline.
         """

--- a/myia/abstract/prim.py
+++ b/myia/abstract/prim.py
@@ -303,7 +303,7 @@ async def static_getter(engine, data, item, fetch, on_dcattr, chk=None,
         if data_v is ANYTHING:
             raise InferenceError(
                 'Could not infer the type or the value of the object'
-                f" on which to resolve the attribute '{item_v}"
+                f" on which to resolve the attribute '{item_v}'"
             )
         if chk:
             chk(data_v, item_v)

--- a/myia/abstract/prim.py
+++ b/myia/abstract/prim.py
@@ -37,7 +37,7 @@ from .data import (
     infer_trace
 )
 from .loop import Pending, find_coherent_result, force_pending
-from .ref import Context, ConditionalContext, Reference
+from .ref import Context, ConditionalContext
 from .utils import sensitivity_transform, build_value, build_type, broaden
 from .infer import Inferrer, to_abstract
 

--- a/myia/abstract/prim.py
+++ b/myia/abstract/prim.py
@@ -245,8 +245,6 @@ async def static_getter(engine, data, item, fetch, on_dcattr, chk=None,
         dataref: The Reference to the data.
         outref: The Reference to the output.
     """
-    from ..abstract import Reference
-
     resources = engine.pipeline.resources
 
     data_t = build_type(data)
@@ -868,17 +866,109 @@ async def _inf_dot(engine, a: AbstractArray, b: AbstractArray):
 ##############
 
 
-@standard_prim(P.switch)
-async def _inf_switch(engine, cond: Bool, tb, fb):
-    v = cond.values[VALUE]
-    if v is True:
-        return tb
-    elif v is False:
-        return fb
-    elif v is ANYTHING:
-        return engine.abstract_merge(tb, fb)
-    else:
-        raise AssertionError(f"Invalid condition value for switch: {v}")
+class _SwitchInferrer(Inferrer):
+
+    async def _special_hastype(self, engine, outref,
+                               xref, typref, tbref, fbref):
+        """Handle `switch(hastype(x, typ), tb, fb)`.
+
+        We want to evaluate tb in a context where x has type typ and fb
+        in a context where it doesn't.
+        """
+        async def wrap(branch_ref, branch_type):
+            node = branch_ref.node
+            if not node.is_constant_graph():
+                raise MyiaTypeError(
+                    'Branches of switch must be functions when the condition'
+                    ' is hastype on a Union.'
+                )
+            branch_ctx = ConditionalContext(ctx, (xref.node, branch_type))
+            new_branch_ref = engine.ref(node, branch_ctx)
+            new_x = g.apply(P.unsafe_static_cast, xref.node, branch_type)
+            await engine.reroute(
+                engine.ref(xref.node, branch_ctx),
+                engine.ref(new_x, ctx)
+            )
+            if branch_ref != new_branch_ref:
+                fn = await engine.reroute(branch_ref, new_branch_ref)
+            else:
+                fn = await branch_ref.get()
+            return fn.get_unique()
+
+        ctx = outref.context
+        g = xref.node.graph
+
+        fulltype = await xref.get()
+        typ = (await typref.get()).values[VALUE]
+        tbtyp, fbtyp = await _split_type(fulltype, typ)
+        # We are not supposed to be here if only one branch could be taken.
+        assert tbtyp is not None
+        assert fbtyp is not None
+        return AbstractFunction(
+            await wrap(tbref, tbtyp),
+            await wrap(fbref, fbtyp)
+        )
+
+    async def _find_op(self, engine, condref):
+        """Find a primitive operator to use for the condition.
+        
+        This skips over the bool primitive or composite used for this
+        pipeline.
+        """
+        ctx = condref.context
+        if condref.node.is_apply():
+            opnode, *args = condref.node.inputs
+            opref = engine.ref(opnode, ctx)
+            try:
+                op = (await opref.get()).get_unique()
+            except MyiaTypeError:
+                return None, None
+            if isinstance(op, PrimitiveFunction):
+                op = op.prim
+            elif isinstance(op, GraphFunction):
+                op = op.graph
+
+            if op is engine.pipeline.resources.convert(bool):
+                return await self._find_op(engine, engine.ref(args[0], ctx))
+            elif isinstance(op, Primitive):
+                return op, [engine.ref(a, ctx) for a in args]
+            else:
+                return None, None
+        else:
+            return None, None
+
+    async def run(self, engine, outref, argrefs):
+        res = await self._run_helper(engine, outref, argrefs)
+        # args = tuple([await ref.get() for ref in argrefs])
+        # self.cache[args] = res
+        return res
+
+    async def _run_helper(self, engine, outref, argrefs):
+        check_nargs(P.switch, 3, argrefs)
+        condref, tbref, fbref = argrefs
+
+        cond = await condref.get()
+        await force_pending(engine.check(Bool, build_type(cond)))
+
+        v = cond.values[VALUE]
+        if v is True:
+            return await tbref.get()
+        elif v is False:
+            return await fbref.get()
+        elif v is ANYTHING:
+            op, args = await self._find_op(engine, condref)
+            method = op and getattr(self, f'_special_{op}', None)
+            if method is None:
+                tb = await tbref.get()
+                fb = await fbref.get()
+                return engine.abstract_merge(tb, fb)
+            else:
+                return await method(engine, outref, *args, tbref, fbref)
+        else:
+            raise AssertionError(f"Invalid condition value for switch: {v}")
+
+
+abstract_inferrer_constructors[P.switch] = _SwitchInferrer.partial()
 
 
 #################

--- a/myia/abstract/ref.py
+++ b/myia/abstract/ref.py
@@ -82,7 +82,7 @@ class ConditionalContext:
         parent = self.context.filter(graph.parent)
         if parent is self.context:
             return Context(self, graph, argkey)
-        else:
+        else:  # pragma: no cover
             return Context(parent, graph, argkey)
 
     def __hash__(self):

--- a/myia/abstract/ref.py
+++ b/myia/abstract/ref.py
@@ -53,6 +53,47 @@ class Context:
 _empty_context = Context(None, None, ())
 
 
+class ConditionalContext:
+    """Wraps another context."""
+
+    def __init__(self, context, argkey):
+        """Initialize the ConditionalContext."""
+        self.graph = context.graph
+        self.context = context
+        self.argkey = argkey
+        self.parent = self.context
+        self.parent_cache = dict(context.parent_cache) if context else {}
+        self.parent_cache[self.graph] = self
+        self._hash = hash((self.parent, self.argkey))
+
+    def filter(self, graph):
+        """Return a context restricted to a graph's dependencies."""
+        if graph is self.graph:
+            return self
+        else:
+            res = self.context.filter(graph)
+            if res == Context.empty():
+                return res
+            else:
+                return ConditionalContext(res, self.argkey)
+
+    def add(self, graph, argkey):
+        """Extend this context with values for another graph."""
+        parent = self.context.filter(graph.parent)
+        if parent is self.context:
+            return Context(self, graph, argkey)
+        else:
+            return Context(parent, graph, argkey)
+
+    def __hash__(self):
+        return self._hash
+
+    def __eq__(self, other):
+        return type(other) is ConditionalContext \
+            and self.parent == other.parent \
+            and self.argkey == other.argkey
+
+
 class Contextless:
     """Singleton Context which specializes to itself.
 

--- a/myia/abstract/ref.py
+++ b/myia/abstract/ref.py
@@ -143,10 +143,7 @@ class Reference(AbstractReference):
         assert context is not None
         self.node = node
         self.engine = engine
-        if node.is_constant_graph():
-            self.context = context.filter(node.value.parent)
-        else:
-            self.context = context.filter(node.graph)
+        self.context = context
         self._hash = hash((self.node, self.context))
 
     async def get(self):

--- a/myia/abstract/utils.py
+++ b/myia/abstract/utils.py
@@ -26,6 +26,7 @@ from .data import (
     AbstractClass,
     AbstractJTagged,
     AbstractUnion,
+    abstract_union,
     TrackDict,
     VirtualFunction,
     GraphFunction,
@@ -244,6 +245,11 @@ def abstract_clone(self, x: AbstractClass, *args):
 
 
 @overload  # noqa: F811
+def abstract_clone(self, x: AbstractUnion, *args):
+    return abstract_union([self(y, *args) for y in x.options])
+
+
+@overload  # noqa: F811
 def abstract_clone(self, x: AbstractJTagged, *args):
     return AbstractJTagged(self(x.element, *args))
 
@@ -309,6 +315,11 @@ async def abstract_clone_async(self, x: AbstractClass):
         x.methods,
         await self(x.values)
     )
+
+
+@overload  # noqa: F811
+async def abstract_clone_async(self, x: AbstractUnion):
+    return abstract_union([await self(y) for y in x.options])
 
 
 @overload  # noqa: F811

--- a/myia/abstract/utils.py
+++ b/myia/abstract/utils.py
@@ -387,11 +387,15 @@ async def concretize_abstract(self, x: Pending):
 
 @overload  # noqa: F811
 async def concretize_abstract(self, r: Reference):
-    return Reference(
-        r.engine,
-        r.node,
-        await self(r.context)
-    )
+    # There's a bit of a messup here where we can't build Reference using the
+    # constructor because the node in the reference is sometimes unmanaged.
+    # That's likely because of redirections made by the union code in switch.
+    ref = object.__new__(Reference)
+    ref.engine = r.engine
+    ref.node = r.node
+    ref.context = await self(r.context)
+    ref._hash = hash((ref.node, ref.context))
+    return ref
 
 
 @overload  # noqa: F811

--- a/myia/abstract/utils.py
+++ b/myia/abstract/utils.py
@@ -387,15 +387,11 @@ async def concretize_abstract(self, x: Pending):
 
 @overload  # noqa: F811
 async def concretize_abstract(self, r: Reference):
-    # There's a bit of a messup here where we can't build Reference using the
-    # constructor because the node in the reference is sometimes unmanaged.
-    # That's likely because of redirections made by the union code in switch.
-    ref = object.__new__(Reference)
-    ref.engine = r.engine
-    ref.node = r.node
-    ref.context = await self(r.context)
-    ref._hash = hash((ref.node, ref.context))
-    return ref
+    return Reference(
+        r.engine,
+        r.node,
+        await self(r.context),
+    )
 
 
 @overload  # noqa: F811

--- a/myia/abstract/utils.py
+++ b/myia/abstract/utils.py
@@ -25,6 +25,7 @@ from .data import (
     AbstractList,
     AbstractClass,
     AbstractJTagged,
+    AbstractUnion,
     TrackDict,
     VirtualFunction,
     GraphFunction,
@@ -145,6 +146,11 @@ def build_type(self, x: AbstractClass):
 @overload  # noqa: F811
 def build_type(self, x: AbstractJTagged):
     return dtype.JTagged[self(x.element)]
+
+
+@overload  # noqa: F811
+def build_type(self, x: AbstractUnion):
+    return dtype.Union[[self(opt) for opt in x.options]]
 
 
 @overload  # noqa: F811

--- a/myia/compile/transform.py
+++ b/myia/compile/transform.py
@@ -9,7 +9,6 @@ from .vm import FinalVM
 def set_types(graph, argspec, outspec, pipeline):
     """Re-infer and set all the types for the nodes."""
     pipeline.resources.inferrer.infer(graph, argspec, outspec, clear=True)
-    graph.manager.keep_roots()
 
     for ref, fut in pipeline.resources.inferrer.engine.cache.cache.items():
         v = fut.result()

--- a/myia/compile/transform.py
+++ b/myia/compile/transform.py
@@ -9,6 +9,7 @@ from .vm import FinalVM
 def set_types(graph, argspec, outspec, pipeline):
     """Re-infer and set all the types for the nodes."""
     pipeline.resources.inferrer.infer(graph, argspec, outspec, clear=True)
+    graph.manager.keep_roots()
 
     for ref, fut in pipeline.resources.inferrer.engine.cache.cache.items():
         v = fut.result()

--- a/myia/dtype.py
+++ b/myia/dtype.py
@@ -248,9 +248,10 @@ class Union(Object):
     @classmethod
     def parameterize(cls, *elements):
         """Parameterize using a list of elements."""
-        if len(elements) == 1 and isinstance(elements[0], (tuple, list)):
+        seqtype = (tuple, list, set, frozenset)
+        if len(elements) == 1 and isinstance(elements[0], seqtype):
             elements, = elements
-        return cls.make_subtype(elements=tuple(elements))
+        return cls.make_subtype(elements=frozenset(elements))
 
     @classmethod
     def __type_repr__(cls):

--- a/myia/dtype.py
+++ b/myia/dtype.py
@@ -236,6 +236,29 @@ class Tuple(Object):
         return f'Tuple[{elems}]'
 
 
+class Union(Object):
+    """Represents a set of possible types.
+
+    Instantiate with `Union[type1, type2, ... typeN]`.  A single
+    sequence of types is also acceptable as the sole argument.
+    """
+
+    elements: TupleT[Type, ...]
+
+    @classmethod
+    def parameterize(cls, *elements):
+        """Parameterize using a list of elements."""
+        if len(elements) == 1 and isinstance(elements[0], (tuple, list)):
+            elements, = elements
+        return cls.make_subtype(elements=tuple(elements))
+
+    @classmethod
+    def __type_repr__(cls):
+        elems = getattr(cls, 'elements', [])
+        elems = ', '.join(map(repr, elems))
+        return f'Union[{elems}]'
+
+
 class Array(Object):
     """Represents an array of values.
 

--- a/myia/pipeline/steps.py
+++ b/myia/pipeline/steps.py
@@ -9,7 +9,7 @@ from itertools import count
 
 from .. import dtype
 from ..abstract import AbstractTuple, AbstractList, AbstractClass, \
-    AbstractArray, TYPE, AbstractScalar
+    AbstractArray, TYPE, AbstractScalar, AbstractUnion
 from ..cconv import closure_convert
 from ..ir import Graph
 from ..opt import lib as optlib, CSE, erase_class, erase_tuple, NodeMap, \
@@ -547,6 +547,15 @@ def convert_arg(self, arg, orig_t: AbstractArray, backend):
         arg = backend.from_numpy(arg)
     backend.check_array(arg, et)
     return [arg]
+
+
+@overload  # noqa: F811
+def convert_arg(self, arg, orig_t: AbstractUnion, backend):
+    for opt in orig_t.options:
+        try:
+            return self(arg, opt, backend)
+        except TypeError:
+            continue
 
 
 @overload  # noqa: F811

--- a/myia/pipeline/steps.py
+++ b/myia/pipeline/steps.py
@@ -556,6 +556,9 @@ def convert_arg(self, arg, orig_t: AbstractUnion, backend):
             return self(arg, opt, backend)
         except TypeError:
             continue
+    else:
+        opts = ", ".join(map(str, orig_t.options))
+        raise TypeError(f'Expected one of {opts}')
 
 
 @overload  # noqa: F811

--- a/myia/prim/py_implementations.py
+++ b/myia/prim/py_implementations.py
@@ -688,4 +688,4 @@ def env_add(env1, env2):
 @register(primops.unsafe_static_cast)
 def unsafe_static_cast(x, t):  # pragma: no cover
     """Implement `unsafe_static_cast`."""
-    return x
+    return x  # pragma: no cover

--- a/myia/specialize.py
+++ b/myia/specialize.py
@@ -88,10 +88,8 @@ class _GraphSpecializer:
 
     def __init__(self, specializer, graph, context):
         parent_context = context.parent
-        assert not isinstance(parent_context, ConditionalContext)
-        # # Try the code below if this condition obtains
-        # while isinstance(parent_context, ConditionalContext):
-        #     parent_context = parent_context.parent
+        while isinstance(parent_context, ConditionalContext):
+            parent_context = parent_context.parent
         self.parent = specializer.specializations[parent_context]
         self.specializer = specializer
         self.engine = specializer.engine
@@ -300,16 +298,13 @@ class _GraphSpecializer:
                 _iref = self.specializer.engine.get_actual_ref(iref)
                 if _iref is not iref:
                     curr = self
-                    assert not _iref.node.is_constant_graph()
-                    assert _iref.node.graph is curr.graph
-                    # # Try the code below if these assertions are triggered
-                    # if _iref.node.is_constant_graph():
-                    #     _g = _iref.node.value.parent
-                    # else:
-                    #     _g = _iref.node.graph
-                    # while curr and _g is not curr.graph:
-                    #     curr = curr.parent
-                    # assert curr is not None
+                    if _iref.node.is_constant_graph():
+                        _g = _iref.node.value.parent
+                    else:
+                        _g = _iref.node.graph
+                    while curr and _g is not curr.graph:
+                        curr = curr.parent
+                    assert curr is not None
                     curr.cl.remapper.clone_disconnected(_iref.node)
                     iref = _iref
                     ival = await iref.get()

--- a/myia/utils/intern.py
+++ b/myia/utils/intern.py
@@ -29,10 +29,14 @@ class Atom(EqKey):
 class Elements(EqKey):
     """Object with multiple values to process for equality recursively."""
 
-    def __init__(self, obj, *values):
+    def __init__(self, obj, *values, values_iterable=None):
         """Initialize an Elements."""
         super().__init__(obj)
-        self.values = values
+        if values_iterable is None:
+            self.values = values
+        else:
+            assert not values
+            self.values = values_iterable
 
 
 def eqkey(x):
@@ -41,6 +45,8 @@ def eqkey(x):
         return x
     elif isinstance(x, (list, tuple)):
         return Elements(x, *x)
+    elif isinstance(x, (set, frozenset)):
+        return Elements(x, values_iterable=frozenset(x))
     elif isinstance(x, dict):
         return Elements(x, *x.items())
     elif hasattr(x, '__eqkey__'):
@@ -63,7 +69,7 @@ def deep_eqkey(obj):
 
     key = eqkey(obj)
     if isinstance(key, Elements):
-        dk = key.type, tuple(deep_eqkey(x) for x in key.values)
+        dk = key.type, type(key.values)(deep_eqkey(x) for x in key.values)
     else:
         assert isinstance(key, Atom)
         dk = key.type, key.value

--- a/myia/utils/overload.py
+++ b/myia/utils/overload.py
@@ -197,7 +197,9 @@ class Overload:
 
         if self._wrapper is None:
             if method is None:
-                raise TypeError(f'No overloaded method for {type(main)}')
+                raise TypeError(
+                    f'No overloaded method in {self} for {type(main)}'
+                )
             else:
                 return method(*args, **kwargs)
         else:

--- a/tests/common.py
+++ b/tests/common.py
@@ -5,7 +5,7 @@ from myia import dtype
 from myia.abstract import VALUE, TYPE, SHAPE, \
     AbstractValue, AbstractScalar, AbstractArray, \
     AbstractList, AbstractTuple, AbstractType, AbstractClass, \
-    AbstractJTagged, ANYTHING
+    AbstractJTagged, AbstractUnion, ANYTHING
 from myia.dtype import Bool, Int, UInt, Float, List, Array, Tuple, Function, \
     Object, pytype_to_myiatype
 from myia.ir import MultitypeGraph
@@ -96,6 +96,11 @@ def Shp(*vals):
 
 def Ty(t):
     return AbstractType(t)
+
+
+def U(*opts):
+    opts = [to_abstract_test(x) for x in opts]
+    return AbstractUnion(opts)
 
 
 @overload(bootstrap=True)

--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -8,7 +8,7 @@ from myia.prim.py_implementations import typeof
 from myia.abstract import (
     ANYTHING, MyiaTypeError,
     AbstractScalar, AbstractTuple as T, AbstractList as L,
-    AbstractJTagged, AbstractError, AbstractFunction,
+    AbstractJTagged, abstract_union, AbstractError, AbstractFunction,
     InferenceLoop, to_abstract, build_value, amerge,
     Possibilities as _Poss,
     VALUE, TYPE, DEAD, build_type_fn,
@@ -19,6 +19,10 @@ from myia.utils import SymbolicKeyInstance
 from myia.ir import Constant
 
 from .common import Point, to_abstract_test, f32, Ty, af32_of
+
+
+def U(*opts):
+    return abstract_union(opts)
 
 
 def S(v=ANYTHING, t=None, s=None):
@@ -109,6 +113,16 @@ def test_merge_possibilities():
         amerge(a, b, loop=None, forced=True)
 
     assert amerge(a, c, loop=None, forced=True) is a
+
+
+def test_union():
+    a = U(S(t=ty.Int[64]), S(t=ty.Int[32]), S(t=ty.Int[16]))
+    b = U(S(t=ty.Int[64]), U(S(t=ty.Int[32]), S(t=ty.Int[16])))
+    assert a == b
+
+    c = S(t=ty.Int[64])
+    d = U(S(t=ty.Int[64]))
+    assert c == d
 
 
 def test_repr():

--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -124,6 +124,10 @@ def test_union():
     d = U(S(t=ty.Int[64]))
     assert c == d
 
+    u = ty.Union[ty.Int[64], ty.Int[32], ty.Int[16]]
+    assert build_type_fn(a) == u
+    assert repr(u).startswith('Union')  # member order can vary
+
 
 def test_repr():
 

--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -201,6 +201,9 @@ def test_abstract_clone_async():
         f1 = AbstractFunction(P.scalar_add, P.scalar_mul)
         assert (await upcast_async(f1)) is f1
 
+        u1 = U(s1, s2)
+        assert (await upcast_async(u1)) is s2
+
     asyncio.run(coro())
 
 

--- a/tests/test_specialize.py
+++ b/tests/test_specialize.py
@@ -2,6 +2,7 @@
 import numpy
 from pytest import mark
 
+from myia import abstract as a, dtype
 from myia.abstract import from_value
 from myia.pipeline import scalar_debug_pipeline, standard_debug_pipeline
 from myia.composite import list_map
@@ -46,12 +47,16 @@ def _eq(x: object, y):
 
 
 def specializer_decorator(pipeline):
-    def specialize(*arglists):
+    def specialize(*arglists, abstract=None):
 
         def decorate(fn):
             def run_test(args):
                 pip = pipeline.make()
-                argspec = tuple(from_value(arg, broaden=True) for arg in args)
+                if abstract is None:
+                    argspec = tuple(from_value(arg, broaden=True)
+                                    for arg in args)
+                else:
+                    argspec = abstract
 
                 result_py = fn(*args)
 
@@ -82,6 +87,9 @@ def specializer_decorator(pipeline):
 
 specialize = specializer_decorator(specialize_pipeline)
 specialize_std = specializer_decorator(specialize_pipeline_std)
+specialize_no_validate = specializer_decorator(
+    specialize_pipeline.configure(validate=False)
+)
 
 
 int1 = 13
@@ -382,3 +390,24 @@ def test_partial_outside_scope(x, y):
         return partial(f, z)
 
     return g(x)(y)
+
+
+abs_i64 = a.AbstractScalar({a.VALUE: a.ANYTHING, a.TYPE: dtype.Int[64]})
+
+
+_union_type = a.abstract_union([
+    abs_i64,
+    a.AbstractList(abs_i64)
+])
+
+
+@specialize_no_validate(
+    (int1,),
+    ([int1, int2],),
+    abstract=(_union_type,)
+)
+def test_union(x):
+    if hastype(x, i64):
+        return x
+    else:
+        return x[0]


### PR DESCRIPTION
This implements part of the union types feature, namely `AbstractUnion` and support for it in the `switch` statement. There are still issues, namely supporting `AbstractUnion`, `hastype` and `unsafe_static_cast` in the backend, as well as recursive ADTs which will eventually come in a different PR.
