### PR TITLE
Generalize broadcast in HyperMap

### DIFF
--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -48,18 +48,23 @@ class InferenceEngine:
         self.loop = InferenceLoop(InferenceError)
         self.pipeline = pipeline
         self.mng = self.pipeline.resources.manager
-        self.constructors = {
-            prim: cons()
-            for prim, cons in constructors.items()
-        }
+        self._constructors = constructors
+        self.errors = []
+        self.context_class = context_class
+        self.reset()
+
+    def reset(self):
+        """Reset all of the InferenceEngine's caches."""
         self.cache = EvaluationCache(
             loop=self.loop,
             keycalc=self.compute_ref,
             keytransform=self.get_actual_ref
         )
-        self.errors = []
-        self.context_class = context_class
         self.reference_map = {}
+        self.constructors = {
+            prim: cons()
+            for prim, cons in self._constructors.items()
+        }
 
     def run(self, graph, *, argspec, outspec=None):
         """Run the inferrer on a graph given initial values.

--- a/myia/abstract/ref.py
+++ b/myia/abstract/ref.py
@@ -226,7 +226,3 @@ class EvaluationCache:
         fut = asyncio.Future(loop=self.loop)
         fut.set_result(value)
         self.cache[key] = fut
-
-    def clear(self):
-        """Clear the cache completely."""
-        self.cache.clear()

--- a/myia/abstract/utils.py
+++ b/myia/abstract/utils.py
@@ -415,6 +415,11 @@ async def concretize_abstract(self, ctx: Context):
     )
 
 
+@overload  # noqa: F811
+async def concretize_abstract(self, t: tuple):
+    return tuple([await self(x) for x in t])
+
+
 @overload.wrapper  # noqa: F811
 async def concretize_abstract(__call__, self, x):
     if hasattr(x, '_concrete'):

--- a/myia/composite.py
+++ b/myia/composite.py
@@ -5,9 +5,10 @@ from dataclasses import dataclass
 from functools import reduce
 
 from .abstract import AbstractArray, SHAPE, ANYTHING, MyiaShapeError, \
-    AbstractFunction, GraphFunction, AbstractList, AbstractTuple
-from .dtype import Array, Object, Int, UInt, Float, Number, Bool, Tuple, \
-    List, Class, EnvType, Function, Problem
+    AbstractFunction, GraphFunction, AbstractList, AbstractTuple, \
+    AbstractClass
+from .dtype import Array, Object, Int, UInt, Float, Number, Bool, \
+    EnvType, Function, Problem
 from .hypermap import HyperMap
 from .abstract import MyiaTypeError, broaden
 from .info import About
@@ -549,7 +550,7 @@ def _array_zero(xs):
 
 zeros_like = HyperMap(
     name='zeros_like',
-    nonleaf=(Tuple, List, Class),
+    nonleaf=(AbstractTuple, AbstractList, AbstractClass),
     fn_leaf=_leaf_zeros_like
 )
 

--- a/myia/composite.py
+++ b/myia/composite.py
@@ -9,7 +9,7 @@ from .abstract import AbstractArray, SHAPE, ANYTHING, MyiaShapeError, \
     AbstractClass
 from .dtype import Array, Object, Int, UInt, Float, Number, Bool, \
     EnvType, Function, Problem
-from .hypermap import HyperMap
+from .hypermap import HyperMap, hyper_map
 from .abstract import MyiaTypeError, broaden
 from .info import About
 from .ir import Graph, MetaGraph, MultitypeGraph, Constant
@@ -756,3 +756,47 @@ class GradOperation(MetaGraph):
 
 
 grad = GradOperation('grad')
+
+
+class ArithmeticData:
+    """Mixin to implement access to arithmetic operators.
+
+    When used for a dataclass D, operations like D + D will add together
+    all matching fields from the added instances.
+    """
+
+    @core
+    def __add__(self, x):
+        return hyper_map(add, self, x)
+
+    @core
+    def __sub__(self, x):
+        return hyper_map(sub, self, x)
+
+    @core
+    def __mul__(self, x):
+        return hyper_map(mul, self, x)
+
+    @core
+    def __truediv__(self, x):
+        return hyper_map(truediv, self, x)
+
+    @core
+    def __floordiv__(self, x):
+        return hyper_map(floordiv, self, x)
+
+    @core
+    def __mod__(self, x):
+        return hyper_map(mod, self, x)
+
+    @core
+    def __pow__(self, x):
+        return hyper_map(pow, self, x)
+
+    @core
+    def __pos__(self):
+        return hyper_map(uadd, self)
+
+    @core
+    def __neg__(self):
+        return hyper_map(usub, self)

--- a/myia/dtype.py
+++ b/myia/dtype.py
@@ -442,7 +442,9 @@ def pytype_to_myiatype(pytype, instance=None):
 
         fields = pytype.__dataclass_fields__
         if instance is None:
-            attributes = {name: pytype_to_myiatype(field.type)
+            attributes = {name: Object
+                          if isinstance(field.type, (str, type(None)))
+                          else pytype_to_myiatype(field.type)
                           for name, field in fields.items()}
         else:
             attributes = {}

--- a/myia/pipeline/resources.py
+++ b/myia/pipeline/resources.py
@@ -356,7 +356,7 @@ class InferenceResource(PipelineResource):
     def infer(self, graph, argspec, outspec=None, clear=False):
         """Perform inference."""
         if clear:
-            self.engine.cache.clear()
+            self.engine.reset()
             for node in self.manager.all_nodes:
                 orig_t = node.abstract
                 node.abstract = None

--- a/myia/specialize.py
+++ b/myia/specialize.py
@@ -191,6 +191,8 @@ class _GraphSpecializer:
                         # the inferrer. It should have been, but sometimes
                         # it isn't, not sure why. Hopefully a rewrite of the
                         # specializer should fix everything.
+                        if hasattr(currinf, 'graph_cache'):
+                            await concretize_cache(currinf.graph_cache)
                         g = currinf.get_graph(eng, broad_argvals)
                         ctx = currinf.make_context(eng, broad_argvals)
                         if eng.ref(g.output, ctx) in eng.cache.cache:

--- a/myia/utils/overload.py
+++ b/myia/utils/overload.py
@@ -65,6 +65,7 @@ class Overload:
                  wrapper=None,
                  initial_state=None,
                  mixins=[],
+                 name=None,
                  _parent=None):
         """Initialize an Overload."""
         if bind_to is True:
@@ -76,7 +77,7 @@ class Overload:
         self._wrapper = wrapper
         self.state = None
         self.initial_state = initial_state
-        self.name = None
+        self.name = name
         if _parent:
             assert _parent.which is not None
             self.map = _parent.map
@@ -169,7 +170,7 @@ class Overload:
         return ov
 
     def __get__(self, obj, cls):
-        return Overload(bind_to=obj, _parent=self)
+        return Overload(bind_to=obj, _parent=self, name=self.name)
 
     def __getitem__(self, t):
         if self.__self__:
@@ -206,7 +207,7 @@ class Overload:
             return self._wrapper(method, *args, **kwargs)
 
     def __repr__(self):
-        return f'<Overload {self.name or hex(self.id)}>'
+        return f'<Overload {self.name or hex(id(self))}>'
 
 
 def _find_overload(fn, bootstrap, initial_state):

--- a/tests/common.py
+++ b/tests/common.py
@@ -10,6 +10,7 @@ from myia.dtype import Bool, Int, UInt, Float, List, Array, Tuple, Function, \
     Object, pytype_to_myiatype
 from myia.ir import MultitypeGraph
 from myia.utils import overload, EnvInstance
+from myia.composite import ArithmeticData
 
 
 B = Bool
@@ -181,7 +182,7 @@ class Thing:
 
 
 @dataclass(frozen=True)
-class Point:
+class Point(ArithmeticData):
     x: i64
     y: i64
 
@@ -190,10 +191,10 @@ class Point:
 
 
 @dataclass(frozen=True)
-class Point3D:
-    x: i64
-    y: i64
-    z: i64
+class Point3D(ArithmeticData):
+    x: Object
+    y: Object
+    z: Object
 
     def abs(self):
         return (self.x ** 2 + self.y ** 2 + self.z ** 2) ** 0.5

--- a/tests/test_hypermap.py
+++ b/tests/test_hypermap.py
@@ -1,0 +1,33 @@
+
+import numpy
+
+# composite has to be imported before hypermap because of circular import
+# shenanigans
+from myia import composite  # noqa
+
+from myia.hypermap import HyperMap, hyper_map
+from myia.prim.py_implementations import scalar_add
+
+from .common import Point
+
+
+def test_hypermap():
+    # Normal
+    assert hyper_map(scalar_add, 10, 20) == 30
+    assert hyper_map(scalar_add, (1, 2), (10, 20)) == (11, 22)
+    assert hyper_map(scalar_add, [1, 2, 3], [3, 2, 1]) == [4, 4, 4]
+    assert (hyper_map(scalar_add, numpy.ones((2, 2)), numpy.ones((2, 2)))
+            == 2 * numpy.ones((2, 2))).all()
+
+    # Broadcast
+    assert hyper_map(scalar_add, [1, 2, 3], 10) == [11, 12, 13]
+    assert hyper_map(scalar_add, Point([1, 2], (3, 4)), Point(10, 100)) \
+        == Point([11, 12], (103, 104))
+    assert (hyper_map(scalar_add, numpy.ones((2, 2)), 9)
+            == 10 * numpy.ones((2, 2))).all()
+
+    # Provide fn_leaf
+    adder = HyperMap(fn_leaf=scalar_add)
+    assert adder((1, 2), (10, 20)) == (11, 22)
+    assert (adder(numpy.ones((2, 2)), numpy.ones((2, 2)))
+            == 2 * numpy.ones((2, 2))).all()

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1565,6 +1565,57 @@ def test_dataclass_method(pt):
     return pt.abs()
 
 
+@infer_std((Point(i64, i64), Point(i64, i64), Point(i64, i64)))
+def test_arithmetic_data_add(pt1, pt2):
+    return pt1 + pt2
+
+
+@infer_std((Point(i64, i64), Point(i64, i64)))
+def test_arithmetic_data_add_ct(pt):
+    return pt + 10
+
+
+@infer_std((Point(i64, i64), Point(i64, i64), Point(i64, i64)))
+def test_arithmetic_data_sub(pt1, pt2):
+    return pt1 - pt2
+
+
+@infer_std((Point(i64, i64), Point(i64, i64), Point(i64, i64)))
+def test_arithmetic_data_mul(pt1, pt2):
+    return pt1 * pt2
+
+
+@infer_std((Point3D(f64, f64, f64), Point3D(f64, f64, f64),
+            Point3D(f64, f64, f64)))
+def test_arithmetic_data_truediv(pt1, pt2):
+    return pt1 / pt2
+
+
+@infer_std((Point(i64, i64), Point(i64, i64), Point(i64, i64)))
+def test_arithmetic_data_floordiv(pt1, pt2):
+    return pt1 // pt2
+
+
+@infer_std((Point(i64, i64), Point(i64, i64), Point(i64, i64)))
+def test_arithmetic_data_mod(pt1, pt2):
+    return pt1 % pt2
+
+
+@infer_std((Point(i64, i64), Point(i64, i64), Point(i64, i64)))
+def test_arithmetic_data_pow(pt1, pt2):
+    return pt1 ** pt2
+
+
+@infer_std((Point(i64, i64), Point(i64, i64)))
+def test_arithmetic_data_pos(pt):
+    return +pt
+
+
+@infer_std((Point(i64, i64), Point(i64, i64)))
+def test_arithmetic_data_neg(pt):
+    return -pt
+
+
 @infer(
     (i64, i64, i64, i64, Point(i64, i64)),
     (f64, f64, f64, f64, InferenceError),

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -5,14 +5,14 @@ import numpy as np
 
 from types import SimpleNamespace
 
+from myia import abstract
 from myia.abstract import concretize_abstract
 from myia.abstract.prim import UniformPrimitiveInferrer
 from myia.pipeline import standard_pipeline, scalar_pipeline
 from myia.composite import hyper_add, zeros_like, grad, list_map, tail
 from myia.debug.traceback import print_inference_error
-from myia.dtype import Array as A, Int, External, List, \
-    Number, Class, EnvType as Env, Nil
-from myia.hypermap import HyperMap
+from myia.dtype import Int, External, List, Number, Class, EnvType as Env, Nil
+from myia.hypermap import HyperMap, hyper_map
 from myia.abstract import ANYTHING, InferenceError, Contextless, CONTEXTLESS
 from myia.ir import Graph, MultitypeGraph
 from myia.prim import Primitive, ops as P
@@ -1595,8 +1595,11 @@ def test_dataclass_call(thing):
     return thing()
 
 
-hyper_map = HyperMap()
-hyper_map_notuple = HyperMap(nonleaf=(A, Class))
+hyper_map_notuple = HyperMap(
+    nonleaf=(abstract.AbstractArray,
+             abstract.AbstractList,
+             abstract.AbstractClass)
+)
 hyper_map_nobroadcast = HyperMap(broadcast=False)
 
 
@@ -1629,7 +1632,8 @@ def test_hyper_map(x, y):
     return hyper_map(scalar_add, x, y)
 
 
-@infer(((i64, f64), (i64, f64), InferenceError))
+@infer(((i64, f64), (i64, f64), InferenceError),
+       ([f64], f64, [f64]))
 def test_hyper_map_notuple(x, y):
     return hyper_map_notuple(scalar_add, x, y)
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1605,16 +1605,25 @@ hyper_map_nobroadcast = HyperMap(broadcast=False)
     (f64, f64, f64),
     ([f64], [f64], [f64]),
     ([[f64]], [[f64]], [[f64]]),
-    ([f64], f64, InferenceError),
-    ([f64], [[f64]], InferenceError),
     ((i64, f64), (i64, f64), (i64, f64)),
     (Point(i64, i64), Point(i64, i64), Point(i64, i64)),
     (ai64_of(2, 5), ai64_of(2, 5), ai64_of(2, 5)),
     (ai64_of(2, 5), i64, ai64_of(2, 5)),
     (ai64_of(1, 5), ai64_of(2, 1), ai64_of(2, 5)),
     (i64, f64, InferenceError),
-    ([f64], f64, InferenceError),
     (ai64_of(2, 5), af64_of(2, 5), InferenceError),
+
+    # Generic broadcasting tests
+    ([f64], f64, [f64]),
+    ([f64], [[f64]], [[f64]]),
+    ((i64, i64), i64, (i64, i64)),
+    (i64, (i64, i64), (i64, i64)),
+    (Point(i64, i64), i64, Point(i64, i64)),
+
+    # Various errors
+    ((i64, i64), (i64, i64, i64), InferenceError),
+    (Point(i64, i64), Point3D(i64, i64, i64), InferenceError),
+    ((i64, i64), [i64], InferenceError),
 )
 def test_hyper_map(x, y):
     return hyper_map(scalar_add, x, y)

--- a/tests/test_specialize.py
+++ b/tests/test_specialize.py
@@ -14,6 +14,7 @@ from myia.prim.py_implementations import \
     scalar_usub, scalar_uadd, switch, array_map
 from myia.validate import ValidationError
 from myia.utils import overload
+from myia.hypermap import hyper_map
 
 from .common import mysum, i64, f64, Point
 
@@ -110,6 +111,9 @@ int2 = 21
 
 fp1 = 2.7
 fp2 = 6.91
+
+pt1 = Point(10, 20)
+pt2 = Point(100, 200)
 
 
 @specialize((int1, int2),
@@ -425,3 +429,17 @@ def test_union(x):
         return x
     else:
         return x[0]
+
+
+@specialize(
+    (int1, int2),
+    (pt1, int1),
+    (pt1, pt2),
+)
+def test_hyper_map(x, y):
+    return hyper_map(scalar_add, x, y)
+
+
+@specialize((int1,))
+def test_hyper_map_ct(x):
+    return hyper_map(scalar_add, x, 1)


### PR DESCRIPTION
`hyper_map` now supports operating on a scalar and a data structure, so that e.g. `hyper_map(f, [1, 2], 3)` is equivalent to `hyper_map(f, [1, 2], [3, 3])`. Among other things this would allow multiplying the gradient of a model by a learning rate.

The `ArithmeticData` mixin is also added. It defines `__add__`, `__sub__`, etc. using `hyper_map`. For the time being, adding/subtracting/etc. a scalar requires the scalar to be the second argument, since we currently have no support for `__radd__` and the like.

As a side effect of implementing this functionality, `ListMap` now takes a `loop_mask` argument that determines which arguments are lists to loop on. The rest of the arguments are effectively broadcasted.
