### PR TITLE
Make the pytorch backend faster.

### DIFF
--- a/myia/compile/backends/pytorch.py
+++ b/myia/compile/backends/pytorch.py
@@ -190,7 +190,7 @@ class PyTorchBackend(Backend):
 
     def to_numpy(self, v):
         """Make a numpy array from a torch tensor."""
-        if v.is_cuda:
+        if v.is_cuda:  # pragma: no cover
             v = v.cpu()
         return v.numpy()
 

--- a/myia/compile/backends/pytorch.py
+++ b/myia/compile/backends/pytorch.py
@@ -37,6 +37,39 @@ simple_mapping = {
     P.scalar_add: lambda a, b: a + b,
     P.scalar_sub: lambda a, b: a - b,
     P.scalar_mul: lambda a, b: a * b,
+    P.scalar_div: lambda a, b: (a / b).astype(a.dtype),
+    P.scalar_mod: lambda a, b: a % b,
+    P.scalar_pow: lambda a, b: a ** b,
+    P.scalar_floor: np.floor,
+    P.scalar_uadd: lambda a: a,
+    P.scalar_usub: lambda a: -a,
+    P.scalar_exp: np.exp,
+    P.scalar_log: np.log,
+    P.scalar_tan: np.tan,
+    P.scalar_tanh: np.tanh,
+
+    P.scalar_eq: lambda a, b: a == b,
+    P.scalar_lt: lambda a, b: a < b,
+    P.scalar_gt: lambda a, b: a > b,
+    P.scalar_ne: lambda a, b: a != b,
+    P.scalar_le: lambda a, b: a <= b,
+    P.scalar_ge: lambda a, b: a >= b,
+
+    P.bool_and: lambda a, b: a & b,
+    P.bool_or: lambda a, b: a | b,
+    P.bool_eq: lambda a, b: a == b,
+    P.bool_not: lambda a: ~a,
+
+    P.distribute: lambda a, shp: a.expand(*shp),
+    P.transpose: lambda a, perm: a.permute(*perm),
+    P.dot: torch.mm,
+}
+
+
+scalar_mapping = {
+    P.scalar_add: lambda a, b: a + b,
+    P.scalar_sub: lambda a, b: a - b,
+    P.scalar_mul: lambda a, b: a * b,
     P.scalar_div: lambda a, b: a / b,
     P.scalar_mod: lambda a, b: a % b,
     P.scalar_pow: lambda a, b: a ** b,
@@ -59,10 +92,6 @@ simple_mapping = {
     P.bool_or: lambda a, b: a | b,
     P.bool_eq: torch.eq,
     P.bool_not: lambda a: ~a,
-
-    P.distribute: lambda a, shp: a.expand(*shp),
-    P.transpose: lambda a, perm: a.permute(*perm),
-    P.dot: torch.mm,
 }
 
 
@@ -71,8 +100,8 @@ def pytorch_array_map(op):
     fn = op.inputs[1]
     assert fn.is_constant(Primitive)
     fn = fn.value
-    if fn in simple_mapping:
-        impl = simple_mapping[fn]
+    if fn in scalar_mapping:
+        impl = scalar_mapping[fn]
     else:
         raise NotImplementedError(f'array_map of {fn}')
 

--- a/myia/compile/transform.py
+++ b/myia/compile/transform.py
@@ -261,7 +261,10 @@ class CompileGraph:
                         self.add_instr('tuple_getitem',
                                        self.ref(split.inputs[1]),
                                        self.ref(split.inputs[2]))
-                    elif fn.value == P.tuple_setitem:
+                    elif fn.value == P.tuple_setitem:  # pragma: no cover
+                        raise RuntimeError(
+                            "Please report your testcase so that "
+                            "we can add it to the testsuite")
                         self.add_instr('tuple_setitem',
                                        self.ref(split.inputs[1]),
                                        self.ref(split.inputs[2]),

--- a/myia/compile/vm.py
+++ b/myia/compile/vm.py
@@ -289,7 +289,7 @@ class FinalVM:
         idx = self.backend.to_scalar(self._ref(idx))
         self._push(a[idx])
 
-    def inst_tuple_setitem(self, t, idx, v):
+    def inst_tuple_setitem(self, t, idx, v):  # pragma: no cover
         """Set an item in a tuple.
 
         Arguemnts:
@@ -297,6 +297,8 @@ class FinalVM:
            idx: index
            v: value to set
         """
+        raise RuntimeError("Please report your test case so that "
+                           "we can add it to the test suite")
         t = self._ref(t)
         idx = self.backend.to_scalar(self._ref(idx))
         v = self._ref(v)

--- a/myia/hypermap.py
+++ b/myia/hypermap.py
@@ -154,6 +154,7 @@ class HyperMap(MetaGraph):
         """Create a graph for mapping over the given args."""
         g = Graph()
         g.debug.name = 'hyper_map'
+        g.flags['core'] = True
         argmap = {}
         if self.fn_leaf is None:
             fn_t, *args = all_args

--- a/myia/pipeline/steps.py
+++ b/myia/pipeline/steps.py
@@ -631,7 +631,24 @@ def convert_result(self, arg, orig_t, vm_t: AbstractArray, backend):
 
 
 class Wrap(PipelineStep):
+    """Pipeline step to export a callable.
+
+    Inputs:
+        graph: The graph to wrap into a callable.
+        output: callable
+        argspec: types of inputs
+        outspec: types of outputs
+        orig_argspec: initial argspec
+        orig_outspec: intial outspec
+        erase_class: boolean marker
+        erase_tuple: boolean marker
+
+    Outputs:
+        output: wrapped callable.
+    """
+
     def __init__(self, pipeline_init, return_backend=False):
+        """Initialize the Wrap."""
         super().__init__(pipeline_init)
         self.return_backend = return_backend
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -51,6 +51,15 @@ def test_myia_specialize_values():
     assert ft is not ff
 
 
+def test_myia_return_backend():
+    @myia(return_backend=True)
+    def f(x, y):
+        return x + y
+
+    # Only tests that it returns something and it works
+    assert f(10, 20) is not None
+
+
 def test_myia_struct_arg():
     @myia
     def f(pt):


### PR DESCRIPTION
This is mainly three things:
 * Make sure all scalars are on the CPU
 * Allow returning the internal values for the backend (to avoid GPU -> CPU transfers)
 * Inline hyper_add to make sure we simplify redundant additions of 0.
