### PR TITLE
Debugging tools, minor improvements to errors and optimization names

### DIFF
--- a/debug/butest.py
+++ b/debug/butest.py
@@ -9,6 +9,8 @@ from itertools import count
 from dataclasses import dataclass
 from buche import buche, H, Reader, Repl, CodeGlobals, BucheDb
 
+from .gprint import mcss
+
 template_path = f'{os.path.dirname(__file__)}/test_template.html'
 
 _currid = count()
@@ -207,6 +209,8 @@ def pytest_sessionstart(session):
     for s in scripts:
         buche(H.script(type="text/javascript", src=s))
     buche(H.span())
+    buche(H.style(mcss))
+    buche.require('cytoscape')
 
 
 def pytest_report_collectionfinish(config, startdir, items):

--- a/debug/gprint.py
+++ b/debug/gprint.py
@@ -9,8 +9,8 @@ from myia.abstract import (
     AbstractValue, AbstractScalar, AbstractFunction, AbstractTuple,
     AbstractList, AbstractClassBase, AbstractJTagged, AbstractArray,
     GraphFunction, PartialApplication, TypedPrimitive, PrimitiveFunction,
-    MetaGraphFunction, AbstractUnion, VALUE, ANYTHING,
-    PendingTentative
+    MetaGraphFunction, AbstractUnion, VALUE, ANYTHING, JTransformedFunction,
+    VirtualFunction, PendingTentative
 )
 from myia.dtype import Type, Bool, Int, Float, TypeMeta, UInt
 from myia.utils import OrderedSet, UNKNOWN, SymbolicKeyInstance
@@ -1295,9 +1295,8 @@ class _AbstractList:
 @mixin(AbstractClassBase)
 class _AbstractClassBase:
     def __hrepr__(self, H, hrepr):
