### PR TITLE
Add RNN and LSTM examples

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,7 @@ omit =
     tests/*
     debug/*
     myia/debug/*
+    examples/*
 
 [report]
 exclude_lines =

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ env:
   - TEST_SUITE=unit
 script:
   - if [[ $TEST_SUITE == "static" ]]; then flake8 && pydocstyle myia; fi
-  - if [[ $TEST_SUITE == "unit" ]]; then pytest --cov=./ tests; fi
+  - if [[ $TEST_SUITE == "unit" ]]; then pytest --cov=./; fi
 after_success:
   - if [[ $TEST_SUITE == "unit" ]]; then codecov; fi

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,4 +3,5 @@ ignore:
   - "docs"
   - "setup.py"
   - "myia/debug"
+  - "examples"
 comment: false

--- a/examples/lstm.py
+++ b/examples/lstm.py
@@ -20,6 +20,7 @@ from myia.debug import traceback  # noqa
 ###########
 
 
+dtype = 'float32'
 device_type = 'cpu'
 # device_type = 'cuda'  # Uncomment to run on the gpu
 
@@ -35,7 +36,7 @@ device_type = 'cpu'
 
 def param(R, *size):
     """Generates a random array using the generator R."""
-    return numpy.array(R.rand(*size) * 2 - 1, dtype='float32')
+    return numpy.array(R.rand(*size) * 2 - 1, dtype=dtype)
 
 
 def generate_data(n, batch_size, input_size, target_size, sequence_size,
@@ -71,8 +72,8 @@ def lstm_parameters(*layer_sizes, batch_size, seed=6666):
     b_c = param(R, 1, h)
     b_o = param(R, 1, h)
 
-    s0 = numpy.zeros((batch_size, h), dtype='float32')
-    c0 = numpy.zeros((batch_size, h), dtype='float32')
+    s0 = numpy.zeros((batch_size, h), dtype=dtype)
+    c0 = numpy.zeros((batch_size, h), dtype=dtype)
 
     parameters = [(
         W_i, W_f, W_c, W_o,
@@ -219,6 +220,7 @@ def run_helper(epochs, n, batch_size, layer_sizes):
         layers.append(Tanh())
     model = Sequential(tuple(layers))
     data = generate_data(n, batch_size, layer_sizes[0], layer_sizes[-1], 10)
+    lr = getattr(numpy, dtype)(0.01)
 
     for _ in range(epochs):
         costs = []
@@ -228,7 +230,7 @@ def run_helper(epochs, n, batch_size, layer_sizes):
             if isinstance(cost, numpy.ndarray):
                 cost = float(cost)
             costs.append(cost)
-            model = model - (numpy.float32(0.01) * dmodel)
+            model = model - (lr * dmodel)
         c = sum(costs) / n
         t = time.time() - t0
         print(f'Cost: {c:15.10f}\tTime: {t:15.10f}')

--- a/examples/lstm.py
+++ b/examples/lstm.py
@@ -243,7 +243,7 @@ def run_helper(epochs, n, batch_size, layer_sizes):
 #     regressions, so keep a low number of narrow layers to make sure it runs
 #     quickly.
 #     """
-#     run_helper(1, 5, 5, (10, 3))
+#     run_helper(1, 1, 5, (10, 3))
 
 
 def run():

--- a/examples/lstm.py
+++ b/examples/lstm.py
@@ -236,6 +236,9 @@ def run_helper(epochs, n, batch_size, layer_sizes):
         print(f'Cost: {c:15.10f}\tTime: {t:15.10f}')
 
 
+# We do not currently run this test in the test suite because it is too
+# expensive to run.
+
 # def test_run():
 #     """Run the model.
 

--- a/examples/lstm.py
+++ b/examples/lstm.py
@@ -10,10 +10,9 @@ from numpy.random import RandomState
 from dataclasses import dataclass
 
 from myia import myia, value_and_grad, ArithmeticData
-from myia.prim.py_implementations import distribute, shape, tuple_setitem
 from myia.dtype import Array
 # The following import installs custom tracebacks for inference errors
-# from myia.debug import traceback  # noqa
+from myia.debug import traceback  # noqa
 
 
 ###########

--- a/examples/lstm.py
+++ b/examples/lstm.py
@@ -1,0 +1,254 @@
+"""Example of an RNN in Myia.
+
+Myia is still a work in progress, and this example may change in the future.
+"""
+
+
+import time
+import numpy
+from numpy.random import RandomState
+from dataclasses import dataclass
+
+from myia import myia, value_and_grad, ArithmeticData
+from myia.prim.py_implementations import distribute, shape, tuple_setitem
+from myia.dtype import Array
+# The following import installs custom tracebacks for inference errors
+# from myia.debug import traceback  # noqa
+
+
+###########
+# Options #
+###########
+
+
+device_type = 'cpu'
+# device_type = 'cuda'  # Uncomment to run on the gpu
+
+
+########
+# Data #
+########
+
+
+# This just generates random data so we don't have to load a real dataset,
+# but the model will work just as well on a real dataset.
+
+
+def param(R, *size):
+    """Generates a random array using the generator R."""
+    return numpy.array(R.rand(*size) * 2 - 1, dtype='float32')
+
+
+def generate_data(n, batch_size, input_size, target_size, sequence_size,
+                  *, seed=91):
+    """Generate inputs and targets.
+
+    Generates n batches of samples of size input_size, matched with
+    a single target.
+    """
+    R = RandomState(seed=seed)
+    return [([param(R, batch_size, input_size) for i in range(sequence_size)],
+             param(R, batch_size, target_size))
+            for i in range(n)]
+
+
+def lstm_parameters(*layer_sizes, batch_size, seed=6666):
+    """Generates parameters for a MLP given a list of layer sizes."""
+    R = RandomState(seed=seed)
+    i, h, *rest = layer_sizes
+
+    W_i = param(R, i, h)
+    W_f = param(R, i, h)
+    W_c = param(R, i, h)
+    W_o = param(R, i, h)
+
+    R_i = param(R, h, h)
+    R_f = param(R, h, h)
+    R_c = param(R, h, h)
+    R_o = param(R, h, h)
+
+    b_i = param(R, 1, h)
+    b_f = param(R, 1, h)
+    b_c = param(R, 1, h)
+    b_o = param(R, 1, h)
+
+    s0 = numpy.zeros((batch_size, h), dtype='float32')
+    c0 = numpy.zeros((batch_size, h), dtype='float32')
+
+    parameters = [(
+        W_i, W_f, W_c, W_o,
+        R_i, R_f, R_c, R_o,
+        b_i, b_f, b_c, b_o,
+        s0, c0
+    )]
+
+    for i, o in zip((h, *rest[:-1]), rest):
+        W = param(R, i, o)
+        b = param(R, 1, o)
+        parameters.append((W, b))
+
+    return parameters
+
+
+#########
+# Model #
+#########
+
+
+# We generate an LSTM.
+
+
+def sigmoid(x):
+    """Sigmoid activation function."""
+    return (numpy.tanh(x) + 1) / 2
+
+
+@dataclass(frozen=True)
+class Linear(ArithmeticData):
+    """Linear layer."""
+
+    W: 'Weights array'
+    b: 'Biases vector'
+
+    def apply(self, input):
+        """Apply the layer."""
+        return input @ self.W + self.b
+
+
+@dataclass(frozen=True)
+class Tanh(ArithmeticData):
+    """Tanh layer."""
+
+    def apply(self, input):
+        """Apply the layer."""
+        return numpy.tanh(input)
+
+
+@dataclass(frozen=True)
+class LSTMLayer(ArithmeticData):
+    """LSTM layer."""
+
+    W_i: Array
+    W_f: Array
+    W_c: Array
+    W_o: Array
+
+    R_i: Array
+    R_f: Array
+    R_c: Array
+    R_o: Array
+
+    b_i: Array
+    b_f: Array
+    b_c: Array
+    b_o: Array
+
+    s0: Array
+    c0: Array
+
+    def step(self, x_t, h_tm1, c_tm1):
+        """Run one LSTM step."""
+        i_t = sigmoid((x_t @ self.W_i) + (h_tm1 @ self.R_i) + self.b_i)
+        f_t = sigmoid((x_t @ self.W_f) + (h_tm1 @ self.R_f) + self.b_f)
+        o_t = sigmoid((x_t @ self.W_o) + (h_tm1 @ self.R_o) + self.b_o)
+
+        c_hat_t = numpy.tanh(
+            (x_t @ self.W_c) + (h_tm1 @ self.R_c) + self.b_c
+        )
+
+        c_t = f_t * c_tm1 + i_t * c_hat_t
+        h_t = o_t * numpy.tanh(c_t)
+
+        return h_t, c_t
+
+    def apply(self, x):
+        """Apply the layer."""
+        s = self.s0
+        c = self.c0
+        for e in x:
+            s, c = self.step(e, s, c)
+        # Maybe collect and return the full list of s outputs?
+        return s
+
+
+@dataclass(frozen=True)
+class Sequential(ArithmeticData):
+    """Sequential layer, applies all sub-layers in order."""
+
+    layers: 'Tuple of layers'
+
+    def apply(self, x):
+        """Apply the layer."""
+        for layer in self.layers:
+            x = layer.apply(x)
+        return x
+
+
+def cost(model, x, target):
+    """Square difference loss."""
+    y = model.apply(x)
+    diff = target - y
+    return sum(diff * diff)
+
+
+# @myia(backend_options={'target': device_type})
+@myia(backend='pytorch', backend_options={'device': device_type})
+def step(model, x, y):
+    """Returns the loss and parameter gradients."""
+    # value_and_grad will return cost(model, x, y) and dcost(...)/dmodel.
+    # The 'model' argument can be omitted: by default the derivative wrt
+    # the first argument is returned.
+    return value_and_grad(cost, 'model')(model, x, y)
+
+
+def run_helper(epochs, n, batch_size, layer_sizes):
+    """Run a model with the specified layer sizes on n random batches.
+
+    The first layer is an LSTM layer, the rest are linear+tanh.
+
+    Arguments:
+        epochs: How many epochs to run.
+        n: Number of training batches to generate.
+        batch_size: Number of samples per batch.
+        layer_sizes: Sizes of the model's layers.
+    """
+    layers = []
+    lstmp, *linp = lstm_parameters(*layer_sizes, batch_size=batch_size)
+    layers.append(LSTMLayer(*lstmp))
+    for W, b in linp:
+        layers.append(Linear(W, b))
+        layers.append(Tanh())
+    model = Sequential(tuple(layers))
+    data = generate_data(n, batch_size, layer_sizes[0], layer_sizes[-1], 10)
+
+    for _ in range(epochs):
+        costs = []
+        t0 = time.time()
+        for inp, target in data:
+            cost, dmodel = step(model, inp, target)
+            if isinstance(cost, numpy.ndarray):
+                cost = float(cost)
+            costs.append(cost)
+            model = model - (numpy.float32(0.01) * dmodel)
+        c = sum(costs) / n
+        t = time.time() - t0
+        print(f'Cost: {c:15.10f}\tTime: {t:15.10f}')
+
+
+# def test_run():
+#     """Run the model.
+
+#     This function is run automatically in the test suite to check against
+#     regressions, so keep a low number of narrow layers to make sure it runs
+#     quickly.
+#     """
+#     run_helper(1, 5, 5, (10, 3))
+
+
+def run():
+    """Run the model."""
+    run_helper(100, 10, 5, (10, 7, 1))
+
+
+if __name__ == '__main__':
+    run()

--- a/examples/mlp.py
+++ b/examples/mlp.py
@@ -110,8 +110,8 @@ def cost(model, x, target):
     return sum(diff * diff)
 
 
-# @myia(backend='pytorch', backend_options={'device': device_type})
-@myia(backend_options={'target': device_type})
+# @myia(backend_options={'target': device_type})
+@myia(backend='pytorch', backend_options={'device': device_type})
 def step(model, x, y):
     """Returns the loss and parameter gradients."""
     # value_and_grad will return cost(model, x, y) and dcost(...)/dmodel.

--- a/examples/mlp.py
+++ b/examples/mlp.py
@@ -19,6 +19,7 @@ from myia.debug import traceback  # noqa
 ###########
 
 
+dtype = 'float32'
 device_type = 'cpu'
 # device_type = 'cuda'  # Uncomment to run on the gpu
 
@@ -34,7 +35,7 @@ device_type = 'cpu'
 
 def param(R, *size):
     """Generates a random array using the generator R."""
-    return numpy.array(R.rand(*size) * 2 - 1, dtype='float32')
+    return numpy.array(R.rand(*size) * 2 - 1, dtype=dtype)
 
 
 def generate_data(n, batch_size, input_size, target_size, *, seed=87):
@@ -135,6 +136,7 @@ def run_helper(epochs, n, batch_size, layer_sizes):
         layers.append(Tanh())
     model = Sequential(tuple(layers))
     data = generate_data(n, batch_size, layer_sizes[0], layer_sizes[-1])
+    lr = getattr(numpy, dtype)(0.01)
 
     for _ in range(epochs):
         costs = []
@@ -144,7 +146,7 @@ def run_helper(epochs, n, batch_size, layer_sizes):
             if isinstance(cost, numpy.ndarray):
                 cost = float(cost)
             costs.append(cost)
-            model = model - (numpy.float32(0.01) * dmodel)
+            model = model - (lr * dmodel)
         c = sum(costs) / n
         t = time.time() - t0
         print(f'Cost: {c:15.10f}\tTime: {t:15.10f}')

--- a/examples/mlp.py
+++ b/examples/mlp.py
@@ -4,6 +4,7 @@ Myia is still a work in progress, and this example may change in the future.
 """
 
 
+import time
 import numpy
 from numpy.random import RandomState
 from dataclasses import dataclass
@@ -137,11 +138,16 @@ def run_helper(epochs, n, batch_size, layer_sizes):
 
     for _ in range(epochs):
         costs = []
+        t0 = time.time()
         for inp, target in data:
             cost, dmodel = step(model, inp, target)
+            if isinstance(cost, numpy.ndarray):
+                cost = float(cost)
             costs.append(cost)
             model = model - (numpy.float32(0.01) * dmodel)
-        print(f'Cost: {cost / n}')
+        c = sum(costs) / n
+        t = time.time() - t0
+        print(f'Cost: {c:15.10f}\tTime: {t:15.10f}')
 
 
 def test_run():

--- a/examples/rnn.py
+++ b/examples/rnn.py
@@ -189,14 +189,14 @@ def run_helper(epochs, n, batch_size, layer_sizes):
         print(f'Cost: {c:15.10f}\tTime: {t:15.10f}')
 
 
-# def test_run():
-#     """Run the model.
+def test_run():
+    """Run the model.
 
-#     This function is run automatically in the test suite to check against
-#     regressions, so keep a low number of narrow layers to make sure it runs
-#     quickly.
-#     """
-#     run_helper(1, 5, 5, (10, 3))
+    This function is run automatically in the test suite to check against
+    regressions, so keep a low number of narrow layers to make sure it runs
+    quickly.
+    """
+    run_helper(1, 1, 5, (10, 3))
 
 
 def run():

--- a/examples/rnn.py
+++ b/examples/rnn.py
@@ -20,6 +20,7 @@ from myia.debug import traceback  # noqa
 ###########
 
 
+dtype = 'float32'
 device_type = 'cpu'
 # device_type = 'cuda'  # Uncomment to run on the gpu
 
@@ -35,7 +36,7 @@ device_type = 'cpu'
 
 def param(R, *size):
     """Generates a random array using the generator R."""
-    return numpy.array(R.rand(*size) * 2 - 1, dtype='float32')
+    return numpy.array(R.rand(*size) * 2 - 1, dtype=dtype)
 
 
 def generate_data(n, batch_size, input_size, target_size, sequence_size,
@@ -172,6 +173,7 @@ def run_helper(epochs, n, batch_size, layer_sizes):
         layers.append(Tanh())
     model = Sequential(tuple(layers))
     data = generate_data(n, batch_size, layer_sizes[0], layer_sizes[-1], 10)
+    lr = getattr(numpy, dtype)(0.01)
 
     for _ in range(epochs):
         costs = []
@@ -181,7 +183,7 @@ def run_helper(epochs, n, batch_size, layer_sizes):
             if isinstance(cost, numpy.ndarray):
                 cost = float(cost)
             costs.append(cost)
-            model = model - (numpy.float32(0.01) * dmodel)
+            model = model - (lr * dmodel)
         c = sum(costs) / n
         t = time.time() - t0
         print(f'Cost: {c:15.10f}\tTime: {t:15.10f}')

--- a/examples/rnn.py
+++ b/examples/rnn.py
@@ -10,7 +10,6 @@ from numpy.random import RandomState
 from dataclasses import dataclass
 
 from myia import myia, value_and_grad, ArithmeticData
-from myia.prim.py_implementations import distribute, shape, tuple_setitem
 # The following import installs custom tracebacks for inference errors
 from myia.debug import traceback  # noqa
 
@@ -115,9 +114,7 @@ class RNNLayer(ArithmeticData):
 
     def apply(self, x):
         """Apply the layer."""
-        shp = tuple_setitem(shape(self.h0), 0, shape(x[0])[0])
-        h = distribute(self.h0, shp)
-        # h = self.h0
+        h = self.h0
         for e in x:
             h = self.step(e, h)
         # Maybe collect and return the full list of outputs?

--- a/examples/rnn.py
+++ b/examples/rnn.py
@@ -4,6 +4,7 @@ Myia is still a work in progress, and this example may change in the future.
 """
 
 
+import time
 import numpy
 from numpy.random import RandomState
 from dataclasses import dataclass
@@ -164,11 +165,14 @@ def run_helper(epochs, n, batch_size, layer_sizes):
 
     for _ in range(epochs):
         costs = []
+        t0 = time.time()
         for inp, target in data:
             cost, dmodel = step(model, inp, target)
             costs.append(cost)
             model = model - (numpy.float32(0.01) * dmodel)
-        print(f'Cost: {cost / n}')
+        c = sum(costs) / n
+        t = time.time() - t0
+        print(f'Cost: {c:15.10f}\tTime: {t:15.10f}')
 
 
 # def test_run():

--- a/examples/rnn.py
+++ b/examples/rnn.py
@@ -1,0 +1,191 @@
+"""Example of an RNN in Myia.
+
+Myia is still a work in progress, and this example may change in the future.
+"""
+
+
+import numpy
+from numpy.random import RandomState
+from dataclasses import dataclass
+
+from myia import myia, value_and_grad, ArithmeticData
+from myia.prim.py_implementations import distribute, shape, tuple_setitem
+# The following import installs custom tracebacks for inference errors
+from myia.debug import traceback  # noqa
+
+
+###########
+# Options #
+###########
+
+
+device_type = 'cpu'
+# device_type = 'cuda'  # Uncomment to run on the gpu
+
+
+########
+# Data #
+########
+
+
+# This just generates random data so we don't have to load a real dataset,
+# but the model will work just as well on a real dataset.
+
+
+def param(R, *size):
+    """Generates a random array using the generator R."""
+    return numpy.array(R.rand(*size) * 2 - 1, dtype='float32')
+
+
+def generate_data(n, batch_size, input_size, target_size, sequence_size,
+                  *, seed=91):
+    """Generate inputs and targets.
+
+    Generates n batches of samples of size input_size, matched with
+    a single target.
+    """
+    R = RandomState(seed=seed)
+    return [([param(R, batch_size, input_size) for i in range(sequence_size)],
+             param(R, batch_size, target_size))
+            for i in range(n)]
+
+
+def rnn_parameters(*layer_sizes, seed=123123):
+    """Generates parameters for a MLP given a list of layer sizes."""
+    R = RandomState(seed=seed)
+    parameters = []
+    for i, o in zip(layer_sizes[:-1], layer_sizes[1:]):
+        W = param(R, i, o)
+        r = param(R, o, o)
+        b = param(R, 1, o)
+        h0 = param(R, 5, o)
+        parameters.append((W, r, b, h0))
+    return parameters
+
+
+#########
+# Model #
+#########
+
+
+# We generate an RNN.
+
+
+@dataclass(frozen=True)
+class Linear(ArithmeticData):
+    """Linear layer."""
+
+    W: 'Weights array'
+    b: 'Biases vector'
+
+    def apply(self, input):
+        """Apply the layer."""
+        return input @ self.W + self.b
+
+
+@dataclass(frozen=True)
+class Tanh(ArithmeticData):
+    """Tanh layer."""
+
+    def apply(self, input):
+        """Apply the layer."""
+        return numpy.tanh(input)
+
+
+@dataclass(frozen=True)
+class RNNLayer(ArithmeticData):
+    """RNN layer."""
+
+    W: 'Input to state weights'
+    R: 'State transition weights'
+    b: 'Biases vector'
+    h0: 'Initial state'
+
+    def step(self, x, h_tm1):
+        """Run one RNN step."""
+        return numpy.tanh((x @ self.W) + (h_tm1 @ self.R) + self.b)
+
+    def apply(self, x):
+        """Apply the layer."""
+        shp = tuple_setitem(shape(self.h0), 0, shape(x[0])[0])
+        h = distribute(self.h0, shp)
+        # h = self.h0
+        for e in x:
+            h = self.step(e, h)
+        # Maybe collect and return the full list of outputs?
+        return h
+
+
+@dataclass(frozen=True)
+class Sequential(ArithmeticData):
+    """Sequential layer, applies all sub-layers in order."""
+
+    layers: 'Tuple of layers'
+
+    def apply(self, x):
+        """Apply the layer."""
+        for layer in self.layers:
+            x = layer.apply(x)
+        return x
+
+
+def cost(model, x, target):
+    """Square difference loss."""
+    y = model.apply(x)
+    diff = target - y
+    return sum(diff * diff)
+
+
+# @myia(backend_options={'target': device_type})
+@myia(backend='pytorch', backend_options={'device': device_type})
+def step(model, x, y):
+    """Returns the loss and parameter gradients."""
+    # value_and_grad will return cost(model, x, y) and dcost(...)/dmodel.
+    # The 'model' argument can be omitted: by default the derivative wrt
+    # the first argument is returned.
+    return value_and_grad(cost, 'model')(model, x, y)
+
+
+def run_helper(epochs, n, batch_size, layer_sizes):
+    """Run a model with the specified layer sizes on n random batches.
+
+    Arguments:
+        epochs: How many epochs to run.
+        n: Number of training batches to generate.
+        batch_size: Number of samples per batch.
+        layer_sizes: Sizes of the model's layers.
+    """
+    layers = []
+    for W, R, b, h0 in rnn_parameters(*layer_sizes):
+        layers.append(RNNLayer(W, R, b, h0))
+        layers.append(Tanh())
+    model = Sequential(tuple(layers))
+    data = generate_data(n, batch_size, layer_sizes[0], layer_sizes[-1], 10)
+
+    for _ in range(epochs):
+        costs = []
+        for inp, target in data:
+            cost, dmodel = step(model, inp, target)
+            costs.append(cost)
+            model = model - (numpy.float32(0.01) * dmodel)
+        print(f'Cost: {cost / n}')
+
+
+# def test_run():
+#     """Run the model.
+
+#     This function is run automatically in the test suite to check against
+#     regressions, so keep a low number of narrow layers to make sure it runs
+#     quickly.
+#     """
+#     run_helper(1, 5, 5, (10, 3))
+
+
+def run():
+    """Run the model."""
+    # run_helper(100, 10, 5, (10, 50, 1))
+    run_helper(100, 10, 5, (10, 1))
+
+
+if __name__ == '__main__':
+    run()

--- a/myia/compile/backends/__init__.py
+++ b/myia/compile/backends/__init__.py
@@ -124,6 +124,8 @@ class Backend:
                 and issubclass(t.values[abstract.TYPE], dtype.EnvType):
             assert len(v._contents) == 0
             return self.empty_env()
+        elif isinstance(t, abstract.AbstractError):
+            return None
         else:
             raise NotImplementedError(f'convert_value for {t}')
 

--- a/myia/composite.py
+++ b/myia/composite.py
@@ -607,7 +607,7 @@ class ListMap(MetaGraph):
         g = Graph()
         g.flags['core'] = True
         g.flags['ignore_values'] = True
-        g.debug.name = 'list_map'
+        g.debug.name = self._decorate_name('list_map')
         fn = self.fn_rec or g.add_parameter()
         gargs = [g.add_parameter() for _ in args[nfn:]]
 

--- a/myia/ir/clone.py
+++ b/myia/ir/clone.py
@@ -317,6 +317,8 @@ class CloneRemapper(BasicRemapper):
 
     def clone_disconnected(self, droot):
         """Clone a subgraph that's not (yet) connected to its graph/manager."""
+        if droot.graph not in self.graph_repl:
+            return droot
         if droot in self.repl:
             return False
         target_graph = self.get_graph(droot.graph)


### PR DESCRIPTION
This adds `examples/rnn.py` and `examples/lstm.py`, along with a few fixes that make them run properly. Only `rnn.py` is added to the test suite for this PR, since the LSTM is currently a bit too costly.
