### PR TITLE
Add rmethods to ArithmeticData

### DIFF
--- a/examples/mlp.py
+++ b/examples/mlp.py
@@ -140,9 +140,7 @@ def run_helper(epochs, n, batch_size, layer_sizes):
         for inp, target in data:
             cost, dmodel = step(model, inp, target)
             costs.append(cost)
-            # For various reasons including a numpy quirk, when multiplying
-            # by a scalar the scalar needs to be the right side operand.
-            model = model - (dmodel * numpy.float32(0.01))
+            model = model - (numpy.float32(0.01) * dmodel)
         print(f'Cost: {cost / n}')
 
 

--- a/myia/composite.py
+++ b/myia/composite.py
@@ -835,6 +835,8 @@ class ArithmeticData:
     all matching fields from the added instances.
     """
 
+    __array_priority__ = 1_000_000
+
     @core
     def __add__(self, x):
         return hyper_map(add, self, x)
@@ -870,3 +872,31 @@ class ArithmeticData:
     @core
     def __neg__(self):
         return hyper_map(usub, self)
+
+    @core
+    def __radd__(self, x):
+        return hyper_map(add, x, self)
+
+    @core
+    def __rsub__(self, x):
+        return hyper_map(sub, x, self)
+
+    @core
+    def __rmul__(self, x):
+        return hyper_map(mul, x, self)
+
+    @core
+    def __rtruediv__(self, x):
+        return hyper_map(truediv, x, self)
+
+    @core
+    def __rfloordiv__(self, x):
+        return hyper_map(floordiv, x, self)
+
+    @core
+    def __rmod__(self, x):
+        return hyper_map(mod, x, self)
+
+    @core
+    def __rpow__(self, x):
+        return hyper_map(pow, x, self)


### PR DESCRIPTION
This adds `__radd__` etc. to `ArithmeticData`, using `__array_priority__` in order to tell `numpy` to prioritize using these methods.
