### PR TITLE
Tuple slicing and concatenation

### DIFF
--- a/myia/abstract/prim.py
+++ b/myia/abstract/prim.py
@@ -8,7 +8,7 @@ from operator import getitem
 
 from .. import dtype
 from ..abstract import typecheck
-from ..ir import Graph, GraphCloner, CloneRemapper, new_graph
+from ..ir import Graph, GraphCloner, CloneRemapper, new_graph, MetaGraph
 from ..dtype import Number, Bool, ExceptionType
 from ..prim import ops as P, Primitive, py_implementations as py
 from ..utils import Namespace, SymbolicKeyInstance
@@ -34,6 +34,7 @@ from .data import (
     PrimitiveFunction,
     Possibilities,
     GraphFunction,
+    MetaGraphFunction,
     DummyFunction,
     VALUE, TYPE, SHAPE,
     MyiaTypeError, InferenceError, MyiaShapeError, check_nargs,
@@ -245,7 +246,8 @@ class MyiaAttributeError(InferenceError):
 
 
 def _prim_or_graph(afn):
-    # Check that afn represents a single Primitive/Graph and return it.
+    # Check that afn represents a single Primitive/Graph/MetaGraph
+    # and return it.
     assert isinstance(afn, AbstractFunction)
     fn = afn.get_unique()
     if isinstance(fn, PrimitiveFunction):
@@ -253,7 +255,9 @@ def _prim_or_graph(afn):
     if isinstance(fn, GraphFunction):
         assert fn.context == Context.empty()
         fn = fn.graph
-    assert isinstance(fn, (Primitive, Graph))
+    if isinstance(fn, MetaGraphFunction):
+        fn = fn.metagraph
+    assert isinstance(fn, (Primitive, Graph, MetaGraph))
     return fn
 
 

--- a/myia/composite.py
+++ b/myia/composite.py
@@ -9,6 +9,7 @@ from .abstract import AbstractArray, SHAPE, ANYTHING, MyiaShapeError, \
     AbstractFunction, GraphFunction, AbstractList, AbstractTuple, \
     AbstractClassBase, build_value, AbstractError, TYPE, AbstractScalar, \
     AbstractUnion, AbstractTaggedUnion
+from .abstract.data import check_nargs
 from .debug.label import short_labeler
 from .dtype import Array, Number, Bool, \
     EnvType, u8, u16, i8, i16, f32, f64, Nil
@@ -23,7 +24,7 @@ from .prim.py_implementations import \
     scalar_log, scalar_sin, scalar_cos, scalar_tan, scalar_div, \
     scalar_to_array, env_add, scalar_tanh, py_registry, array_reduce, \
     tuple_getitem
-from .utils import newenv
+from .utils import newenv, Slice
 
 
 def core(fn=None, **flags):

--- a/myia/composite.py
+++ b/myia/composite.py
@@ -1,6 +1,7 @@
 """Implementations of primitives as graphs."""
 
 
+import operator
 from dataclasses import dataclass
 from functools import reduce
 
@@ -20,7 +21,8 @@ from .prim.py_implementations import \
     array_map, bool_not, bool_eq, hastype, distribute, shape, \
     broadcast_shape, typeof, scalar_cast, scalar_add, scalar_exp, \
     scalar_log, scalar_sin, scalar_cos, scalar_tan, scalar_div, \
-    scalar_to_array, env_add, scalar_tanh, py_registry, array_reduce
+    scalar_to_array, env_add, scalar_tanh, py_registry, array_reduce, \
+    tuple_getitem
 from .utils import newenv
 
 
@@ -381,7 +383,7 @@ def array_iter(xs):
 @core
 def tuple_next(xs):
     """Next tuple."""
-    return xs[0], tail(xs)
+    return xs[0], xs[1:]
 
 
 @core
@@ -390,32 +392,69 @@ def tuple_hasnext(xs):
     return len(xs) > 0
 
 
-class Tail(MetaGraph):
-    """Implementation of tail."""
+class TupleReorganizer(MetaGraph):
+    """Parametrizable MetaGraph to combine or extract tuples."""
+
+    def __init__(self, name, gen):
+        """Initialize a TupleReorganizer."""
+        super().__init__(name)
+        self.gen = gen
+
+    def map_tuples(self, g, params, tups):
+        """Map each element of each tuple to a getitem on the parameter."""
+        rval = []
+        for tup, param in zip(tups, params):
+            if not isinstance(tup, AbstractTuple):
+                raise MyiaTypeError(f'Expected AbstractTuple, not {tup}')
+            rval.append([
+                g.apply(P.tuple_getitem, param, i)
+                for i, elem in enumerate(tup.elements)
+            ])
+        return rval
 
     def generate_graph(self, args):
-        """Generate tail specialized for the given Tuple type.
-
-        tail(x) generates make_tuple(x[1], x[2], ...)
-        """
-        if len(args) != 1:
-            raise MyiaTypeError('tail takes one argument')
-        a, = args
-        if not isinstance(a, AbstractTuple):
-            raise MyiaTypeError('tail requires a Tuple')
-        if len(a.elements) == 0:
-            raise MyiaTypeError('tail requires a non-empty Tuple')
+        """Generate the graph."""
         g = Graph()
-        g.set_flags('core', 'reference')
-        tup = g.add_parameter()
-        tup.debug.name = "tup"
-        elems = [g.apply(P.tuple_getitem, tup, i)
-                 for i in range(1, len(a.elements))]
-        g.output = g.apply(P.make_tuple, *elems)
+        for arg in args:
+            g.add_parameter()
+        g.output = self.gen(self, g, args)
         return g
 
 
-tail = Tail('tail')
+def tuple_reorganizer(fn):
+    """Shortcut to create a new TupleReorganizer from a function."""
+    return TupleReorganizer(name=fn.__name__, gen=fn)
+
+
+@tuple_reorganizer
+def tuple_concat(self, g, args):
+    """Metagraph for tuple concatenation."""
+    tups = self.map_tuples(g, g.parameters, args)
+    return g.apply(P.make_tuple, *reduce(operator.add, tups))
+
+
+@tuple_reorganizer
+def tuple_getslice(self, g, args):
+    """Metagraph for getting a slice from a tuple."""
+    check_nargs('tail', 4, args)
+    tuparg, start, stop, step = args
+    try:
+        start = build_value(start)
+        stop = build_value(stop)
+        step = build_value(step)
+    except ValueError:
+        raise MyiaTypeError('Slice start, stop and step must be static')
+    tup, = self.map_tuples(g, g.parameters[:1], [tuparg])
+    return g.apply(P.make_tuple, *tup[start:stop:step])
+
+
+@core
+def tuple_get(t, item):
+    """Implementation of `tuple.__getitem__`."""
+    if hastype(item, Slice):
+        return tuple_getslice(t, item.start, item.stop, item.step)
+    else:
+        return tuple_getitem(t, item)
 
 
 #################

--- a/myia/operations.py
+++ b/myia/operations.py
@@ -58,3 +58,8 @@ def hasnext(it):  # pragma: no cover
 def to_array(x, t):  # pragma: no cover
     """Myia to_array function."""
     raise RuntimeError('This operation is not meant to be called directly.')
+
+
+def slice(start, stop, step):  # pragma: no cover
+    """Function application."""
+    raise RuntimeError('This operation is not meant to be called directly.')

--- a/myia/parser.py
+++ b/myia/parser.py
@@ -471,6 +471,23 @@ class Parser:
         """Process subscript indexes."""
         return self.process_node(block, node.value, used=False)
 
+    def process_Slice(self, block: 'Block', node: ast.Slice) -> ANFNode:
+        """Process subscript slices."""
+        op = block.operation('slice')
+        if node.lower is None:
+            lower = Constant(None)
+        else:
+            lower = self.process_node(block, node.lower)
+        if node.upper is None:
+            upper = Constant(None)
+        else:
+            upper = self.process_node(block, node.upper)
+        if node.step is None:
+            step = Constant(None)
+        else:
+            step = self.process_node(block, node.step)
+        return block.graph.apply(op, lower, upper, step)
+
     def process_Attribute(self, block: 'Block',
                           node: ast.Attribute) -> ANFNode:
         """Process attributes: `x.y`."""

--- a/myia/pipeline/resources.py
+++ b/myia/pipeline/resources.py
@@ -222,7 +222,8 @@ standard_method_map = TypeMap({
     },
     abstract.AbstractTuple: {
         '__len__': P.tuple_len,
-        '__getitem__': P.tuple_getitem,
+        '__add__': C.tuple_concat,
+        '__getitem__': C.tuple_get,
         '__setitem__': P.tuple_setitem,
         '__myia_iter__': P.identity,
         '__myia_next__': C.tuple_next,

--- a/myia/pipeline/resources.py
+++ b/myia/pipeline/resources.py
@@ -9,7 +9,7 @@ from ..monomorphize import monomorphize
 from ..abstract import InferenceEngine
 from ..ir import Graph, clone
 from ..prim import ops as P
-from ..utils import overload, TypeMap
+from ..utils import overload, TypeMap, Slice
 
 from .pipeline import PipelineResource
 
@@ -56,6 +56,11 @@ scalar_object_map = {
     operations.to_array: C.to_array,
     operations.switch: P.switch,
     operations.user_switch: P.user_switch,
+<<<<<<< HEAD
+=======
+    operations.apply: P.apply,
+    operations.slice: Slice,
+>>>>>>> 10bb2037... Add Slice and parser support for slice syntax
     math.floor: P.scalar_floor,
     math.trunc: P.scalar_trunc,
     math.exp: P.scalar_exp,
@@ -110,6 +115,7 @@ standard_object_map = {
     operations.to_array: C.to_array,
     operations.switch: P.switch,
     operations.user_switch: P.user_switch,
+    operations.slice: Slice,
     math.floor: P.scalar_floor,
     math.trunc: P.scalar_trunc,
     math.exp: P.scalar_exp,

--- a/myia/pipeline/resources.py
+++ b/myia/pipeline/resources.py
@@ -56,11 +56,7 @@ scalar_object_map = {
     operations.to_array: C.to_array,
     operations.switch: P.switch,
     operations.user_switch: P.user_switch,
-<<<<<<< HEAD
-=======
-    operations.apply: P.apply,
     operations.slice: Slice,
->>>>>>> 10bb2037... Add Slice and parser support for slice syntax
     math.floor: P.scalar_floor,
     math.trunc: P.scalar_trunc,
     math.exp: P.scalar_exp,

--- a/myia/prim/py_implementations.py
+++ b/myia/prim/py_implementations.py
@@ -241,7 +241,8 @@ def typeof(x):
 @register(primops.hastype)
 def hastype(x, t):
     """Implement `hastype`."""
-    from ..abstract import type_to_abstract, TYPE, AbstractScalar
+    from ..abstract import type_to_abstract, TYPE, AbstractScalar, \
+        AbstractClassBase, ANYTHING
     tt = type_to_abstract(t)
     if isinstance(tt, AbstractScalar):
         try:
@@ -249,6 +250,9 @@ def hastype(x, t):
             return issubclass(typ, tt.values[TYPE])
         except KeyError:
             return False
+    elif (isinstance(tt, AbstractClassBase)
+          and all(v is ANYTHING for k, v in tt.attributes.items())):
+        return isinstance(x, tt.tag)
     else:
         raise NotImplementedError(
             'The Python implementation of hastype only support simple types.'

--- a/myia/utils/__init__.py
+++ b/myia/utils/__init__.py
@@ -18,7 +18,7 @@ from .merge import (  # noqa
 from .misc import (  # noqa
     ADT, Named, MISSING, UNKNOWN, Registry, repr_, list_str, keyword_decorator,
     Event, Events, NS, Namespace, ModuleNamespace, ClosureNamespace, eprint,
-    is_dataclass_type, dataclass_methods, ErrorPool, TaggedValue
+    is_dataclass_type, dataclass_methods, ErrorPool, TaggedValue, Slice
 )
 
 from .overload import (  # noqa

--- a/myia/utils/misc.py
+++ b/myia/utils/misc.py
@@ -19,6 +19,15 @@ class ADT:
     """Base class for an algebraic data type."""
 
 
+@dataclass  # pragma: no cover
+class Slice:
+    """Myia version of a slice."""
+
+    start: object
+    stop: object
+    step: object
+
+
 class TaggedValue:
     """Represents a tagged value for a TaggedUnion."""
 

--- a/myia/utils/misc.py
+++ b/myia/utils/misc.py
@@ -1,5 +1,6 @@
 """Miscellaneous utilities."""
 
+from dataclasses import dataclass
 import builtins
 import functools
 import sys

--- a/tests/prim/test_py_implementations.py
+++ b/tests/prim/test_py_implementations.py
@@ -12,7 +12,7 @@ from myia.prim.py_implementations import setattr as myia_setattr, \
     switch, scalar_to_array, broadcast_shape, scalar_cast, list_reduce, \
     list_map, env_getitem, env_setitem, env_add, embed, \
     array_to_scalar, transpose, return_, make_record, list_getitem, \
-    array_getitem, array_setitem, bool_eq, dict_getitem
+    array_getitem, array_setitem, bool_eq, dict_getitem, tuple_getitem
 from myia.utils import newenv
 
 from ..test_lang import parse_compare
@@ -146,7 +146,7 @@ def test_prim_tuple(x, y):
 
 @parse_compare(((1, 2, 3), 0), ((4, -6, 7), 2))
 def test_prim_tuple_getitem(data, item):
-    return data[item]
+    return tuple_getitem(data, item)
 
 
 @parse_compare(([1, 2, 3], 0), ([4, -6, 7], 2))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,7 +16,7 @@ from myia.abstract import ArrayWrapper
 from myia.compile import load_backend, LoadingError
 
 from .common import Point, Point3D, i64, f64, to_abstract_test, ai64_of, \
-    ai32_of, af64_of, MA, D
+    ai32_of, af64_of, MA, D, Thing
 
 
 def test_myia():
@@ -36,7 +36,7 @@ def test_myia():
     with pytest.raises(InferenceError):
         f(10, 20, 30)
     with pytest.raises(InferenceError):
-        f((10, 20), (30, 40))
+        f(Thing(10), Thing(20))
 
 
 def test_myia_specialize_values():

--- a/tests/test_monomorphize.py
+++ b/tests/test_monomorphize.py
@@ -580,3 +580,8 @@ def test_reducetree(t):
 )
 def test_hypermap_tree(t):
     return hyper_map(scalar_add, t, t)
+
+
+@specialize(((int1, int2), (fp1, fp2)),)
+def test_tuple_surgery(xs, ys):
+    return xs[::-1]


### PR DESCRIPTION
* Slicing syntax `obj[start:stop:step]`
* Support for tuple slicing
* `tuple_concat` operation, mapped to `tuple.__add__`
* Removed `tail(tup)`, which is now redundant with `tup[1:]`