-        tagname = self.tag.__qualname__
         return hrepr.stdrepr_object(
-            f'★{tagname}',
+            f'★{self.tag.__qualname__}',
             self.attributes.items(),
             delimiter="↦",
             cls='abstract'
@@ -1307,9 +1306,13 @@ class _AbstractClassBase:
 @mixin(GraphFunction)
 class _GraphFunction:
     def __hrepr__(self, H, hrepr):
+        optkey = ([('tracking_id', self.tracking_id)]
+                  if self.tracking_id is not None else [])
         return hrepr.stdrepr_object(
             'GraphFunction',
-            (('graph', self.graph), ('context', self.context)),
+            (('graph', self.graph),
+             ('context', self.context),
+             *optkey),
             delimiter="↦",
         )
 
@@ -1352,5 +1355,26 @@ class _PrimitiveFunction:
         return hrepr.stdrepr_object(
             'PrimitiveFunction',
             (('prim', self.prim),),
+            delimiter="↦",
+        )
+
+
+@mixin(JTransformedFunction)
+class _JTransformedFunction:
+    def __hrepr__(self, H, hrepr):
+        return hrepr.stdrepr_object(
+            'JTransformedFunction',
+            (('fn', self.fn),),
+            delimiter="↦",
+        )
+
+
+@mixin(VirtualFunction)
+class _VirtualFunction:
+    def __hrepr__(self, H, hrepr):
+        return hrepr.stdrepr_object(
+            'VirtualFunction',
+            (('args', self.args),
+             ('output', self.output)),
             delimiter="↦",
         )

--- a/debug/inject.py
+++ b/debug/inject.py
@@ -6,6 +6,7 @@ from buche import buche
 
 # Load custom hrepr methods for Graph etc.
 from . import gprint  # noqa
+from .logword import ibuche, logword, afterword, breakword
 
 
 def bucheg(graph, **kwargs):
@@ -14,17 +15,11 @@ def bucheg(graph, **kwargs):
     def ttip(node):
         if isinstance(node, ANFNode):
             return node.abstract
-    buche(graph, node_tooltip=ttip, function_in_node=True,
-          graph_width='95vw', graph_height='95vh',
-          **kwargs)
 
-
-_log = []
-
-
-def ibuche(*args, **kwargs):
-    _log.append(args)
-    buche(*args, interactive=True, **kwargs)
+    kw = dict(node_tooltip=ttip, function_in_node=True,
+              graph_width='95vw', graph_height='95vh')
+    kw.update(kwargs)
+    buche(graph, **kw)
 
 
 suite = {
@@ -32,6 +27,9 @@ suite = {
     'bucheg': bucheg,
     'ibuche': ibuche,
     'Subgraph': gprint.Subgraph,
+    'logword': logword,
+    'afterword': afterword,
+    'breakword': breakword,
 }
 
 

--- a/debug/logword.py
+++ b/debug/logword.py
@@ -1,0 +1,131 @@
+
+from buche import buche
+import random
+import hashlib
+import colorsys
+import os
+
+
+_log = []
+
+
+def ibuche(*args, **kwargs):
+    _log.append(args)
+    buche(*args, interactive=True, **kwargs)
+
+
+class WordGroup:
+    """Deterministic word generator.
+
+    Generates a sequence of words from /usr/share/dict/words. The sequence
+    deterministically depends on the name of the group.
+    """
+
+    _words = []
+
+    @classmethod
+    def words(cls):
+        if not cls._words:
+            cls._words[:] = [
+                word.lower()
+                for word in open('/usr/share/dict/words').read().split('\n')
+            ]
+        return cls._words
+
+    def __init__(self, name):
+        self.name = name
+        self.hash = int(hashlib.md5(self.name.encode()).hexdigest(), base=16)
+        self.R = random.Random(self.hash)
+        self.current = None
+
+    def gen(self):
+        words = self.words()
+        w = words[self.R.randint(0, len(words) - 1)]
+        self.current = w
+        return w
+
+    def rgb(self):
+        """Generate an RGB color string for this group."""
+        # We generate the color in the YIQ space first because the Y component,
+        # corresponding to brightness, is fairly accurate, so we can easily
+        # restrict it to a range that looks decent on a white background, and
+        # then convert to RGB with the standard colorsys package. The IQ
+        # components control hue and have bizarre valid ranges.
+        h = self.hash
+        # 0.3 <= Y <= 0.6
+        y = 0.3 + ((h & 0xFF) / 0xFF) * 0.4
+        h >>= 16
+        i = (((h & 0xFF) - 0x80) / 0x80) * 0.5957
+        h >>= 16
+        q = (((h & 0xFF) - 0x80) / 0x80) * 0.5226
+        r, g, b = colorsys.yiq_to_rgb(y, i, q)
+        r = int(r * 255)
+        g = int(g * 255)
+        b = int(b * 255)
+        return f'rgb({r}, {g}, {b})'
+
+
+class Logword:
+    """Tool to track progress through a program on stdout."""
+
+    _groups = {}
+
+    def __init__(self,
+                 watch=None,
+                 gen=True,
+                 nowatch_log=False,
+                 print_word=True,
+                 group='main',
+                 data=[]):
+        self.data = data if isinstance(data, (list, tuple)) else [data]
+        if group not in Logword._groups:
+            Logword._groups[group] = WordGroup(group)
+        self.group = Logword._groups[group]
+        self.watch = watch
+        self.word = self.group.gen() if gen else self.group.current
+        self.match = self.watch == self.word
+        self.active = self.match or (nowatch_log and self.watch is None)
+        if print_word:
+            self.log(self, *self.data, force=self.watch is None)
+
+    def breakpoint(self):
+        if self.active:
+            breakpoint()
+
+    def log(self, *objs, force=False):
+        if force or self.active:
+            if os.environ.get('BUCHE'):
+                ibuche(*objs)
+            else:
+                print(*objs)
+
+    def __bool__(self):
+        return self.active
+
+    def __str__(self):
+        return f'⏎ {self.group.name}:{self.word}'
+
+    def __hrepr__(self, H, hrepr):
+        return H.div(f'⏎ {self.group.name}:{self.word}',
+                     style=f'color:{self.group.rgb()};font-weight:bold;')
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, tb):
+        pass
+
+
+def logword(*data, **kw):
+    """Prints out a word along with the given data."""
+    return Logword(data=data, **kw)
+
+
+def afterword(word, **kw):
+    """True after logword prints out the given word."""
+    return Logword(watch=word, gen=False, print_word=False, **kw)
+
+
+def breakword(word, **kw):
+    """Activate a breakpoint after logword prints out the given word."""
+    afterword(word, **kw).breakpoint()

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -141,7 +141,7 @@ class InferenceEngine:
             return await self.infer_apply(ref)
 
         else:
-            raise AssertionError(f'Missing information for {ref}', ref.node)
+            raise AssertionError(f'Missing information for {ref.node}', ref)
 
     def get_inferred(self, ref):
         """Get a Future for the value associated to the Reference.

--- a/myia/ir/manager.py
+++ b/myia/ir/manager.py
@@ -381,7 +381,7 @@ class ParentStatistic(NestingStatisticGraphWise):
             self[g], = deps
         else:
             # The way code is structured, this should never happen
-            raise AssertionError('Too many parents')
+            raise AssertionError(f'Too many parents for {g}')
         return self.get(g)
 
 

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -667,7 +667,7 @@ def resolve_globals(optimizer, node, equiv):
 ############
 
 
-def make_inliner(inline_criterion, check_recursive):
+def make_inliner(inline_criterion, check_recursive, name):
     """Create an inliner.
 
     Args:
@@ -675,6 +675,7 @@ def make_inliner(inline_criterion, check_recursive):
             returns whether the graph should be inlined or not.
         check_recursive: Check whether a function is possibly recursive
             before inlining it. If it is, don't inline.
+        name: The name of the optimization.
     """
     @pattern_replacer(G, Xs, interest=Graph)
     def inline(optimizer, node, equiv):
@@ -695,6 +696,7 @@ def make_inliner(inline_criterion, check_recursive):
         clone = GraphCloner(inline=(g, node.graph, args), total=False)
         return clone[g.output]
 
+    inline.name = name
     return inline
 
 
@@ -727,19 +729,25 @@ def caller_is_marked(g, node, args):
 
 
 inline_trivial = make_inliner(inline_criterion=is_trivial_graph,
-                              check_recursive=False)
+                              check_recursive=False,
+                              name='inline_trivial')
 
 inline_unique_uses = make_inliner(inline_criterion=is_unique_use,
-                                  check_recursive=True)
+                                  check_recursive=True,
+                                  name='inline_unique_uses')
 
 inline_core = make_inliner(inline_criterion=is_core,
-                           check_recursive=False)
+                           check_recursive=False,
+                           name='inline_core')
 
 inline_inside_marked_caller = \
     make_inliner(inline_criterion=caller_is_marked,
-                 check_recursive=False)
+                 check_recursive=False,
+                 name='inline_inside_marked_caller')
 
-inline = make_inliner(inline_criterion=None, check_recursive=True)
+inline = make_inliner(inline_criterion=None,
+                      check_recursive=True,
+                      name='inline')
 
 
 @pattern_replacer('just', G, interest=None)

--- a/tests/opt/test_lib.py
+++ b/tests/opt/test_lib.py
@@ -770,7 +770,8 @@ def test_inline_criterion():
 
     inline_binary = lib.make_inliner(
         lambda node, g, args: len(args) == 2,
-        check_recursive=False
+        check_recursive=False,
+        name='inline_binary'
     )
 
     def bin(x, y):


### PR DESCRIPTION
* Add a debugging tool in `debug.logword` which lets us print a deterministic sequence of words and then add behavior or a breakpoint after a specific word gets printed out. It is meant to be used a bit like a conditional breakpoint, in cases where it's too much trouble to write out the condition.
* Up to now, all the inlining optimizations were named 'inline', if you printed them out, which is not very useful. Now they all have appropriate names.
* A few assertion errors were tweaked to be a bit more useful for when they inevitably crop up.
