### PR TITLE
More robust eqrec/hashrec

### DIFF
--- a/myia/utils/__init__.py
+++ b/myia/utils/__init__.py
@@ -7,7 +7,7 @@ from .env import (  # noqa
 from .intern import (  # noqa
     Interned, InternedMC, EqKey, Atom, Elements, eqkey, deep_eqkey,
     RecursionException, eq, hash, hashrec, eqrec, IncompleteException,
-    PossiblyRecursive
+    PossiblyRecursive, intern,
 )
 
 from .merge import (  # noqa

--- a/myia/utils/intern.py
+++ b/myia/utils/intern.py
@@ -112,7 +112,6 @@ def hashrec(obj, n=100):
         obj: The object for which to compute a hash.
         n: The maximum number of contributions to the hash.
     """
-
     count = 0
     h = []
     for key in _bfs(obj):

--- a/myia/utils/intern.py
+++ b/myia/utils/intern.py
@@ -121,7 +121,7 @@ def hashrec(obj, n=100):
         if isinstance(key, Atom):
             h.extend((key.type, key.value))
         else:
-            h.append(key.type)
+            h.extend((key.type, len(key.values)))
     return pyhash(tuple(h))
 
 

--- a/myia/utils/intern.py
+++ b/myia/utils/intern.py
@@ -88,32 +88,45 @@ def deep_eqkey(obj, path=frozenset()):
     return dk
 
 
-def hashrec(obj, path, cache):
-    """Hash a (possibly self-referential) object."""
-    oid = id(obj)
-    if oid in path:
-        return 0
-    if oid in cache:
-        return cache[oid][1]
-    path = path | {oid}
+def _bfs(obj):
+    from collections import deque
 
-    key = eqkey(obj)
+    queue = deque()
+    queue.append(obj)
 
-    if isinstance(key, Atom):
-        rval = pyhash((key.type, key.value))
-
-    elif isinstance(key, Elements):
-        subhash = [hashrec(x, path, cache) for x in key.values]
-        rval = pyhash((key.type, type(key.values)(subhash)))
-
-    else:
-        raise AssertionError()
-
-    cache[oid] = obj, rval
-    return rval
+    while queue:
+        obj = queue.popleft()
+        key = eqkey(obj)
+        yield key
+        if isinstance(key, ElementsBase):
+            queue.extend(key.values)
 
 
-def eqrec(obj1, obj2, path1=frozenset(), path2=frozenset(), cache=None):
+def hashrec(obj, n=100):
+    """Hash a (possibly self-referential) object.
+
+    This explores the object breadth-first and uses the first n elements
+    to compute the hash.
+
+    Arguments:
+        obj: The object for which to compute a hash.
+        n: The maximum number of contributions to the hash.
+    """
+
+    count = 0
+    h = []
+    for key in _bfs(obj):
+        if count == n:
+            break
+        count += 1
+        if isinstance(key, Atom):
+            h.extend((key.type, key.value))
+        else:
+            h.append(key.type)
+    return pyhash(tuple(h))
+
+
+def eqrec(obj1, obj2, cache=None):
     """Compare two (possibly self-referential) objects for equality."""
     id1 = id(obj1)
     id2 = id(obj2)
@@ -121,14 +134,6 @@ def eqrec(obj1, obj2, path1=frozenset(), path2=frozenset(), cache=None):
     if (id1, id2) in cache:
         return True
 
-    if id1 in path1 or id2 in path2:
-        return False
-
-    if obj1 is obj2:
-        return True
-
-    path1 = path1 | {id1}
-    path2 = path2 | {id2}
     cache.add((id1, id2))
 
     key1 = eqkey(obj1)
@@ -146,7 +151,7 @@ def eqrec(obj1, obj2, path1=frozenset(), path2=frozenset(), cache=None):
         if len(v1) != len(v2):
             return False
         for x1, x2 in zip(v1, v2):
-            if not eqrec(x1, x2, path1, path2, cache):
+            if not eqrec(x1, x2, cache):
                 return False
         else:
             return True
@@ -161,7 +166,7 @@ def hash(obj):
         return pyhash(deep_eqkey(obj))
 
     except RecursionException:
-        return hashrec(obj, frozenset(), {})
+        return hashrec(obj)
 
 
 def eq(obj1, obj2):
@@ -172,7 +177,7 @@ def eq(obj1, obj2):
         return key1 == key2
 
     except RecursionException:
-        return eqrec(obj1, obj2, frozenset(), frozenset(), set())
+        return eqrec(obj1, obj2, set())
 
 
 class Wrapper:

--- a/myia/utils/intern.py
+++ b/myia/utils/intern.py
@@ -98,7 +98,7 @@ def _bfs(obj):
         obj = queue.popleft()
         key = eqkey(obj)
         yield key
-        if isinstance(key, ElementsBase):
+        if isinstance(key, Elements):
             queue.extend(key.values)
 
 

--- a/myia/utils/intern.py
+++ b/myia/utils/intern.py
@@ -204,20 +204,7 @@ class InternedMC(type):
 
     def intern(cls, inst):
         """Get the interned instance."""
-        wrap = Wrapper(inst)
-        try:
-            existing = _intern_pool.get(wrap, None)
-        except IncompleteException:
-            return inst
-        if existing is None:
-            _intern_pool[wrap] = inst
-            try:
-                inst._canonical = True
-            except Exception:
-                pass
-            return inst
-        else:
-            return existing
+        return intern(inst)
 
     def __call__(cls, *args, **kwargs):
         """Instantiates an interned instance."""
@@ -254,3 +241,21 @@ class PossiblyRecursive:
     def __init__(self):
         """Initialization sets the object to complete."""
         self._incomplete = False
+
+
+def intern(inst):
+    """Get the interned instance."""
+    wrap = Wrapper(inst)
+    try:
+        existing = _intern_pool.get(wrap, None)
+    except IncompleteException:
+        return inst
+    if existing is None:
+        _intern_pool[wrap] = inst
+        try:
+            inst._canonical = True
+        except Exception:
+            pass
+        return inst
+    else:
+        return existing

--- a/tests/utils/test_intern.py
+++ b/tests/utils/test_intern.py
@@ -52,7 +52,7 @@ def test_interned():
 
 def _test(a, b):
     eq = eqrec(a, b, cache=set())
-    hq = hashrec(a, frozenset(), {}) == hashrec(b, frozenset(), {})
+    hq = hashrec(a) == hashrec(b)
     # This is a sanity check that assumes no collisions
     assert hq == eq
     return eq
@@ -79,12 +79,12 @@ def test_eqrec():
 
     assert _test([a, b], [b, b])
     assert _test(a, b)
-    assert not _test(a, [1, a])
-    assert not _test(a, [1, [1, a]])
-    assert not _test(b, [1, a])
+    assert _test(a, [1, a])
+    assert _test(a, [1, [1, a]])
+    assert _test(b, [1, a])
     assert _test([1, b], [1, a])
-    assert not _test(z1, z2)
-    assert not _test(c, [1, c])
+    assert _test(z1, z2)
+    assert _test(c, [1, c])
 
     assert _test(Point(1, 2), Point(1, 2))
     assert _test(2+9j, 2+9j)
@@ -94,6 +94,24 @@ def test_eqrec():
 
     assert eq([a, b], [b, b])
     assert hsh([a, b]) == hsh([b, b])
+
+    # assert _test([a, b], [b, b])
+    # assert _test(a, b)
+    # assert not _test(a, [1, a])
+    # assert not _test(a, [1, [1, a]])
+    # assert not _test(b, [1, a])
+    # assert _test([1, b], [1, a])
+    # assert not _test(z1, z2)
+    # assert not _test(c, [1, c])
+
+    # assert _test(Point(1, 2), Point(1, 2))
+    # assert _test(2+9j, 2+9j)
+    # assert _test((1, 2), (1, 2))
+    # assert not _test((1, 2), (1, 2, 3))
+    # assert not _test((1, 2), [1, 2])
+
+    # assert eq([a, b], [b, b])
+    # assert hsh([a, b]) == hsh([b, b])
 
 
 def test_eqrec_incomplete():

--- a/tests/utils/test_intern.py
+++ b/tests/utils/test_intern.py
@@ -69,6 +69,9 @@ def test_eqrec():
     c = [1, [1]]
     c[1].append(c)
 
+    d = [2]
+    d.append(d)
+
     z1 = []
     z1.append(z1)
     z1.append(z1)
@@ -79,6 +82,7 @@ def test_eqrec():
 
     assert _test([a, b], [b, b])
     assert _test(a, b)
+    assert not _test(a, d)
     assert _test(a, [1, a])
     assert _test(a, [1, [1, a]])
     assert _test(b, [1, a])
@@ -94,24 +98,6 @@ def test_eqrec():
 
     assert eq([a, b], [b, b])
     assert hsh([a, b]) == hsh([b, b])
-
-    # assert _test([a, b], [b, b])
-    # assert _test(a, b)
-    # assert not _test(a, [1, a])
-    # assert not _test(a, [1, [1, a]])
-    # assert not _test(b, [1, a])
-    # assert _test([1, b], [1, a])
-    # assert not _test(z1, z2)
-    # assert not _test(c, [1, c])
-
-    # assert _test(Point(1, 2), Point(1, 2))
-    # assert _test(2+9j, 2+9j)
-    # assert _test((1, 2), (1, 2))
-    # assert not _test((1, 2), (1, 2, 3))
-    # assert not _test((1, 2), [1, 2])
-
-    # assert eq([a, b], [b, b])
-    # assert hsh([a, b]) == hsh([b, b])
 
 
 def test_eqrec_incomplete():


### PR DESCRIPTION
`eqrec` now compares as equal structures that were previously considered non-equal due to limitations on `hashrec`. `hashrec` is changed to remove these limitations, to an algorithm that combines a maximum of n elements yielded by a BFS of the data structure. Data structures larger than n may thus yield the same hash if their first n elements are the same, but that is probably not going to be a problem.

Note: This PR is based on #201.
