### PR TITLE
Support properties

### DIFF
--- a/myia/utils/misc.py
+++ b/myia/utils/misc.py
@@ -319,7 +319,7 @@ def dataclass_methods(dc):
     """Returns a dataclass's method dictionary."""
     return {name: getattr(dc, name)
             for name in dir(dc)
-            if isinstance(getattr(dc, name), (FunctionType,))}
+            if isinstance(getattr(dc, name), (FunctionType, property))}
 
 
 class ErrorPool:

--- a/tests/common.py
+++ b/tests/common.py
@@ -200,6 +200,10 @@ class Point(ArithmeticData):
     def abs(self):
         return (self.x ** 2 + self.y ** 2) ** 0.5
 
+    @property
+    def absprop(self):
+        return self.abs()
+
 
 @dataclass(frozen=True)
 class Point3D(ArithmeticData):

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1602,6 +1602,14 @@ def test_dataclass_method(pt):
     return pt.abs()
 
 
+@infer(
+    (Point(i64, i64), i64),
+    (Point(f64, f64), f64),
+)
+def test_dataclass_property(pt):
+    return pt.absprop
+
+
 @infer_std((Point(i64, i64), Point(i64, i64), Point(i64, i64)))
 def test_arithmetic_data_add(pt1, pt2):
     return pt1 + pt2


### PR DESCRIPTION
Add support for the `@property` decorator on methods in classes understood by Myia.
