### PR TITLE
Interning mechanism

### DIFF
--- a/myia/abstract/__init__.py
+++ b/myia/abstract/__init__.py
@@ -39,7 +39,6 @@ from .data import (  # noqa
     VirtualFunction,
     TypedPrimitive,
     DummyFunction,
-    AbstractBase,
     AbstractValue,
     AbstractScalar,
     AbstractType,

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import numpy as np
+import weakref
 from functools import reduce
 from dataclasses import is_dataclass, replace as dc_replace
 
@@ -331,6 +332,9 @@ def from_value(v, broaden=False):
     return a
 
 
+_abs_cache = weakref.WeakKeyDictionary()
+
+
 @overload.wrapper(bootstrap=True)
 def to_abstract(fn, self, v, context=None, ref=None, loop=None):
     """Translate the value to an abstract value.
@@ -345,18 +349,25 @@ def to_abstract(fn, self, v, context=None, ref=None, loop=None):
             will be given a Pending type so that it can adapt to the types of
             the variables they interact with.
     """
+    cachable = context is None and ref is None and loop is None
+    if cachable:
+        try:
+            return _abs_cache[v]
+        except (TypeError, KeyError) as e:
+            pass
+
     ref = ref and ref.node
 
     if fn is not None:
-        return fn(self, v, context, ref, loop)
+        rval = fn(self, v, context, ref, loop)
 
-    if is_dataclass_type(v):
+    elif is_dataclass_type(v):
         typ = dtype.pytype_to_myiatype(v)
         typarg = AbstractScalar({
             VALUE: typ,
             TYPE: dtype.TypeType,
         })
-        return AbstractFunction(
+        rval = AbstractFunction(
             PartialApplication(
                 P.make_record,
                 (typarg,)
@@ -369,18 +380,26 @@ def to_abstract(fn, self, v, context=None, ref=None, loop=None):
         new_args = {}
         for name, field in v.__dataclass_fields__.items():
             new_args[name] = to_abstract(getattr(v, name), context, loop=loop)
-        return AbstractClass(typ.tag, new_args, typ.methods)
+        rval = AbstractClass(typ.tag, new_args, typ.methods)
 
     elif dtype.ismyiatype(v):
-        return AbstractType(v)
+        rval = AbstractType(v)
 
     else:
         typ = dtype.pytype_to_myiatype(type(v), v)
         assert dtype.ismyiatype(typ, (dtype.External, dtype.EnvType))
-        return AbstractScalar({
+        rval = AbstractScalar({
             VALUE: v,
             TYPE: typ,
         })
+
+    if cachable:
+        try:
+            _abs_cache[v] = rval
+        except TypeError:
+            pass
+
+    return rval
 
 
 @overload  # noqa: F811

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -64,7 +64,7 @@ class InferenceEngine:
 
         Arguments:
             graph: The graph to analyze.
-            argspec: The arguments. Must be a tuple of AbstractBase.
+            argspec: The arguments. Must be a tuple of AbstractValue.
             outspec (optional): Expected inference result. If provided,
                 inference result will be checked against it.
         """

--- a/myia/abstract/prim.py
+++ b/myia/abstract/prim.py
@@ -15,7 +15,7 @@ from ..utils import Namespace, SymbolicKeyInstance, is_dataclass_type
 
 from .data import (
     ANYTHING,
-    AbstractBase,
+    AbstractValue,
     AbstractScalar,
     AbstractType,
     AbstractFunction,
@@ -76,7 +76,7 @@ class StandardInferrer(Inferrer):
                 pass
             elif dtype.ismyiatype(typ):
                 await force_pending(engine.check(typ, build_type(arg)))
-            elif isinstance(typ, type) and issubclass(typ, AbstractBase):
+            elif isinstance(typ, type) and issubclass(typ, AbstractValue):
                 if not isinstance(arg, typ):
                     raise MyiaTypeError(
                         f'Wrong type {arg} != {typ} for {self._infer}'
@@ -541,7 +541,7 @@ async def _inf_list_getitem(engine, arg: AbstractList, idx: dtype.Int[64]):
 async def _inf_tuple_setitem(engine,
                              arg: AbstractTuple,
                              idx: dtype.Int[64],
-                             value: AbstractBase):
+                             value: AbstractValue):
     idx_v = idx.values[VALUE]
     if idx_v is ANYTHING:
         raise MyiaTypeError(
@@ -561,7 +561,7 @@ async def _inf_tuple_setitem(engine,
 async def _inf_list_setitem(engine,
                             arg: AbstractList,
                             idx: dtype.Int[64],
-                            value: AbstractBase):
+                            value: AbstractValue):
     engine.abstract_merge(arg.element, value)
     return arg
 
@@ -569,7 +569,7 @@ async def _inf_list_setitem(engine,
 @standard_prim(P.list_append)
 async def _inf_list_append(engine,
                            arg: AbstractList,
-                           value: AbstractBase):
+                           value: AbstractValue):
     engine.abstract_merge(arg.element, value)
     return arg
 
@@ -977,7 +977,7 @@ async def _inf_env_add(engine, env1, env2):
 @standard_prim(P.unsafe_static_cast)
 async def _inf_unsafe_static_cast(engine, x, typ: AbstractScalar):
     v = typ.values[VALUE]
-    if not isinstance(v, AbstractBase):
+    if not isinstance(v, AbstractValue):
         raise MyiaTypeError('unsafe_static_cast expects a type constant')
     return v
 

--- a/myia/abstract/ref.py
+++ b/myia/abstract/ref.py
@@ -135,7 +135,7 @@ class VirtualReference(AbstractReference):
 
     """
 
-    abstract: 'AbstractBase'
+    abstract: 'AbstractValue'
 
     async def get(self):
         """Get the value (asynchronous)."""

--- a/myia/abstract/utils.py
+++ b/myia/abstract/utils.py
@@ -13,7 +13,7 @@ from .data import (
     ABSENT,
     ANYTHING,
     Possibilities,
-    AbstractBase,
+    AbstractValue,
     AbstractScalar,
     AbstractType,
     AbstractError,
@@ -81,7 +81,7 @@ def build_value(a, default=ABSENT):
 
 
 @overload
-def _build_value(x: AbstractBase):
+def _build_value(x: AbstractValue):
     raise ValueError(x)
 
 

--- a/myia/utils/__init__.py
+++ b/myia/utils/__init__.py
@@ -1,5 +1,10 @@
 """General utilities."""
 
+from .intern import (  # noqa
+    Interned, EqKey, Atom, Elements, eqkey, deep_eqkey, RecursionException,
+    hashrec, eqrec
+)
+
 from .merge import (  # noqa
     DELETE, MergeMode, Merge, Reset, Override,
     merge, cleanup

--- a/myia/utils/intern.py
+++ b/myia/utils/intern.py
@@ -1,0 +1,136 @@
+
+import weakref
+
+
+_intern_pool = {}
+
+
+class EqKey:
+    """Base class for Atom/Elements."""
+
+    def __init__(self, obj):
+        """Initialize an EqKey."""
+        t = type(obj)
+        if t in (int, bool):
+            t = float
+        self.type = t
+
+
+class Atom(EqKey):
+    """Object with a single value to test for equality directly."""
+
+    def __init__(self, obj, value):
+        """Initialize an Atom."""
+        super().__init__(obj)
+        self.value = value
+
+
+class Elements(EqKey):
+    """Object with multiple values to process for equality recursively."""
+
+    def __init__(self, obj, *values):
+        """Initialize an Elements."""
+        super().__init__(obj)
+        self.values = values
+
+
+def eqkey(x):
+    """Return the equality key for x."""
+    if isinstance(x, EqKey):
+        return x
+    elif isinstance(x, (list, tuple)):
+        return Elements(x, *x)
+    elif isinstance(x, dict):
+        return Elements(x, *x.items())
+    elif hasattr(x, '__eqkey__'):
+        return x.__eqkey__()
+    else:
+        return Atom(x, x)
+
+
+class RecursionException(Exception):
+    """Raised when a data structure is found to be recursive."""
+    pass
+
+
+def deep_eqkey(obj):
+    cachable = getattr(obj, '__cache_eqkey__', False)
+    if cachable:
+        cached = getattr(obj, '_eqkey_deepkey', None)
+        if cached is not None:
+            return cached
+
+    key = eqkey(obj)
+    if isinstance(key, Elements):
+        dk = key.type, tuple(deep_eqkey(x) for x in key.values)
+    else:
+        assert isinstance(key, Atom)
+        dk = key.type, key.value
+
+    if cachable:
+        obj._eqkey_deepkey = dk
+    return dk
+
+
+def hashrec(obj):
+    """Hash a (possibly self-referential) object."""
+    return hash(deep_eqkey(obj))
+
+
+def eqrec(obj1, obj2):
+    """Compare two (possibly self-referential) objects for equality."""
+    key1 = deep_eqkey(obj1)
+    key2 = deep_eqkey(obj2)
+    return key1 == key2
+
+
+class Wrapper:
+    """Wraps an object and uses eqrec/hashrec for equality."""
+
+    def __init__(self, obj):
+        """Initialize a Wrapper."""
+        self._obj = weakref.ref(obj)
+
+    def __eq__(self, other):
+        return eqrec(self._obj(), other._obj())
+
+    def __hash__(self):
+        return hashrec(self._obj())
+
+
+class Interned(type):
+    """Represents a class where all members are interned.
+
+    Using the __eqkey__ method to generate a key for equality purposes, each
+    instance with the same eqkey is mapped to a single canonical instance.
+
+    It is possible to create a non-interned instance with `new`.
+
+    The `intern` method on an instance can be used to get the interned version
+    of the instance.
+    """
+
+    def __init__(cls, name, bases, dct):
+        super().__init__(name, bases, dct)
+        cls.intern = lambda self: Interned.intern(type(self), self)
+
+    def new(cls, *args, **kwargs):
+        """Instantiates a non-interned instance."""
+        obj = object.__new__(cls)
+        obj.__init__(*args, **kwargs)
+        return obj
+
+    def intern(cls, inst):
+        """Get the interned instance."""
+        wrap = Wrapper(inst)
+        existing = _intern_pool.get(wrap, None)
+        if existing is None:
+            _intern_pool[wrap] = inst
+            return inst
+        else:
+            return existing
+
+    def __call__(cls, *args, **kwargs):
+        """Instantiates an interned instance."""
+        inst = cls.new(*args, **kwargs)
+        return inst.intern()

--- a/myia/utils/intern.py
+++ b/myia/utils/intern.py
@@ -1,8 +1,9 @@
+"""Tools to intern the instances of certain classes."""
 
 import weakref
 
 
-_intern_pool = {}
+_intern_pool = weakref.WeakValueDictionary()
 
 
 class EqKey:
@@ -50,10 +51,10 @@ def eqkey(x):
 
 class RecursionException(Exception):
     """Raised when a data structure is found to be recursive."""
-    pass
 
 
 def deep_eqkey(obj):
+    """Return a key for equality tests for non-recursive structures."""
     cachable = getattr(obj, '__cache_eqkey__', False)
     if cachable:
         cached = getattr(obj, '_eqkey_deepkey', None)
@@ -111,6 +112,7 @@ class Interned(type):
     """
 
     def __init__(cls, name, bases, dct):
+        """Initialize an interned class."""
         super().__init__(name, bases, dct)
         cls.intern = lambda self: Interned.intern(type(self), self)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -3,7 +3,7 @@ import numpy as np
 from dataclasses import dataclass, is_dataclass
 from myia import dtype
 from myia.abstract import VALUE, TYPE, SHAPE, \
-    AbstractBase, AbstractScalar, AbstractArray, \
+    AbstractValue, AbstractScalar, AbstractArray, \
     AbstractList, AbstractTuple, AbstractType, AbstractClass, \
     AbstractJTagged, ANYTHING
 from myia.dtype import Bool, Int, UInt, Float, List, Array, Tuple, Function, \
@@ -125,7 +125,7 @@ def to_abstract_test(self, x: np.ndarray):
 
 
 @overload  # noqa: F811
-def to_abstract_test(self, x: AbstractBase):
+def to_abstract_test(self, x: AbstractValue):
     return x
 
 

--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -37,7 +37,8 @@ def Poss(*things):
 
 def test_to_abstract():
     inst = SymbolicKeyInstance(Constant(123), 456)
-    assert to_abstract(inst) == AbstractScalar({VALUE: inst, TYPE: ty.SymbolicKeyType})
+    expected = AbstractScalar({VALUE: inst, TYPE: ty.SymbolicKeyType})
+    assert to_abstract(inst) == expected
 
 
 def test_build_value():

--- a/tests/utils/test_intern.py
+++ b/tests/utils/test_intern.py
@@ -1,0 +1,33 @@
+
+from dataclasses import dataclass
+from myia.utils import Interned, Elements
+
+
+@dataclass
+class Point(metaclass=Interned):
+    x: object
+    y: object
+
+    def __eqkey__(self):
+        return Elements(self, (self.x, self.y))
+
+
+def test_interned():
+    p1 = Point(10, 20)
+    p2 = Point(10, 20)
+    p3 = Point(20, 30)
+
+    assert p1 is p2
+    assert p1 is not p3
+    assert p1.x == 10
+    assert p1.y == 20
+
+    p4 = Point.new(10, 20)
+
+    assert p4 is not p1
+    assert p4.intern() is p1
+
+    p5 = Point(p1, p3)
+    p6 = Point(p4, p3)
+
+    assert p5 is p6


### PR DESCRIPTION
* Add the `Interned` metaclass. When used for a class, it makes sure that if `a == b`, then `a is b`, if `a` and `b` are instantiated through the normal constructor.
* Interned classes must define `__eqkey__`, which must return an `Atom` or `Elements` instance. In order to support recursive data structures, it should not call `__eqkey__` recursively (the interner is in charge of doing that on the contents of `Elements`).
* It is possible to create non-interned instances with the `new` classmethod, and to get the interned version of an instance with the `intern` method. This will allow recursive data structures to fit in the interning mechanism, since they have to be constructed through mutation of an initial instance.
* The `broaden` and `concretize_abstract` functions are modified not to create new instances when it is unnecessary to do so.

All in all, this PR makes the whole test suite run 5 to 10% faster. Recursive data structures are not yet supported, but the mechanism is engineered so that their addition shouldn't harm performance for anything else.

The interning code uses weak references. This caused strange performance issues in a previous version, but that doesn't seem to happen anymore. I believe it is important to use weak references, because `AbstractFunction` in particular contains references to graphs, and we want to be able to reclaim them when they are not used anymore.
