### PR TITLE
Expand the interface of grad

### DIFF
--- a/tests/test_hypermap.py
+++ b/tests/test_hypermap.py
@@ -31,3 +31,8 @@ def test_hypermap():
     assert adder((1, 2), (10, 20)) == (11, 22)
     assert (adder(numpy.ones((2, 2)), numpy.ones((2, 2)))
             == 2 * numpy.ones((2, 2))).all()
+
+
+def test_arithmetic_data():
+    assert Point(1, 2) + Point(10, 20) == Point(11, 22)
+    assert Point(1, 2) + 10 == Point(11, 12)


### PR DESCRIPTION
This expands the interface of `grad` to support specifying which argument to take the gradient of:

* `grad(f, 'x')` to take the gradient wrt the argument of f named 'x'
* `grad(f, 0)` to take it wrt the first argument of f
* `grad(f, 'x', 'y')` to return gradients wrt arguments 'x' and 'y' (returned in the same order as specified)
* `grad(f, '*')` to return all the gradients

The `value_and_grad` function is also added. It functions just like `grad`, but the first return value is the normal return value of the function.
