### PR TITLE
conv2d primitive support from backends; support for ‘torch.nn.functional.conv2d’ op of pytorch frontend

### DIFF
--- a/myia/compile/backends/pytorch_conv_grad.py
+++ b/myia/compile/backends/pytorch_conv_grad.py
@@ -1,0 +1,323 @@
+"""Conv2d grads from the link below.
+
+https://github.com/pytorch/pytorch/blob/master/torch/nn/grad.py
+"""
+import torch
+
+
+def _grad_input_padding(grad_output, input_size, stride, padding, kernel_size,
+                        dilation):
+    input_size = list(input_size)
+    k = grad_output.dim() - 2
+
+    if len(input_size) == k + 2:
+        input_size = input_size[-k:]
+    if len(input_size) != k:
+        raise ValueError("input_size must have {} elements (got {})"
+                         .format(k + 2, len(input_size)))
+
+    def dim_size(d):
+        return ((grad_output.size(d + 2) - 1) * stride[d] - 2 * padding[d] +
+                (kernel_size[d] - 1) * dilation[d] + 1)
+
+    min_sizes = [dim_size(d) for d in range(k)]
+    max_sizes = [min_sizes[d] + stride[d] - 1 for d in range(k)]
+    for size, min_size, max_size in zip(input_size, min_sizes, max_sizes):
+        if size < min_size or size > max_size:
+            raise ValueError(
+                ("requested an input grad size of {}, but valid sizes range "
+                 "from {} to {} (for a grad_output of {})").format(
+                     input_size, min_sizes, max_sizes,
+                     grad_output.size()[2:]))
+
+    return tuple(input_size[d] - min_sizes[d] for d in range(k))
+
+
+# TODO: add conv1d
+'''
+def conv1d_input(input_size, weight, grad_output, stride, padding, dilation,
+                 groups):
+    r"""
+    Computes gradient of conv1d with respect to input of convolution.
+
+    This is same as the 1D transposed convolution operator under the hood but
+    requires shape of the gradient w.r.t. input to be specified explicitly.
+
+    Args:
+        input_size : Shape of the input gradient tensor
+        weight: weight tensor (out_channels x in_channels/groups x kW)
+        grad_output : output gradient tensor (minibatch x out_channels x oW)
+
+    Examples:
+        >>> input = torch.randn(1,1,3, requires_grad=True)
+        >>> weight = torch.randn(1,1,1, requires_grad=True)
+        >>> output = F.conv1d(input, weight)
+        >>> grad_output = torch.randn(output.shape)
+        >>> grad_input = torch.autograd.grad(output, input, grad_output)
+        >>> F.grad.conv1d_input(input.shape, weight, grad_output)
+
+    """
+    kernel_size = [weight.shape[2]]
+
+    if input_size is None:
+        raise ValueError("grad.conv1d_input requires specifying an input_size")
+
+    grad_input_padding = _grad_input_padding(grad_output, input_size, stride,
+                                             padding, kernel_size, dilation)
+
+    return torch.conv_transpose1d(
+        grad_output, weight, None, stride, padding, grad_input_padding, groups,
+        dilation)
+
+
+def conv1d_weight(input, weight_size, grad_output, stride, padding, dilation,
+                  groups):
+    r"""
+    Computes gradient of conv1d with respect to weight of the convolution.
+
+    Args:
+        input: input tensor of shape (minibatch x in_channels x iW)
+        weight_size : Shape of the weight gradient tensor
+        grad_output : output gradient tensor (minibatch x out_channels x oW)
+        stride (int or tuple, optional): Stride of the convolution. Default: 1
+        padding (int or tuple, optional): Zero-padding added to both sides of
+                                          the input. Default: 0
+        dilation (int or tuple, optional): Spacing between kernel elements.
+                                           Default: 1
+        groups (int, optional): Number of blocked connections from input
+                                channels to output channels. Default: 1
+
+    Examples::
+        >>> input = torch.randn(1,1,3, requires_grad=True)
+        >>> weight = torch.randn(1,1,1, requires_grad=True)
+        >>> output = F.conv1d(input, weight)
+        >>> grad_output = torch.randn(output.shape)
+        >>> grad_weight = torch.autograd.grad(output, filter, grad_output)
+        >>> F.grad.conv1d_weight(input, weight.shape, grad_output)
+
+    """
+    in_channels = input.shape[1]
+    out_channels = grad_output.shape[1]
+    min_batch = input.shape[0]
+
+    grad_output = grad_output.contiguous().repeat(1, in_channels // groups, 1)
+    grad_output = grad_output.contiguous().view(
+        grad_output.shape[0] * grad_output.shape[1], 1, grad_output.shape[2])
+
+    input = input.contiguous().view(1, input.shape[0] * input.shape[1],
+                                    input.shape[2])
+
+    grad_weight = torch.conv1d(input, grad_output, None, dilation, padding,
+                               stride, in_channels * min_batch)
+
+    grad_weight = grad_weight.contiguous().view(
+        min_batch, grad_weight.shape[1] // min_batch, grad_weight.shape[2])
+
+    return grad_weight.sum(dim=0).view(
+        in_channels // groups, out_channels, grad_weight.shape[2]).transpose(
+            0, 1).narrow(2, 0, weight_size[2])
+#'''
+
+
+def conv2d_input(input_size, weight, grad_output, stride, padding, dilation,
+                 groups):
+    r"""
+    Computes gradient of conv2d with respect to input of convolution.
+
+    This is same as the 2D transposed convolution operator under the hood but
+    requires shape of the gradient w.r.t. input to be specified explicitly.
+
+    Args:
+        input_size : Shape of the input gradient tensor
+        weight: weight tensor (out_channels x in_channels/groups x kH x kW)
+        grad_output : output gradient tensor
+                      (minibatch x out_channels x oH x oW)
+        stride (int or tuple, optional): Stride of the convolution. Default: 1
+        padding (int or tuple, optional): Zero-padding added to both sides of
+                                          the input. Default: 0
+        dilation (int or tuple, optional): Spacing between kernel elements.
+                                           Default: 1
+        groups (int, optional): Number of blocked connections from input
+                                channels to output channels. Default: 1
+
+    Examples:
+        >>> input = torch.randn(1,1,3,3, requires_grad=True)
+        >>> weight = torch.randn(1,1,1,2, requires_grad=True)
+        >>> output = F.conv2d(input, weight)
+        >>> grad_output = torch.randn(output.shape)
+        >>> grad_input = torch.autograd.grad(output, input, grad_output)
+        >>> F.grad.conv2d_input(input.shape, weight, grad_output)
+
+    """
+    kernel_size = (weight.shape[2], weight.shape[3])
+
+    if input_size is None:
+        raise ValueError("grad.conv2d_input requires specifying an input_size")
+
+    grad_input_padding = _grad_input_padding(grad_output, input_size, stride,
+                                             padding, kernel_size, dilation)
+
+    return torch.conv_transpose2d(
+        grad_output, weight, None, stride, padding, grad_input_padding, groups,
+        dilation)
+
+
+def conv2d_weight(input, weight_size, grad_output, stride, padding, dilation,
+                  groups):
+    r"""
+    Computes gradient of conv2d with respect to the weight of the convolution.
+
+    Args:
+        input: input tensor of shape (minibatch x in_channels x iH x iW)
+        weight_size : Shape of the weight gradient tensor
+        grad_output : output gradient tensor
+                      (minibatch x out_channels x oH x oW)
+        stride (int or tuple, optional): Stride of the convolution. Default: 1
+        padding (int or tuple, optional): Zero-padding added to both sides of
+                                          the input. Default: 0
+        dilation (int or tuple, optional): Spacing between kernel elements.
+                                           Default: 1
+        groups (int, optional): Number of blocked connections from input
+                                channels to output channels. Default: 1
+
+    Examples:
+        >>> input = torch.randn(1,1,3,3, requires_grad=True)
+        >>> weight = torch.randn(1,1,1,2, requires_grad=True)
+        >>> output = F.conv2d(input, weight)
+        >>> grad_output = torch.randn(output.shape)
+        >>> grad_weight = torch.autograd.grad(output, filter, grad_output)
+        >>> F.grad.conv2d_weight(input, weight.shape, grad_output)
+
+    """
+    in_channels = input.shape[1]
+    out_channels = grad_output.shape[1]
+    min_batch = input.shape[0]
+
+    grad_output = grad_output.contiguous().repeat(1, in_channels // groups, 1,
+                                                  1)
+    grad_output = grad_output.contiguous().view(
+        grad_output.shape[0] * grad_output.shape[1], 1, grad_output.shape[2],
+        grad_output.shape[3])
+
+    input = input.contiguous().view(1, input.shape[0] * input.shape[1],
+                                    input.shape[2], input.shape[3])
+
+    grad_weight = torch.conv2d(input, grad_output, None, dilation, padding,
+                               stride, in_channels * min_batch)
+
+    grad_weight = grad_weight.contiguous().view(
+        min_batch, grad_weight.shape[1] // min_batch, grad_weight.shape[2],
+        grad_weight.shape[3])
+
+    if groups > 1:
+        return grad_weight.sum(dim=0).view(
+            out_channels, in_channels // groups,
+            grad_weight.shape[2], grad_weight.shape[3]).narrow(
+                2, 0, weight_size[2]).narrow(3, 0, weight_size[3])
+    else:
+        return grad_weight.sum(dim=0).view(
+            in_channels // groups, out_channels, grad_weight.shape[2],
+            grad_weight.shape[3]).transpose(0, 1).narrow(
+                2, 0, weight_size[2]).narrow(3, 0, weight_size[3])
+
+
+# TODO: add conv3d
+'''
+def conv3d_input(input_size, weight, grad_output, stride, padding, dilation,
+                 groups):
+    r"""
+    Computes gradient of conv3d with respect to input of convolution.
+
+    This is same as the 3D transposed convolution operator under the hood but
+    requires shape of the gradient w.r.t. input to be specified explicitly.
+
+    Args:
+        input_size : Shape of the input gradient tensor
+        weight: weights tensor
+                (out_channels x in_channels/groups x kT x kH x kW)
+        grad_output : output gradient tensor
+                      (minibatch x out_channels x oT x oH x oW)
+        stride (int or tuple, optional): Stride of the convolution. Default: 1
+        padding (int or tuple, optional): Zero-padding added to both sides of
+                                          the input. Default: 0
+        dilation (int or tuple, optional): Spacing between kernel elements.
+                                           Default: 1
+        groups (int, optional): Number of blocked connections from input
+                                channels to output channels. Default: 1
+
+    Examples:
+        >>> input = torch.randn(2, 8, 10, 10, 20, requires_grad=True)
+        >>> weight = torch.randn(4, 8, 2, 3, 3, requires_grad=True)
+        >>> output = F.conv3d(input, weight)
+        >>> grad_output = torch.randn(output.shape)
+        >>> grad_input = torch.autograd.grad(output, input, grad_output)
+        >>> F.grad.conv3d_input(input.shape, weight, grad_output)
+
+    """
+    kernel_size = (weight.shape[2], weight.shape[3], weight.shape[4])
+
+    if input_size is None:
+        raise ValueError("grad.conv3d_input requires specifying an input_size")
+
+    grad_input_padding = _grad_input_padding(grad_output, input_size, stride,
+                                             padding, kernel_size, dilation)
+
+    return torch.conv_transpose3d(
+        grad_output, weight, None, stride, padding, grad_input_padding, groups,
+        dilation)
+
+
+def conv3d_weight(input, weight_size, grad_output, stride, padding, dilation,
+                  groups):
+    r"""
+    Computes gradient of conv3d with respect to weight of the convolution.
+
+    Args:
+        input: input tensor of shape
+               (minibatch x in_channels x iT x iH x iW)
+        weight_size : Shape of the weight gradient tensor
+        grad_output : output gradient tensor
+                      (minibatch x out_channels x oT x oH x oW)
+        stride (int or tuple, optional): Stride of the convolution. Default: 1
+        padding (int or tuple, optional): Zero-padding added to both sides of
+                                          the input. Default: 0
+        dilation (int or tuple, optional): Spacing between kernel elements.
+                                           Default: 1
+        groups (int, optional): Number of blocked connections from input
+                                channels to output channels. Default: 1
+
+    Examples:
+        >>> input = torch.randn(2, 8, 10, 10, 20, requires_grad=True)
+        >>> weight = torch.randn(4, 8, 2, 3, 3, requires_grad=True)
+        >>> output = F.conv3d(input, weight)
+        >>> grad_output = torch.randn(output.shape)
+        >>> grad_weight = torch.autograd.grad(output, weight, grad_output)
+        >>> F.grad.conv3d_weight(input, weight.shape, grad_output)
+
+    """
+    in_channels = input.shape[1]
+    out_channels = grad_output.shape[1]
+    min_batch = input.shape[0]
+
+    grad_output = grad_output.repeat(1, in_channels // groups, 1, 1, 1)
+    grad_output = grad_output.contiguous().view(
+        grad_output.shape[0] * grad_output.shape[1], 1, grad_output.shape[2],
+        grad_output.shape[3], grad_output.shape[4])
+
+    input = input.contiguous().view(1, input.shape[0] * input.shape[1],
+                                    input.shape[2], input.shape[3],
+                                    input.shape[4])
+
+    grad_weight = torch.conv3d(input, grad_output, None, dilation, padding,
+                               stride, in_channels * min_batch)
+
+    grad_weight = grad_weight.contiguous().view(
+        min_batch, grad_weight.shape[1] // min_batch, grad_weight.shape[2],
+        grad_weight.shape[3], grad_weight.shape[4])
+
+    return grad_weight.sum(dim=0).view(
+        in_channels // groups, out_channels, grad_weight.shape[2],
+        grad_weight.shape[3], grad_weight.shape[4]).transpose(0, 1).narrow(
+            2, 0, weight_size[2]).narrow(3, 0, weight_size[3]).narrow(
+                4, 0, weight_size[4])
+#'''

--- a/myia/frontends/pytorch.py
+++ b/myia/frontends/pytorch.py
@@ -31,7 +31,16 @@ from .pytorch_abstract_types import (
     AbstractPyTorchTensor,
     PyTorchTensorWrapper,
 )
-from .pytorch_functions import _sum, item, linear, relu, sigmoid, t, tensor_dim
+from .pytorch_functions import (
+    _sum,
+    conv2d,
+    item,
+    linear,
+    relu,
+    sigmoid,
+    t,
+    tensor_dim,
+)
 
 _type_map = {
     torch.int8: Int[8],
@@ -56,15 +65,16 @@ def pytorch_dtype_to_type(dtype):
 standard_object_map.update({
     torch.exp: C.exp,
     torch.log: C.log,
+    torch.mm: P.dot,
     torch.relu: relu,
     torch.reshape: P.reshape,
     torch.sigmoid: sigmoid,
     torch.sum: _sum,
     torch.t: t,
     torch.tanh: C.tanh,
-
-    torch.nn.functional.linear: linear,
     # torch.zeros_like: C.zeros_like,  # currently only works with pt backend
+    torch.nn.functional.linear: linear,
+    torch.nn.functional.conv2d: conv2d,
 })
 
 
@@ -91,13 +101,12 @@ standard_method_map[AbstractPyTorchTensor].update({
     'relu': relu,
     'reshape': P.reshape,
     'sigmoid': sigmoid,
+    'shape': property(P.shape),
     'sum': _sum,
     't': t,
     'tanh': C.tanh,
     'view': P.reshape,  # contiguousness is ignored by us for now?
-
-    # I think 'zeros_like' is hidden method of tensor used by bwd
-    'zeros_like': C.zeros_like,
+    'zeros_like': C.zeros_like,  # hidden method used by bwd (I think)
 })
 
 

--- a/myia/frontends/pytorch_functions.py
+++ b/myia/frontends/pytorch_functions.py
@@ -15,7 +15,7 @@
 #           pytorch original.                                               #
 #############################################################################
 
-from .. import composite as C
+from .. import composite as C, dtype as D
 from ..composite import core
 from ..hypermap import hyper_map
 from ..ir import MultitypeGraph
@@ -27,6 +27,34 @@ from .pytorch_abstract_types import APT
 
 
 # ############# THESE FUNCTIONS SHOULD BE IN ALPHABETICAL ORDER #############
+
+# This is a helper function
+@core
+def _pair(x):
+    if not P.hastype(x, D.TupleT):
+        x = (x, x)
+    return x
+
+
+@core
+def conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1,
+           groups=1):
+    r"""Applies a Conv2d."""
+    # noqa: D202
+    """
+    # This is for later versions of pytorch that support other paddings?
+    if padding_mode != 'zeros':
+        raise Exception("'zeros' is the only padding_mode that is currently
+                        supported.")
+    #"""
+
+    stride = _pair(stride)
+    padding = _pair(padding)
+    dilation = _pair(dilation)
+    ret = P.conv2d(input, weight, stride, padding, dilation, groups)
+    if bias is not None:
+        ret = ret + bias.reshape((1, bias.shape[0], 1, 1))
+    return ret
 
 
 @core

--- a/myia/prim/ops.py
+++ b/myia/prim/ops.py
@@ -106,6 +106,10 @@ reshape = Primitive('reshape')
 transpose = Primitive('transpose')
 dot = Primitive('dot')
 
+conv2d = Primitive('conv2d')
+conv2d_input_grad = Primitive('conv2d_input_grad')
+conv2d_weight_grad = Primitive('conv2d_weight_grad')
+
 
 ##############
 # Statements #

--- a/myia/prim/py_implementations.py
+++ b/myia/prim/py_implementations.py
@@ -470,6 +470,29 @@ def dot(a, b):
     return np.dot(a, b)
 
 
+@register(primops.conv2d)
+def conv2d(input, weight, stride, padding, dilation, groups):
+    """Implement 2d_convolution."""
+    # TODO
+    raise NotImplementedError()
+
+
+@register(primops.conv2d_input_grad)
+def conv2d_input_grad(input_size, weight, grad_output, stride, padding,
+                      dilation, groups):
+    """Implement conv2d_input_grad."""
+    # TODO
+    raise NotImplementedError()
+
+
+@register(primops.conv2d_weight_grad)
+def conv2d_weight_grad(input, weight_size, grad_output, stride, padding,
+                       dilation, groups):
+    """Implement conv2d_weight_grad."""
+    # TODO
+    raise NotImplementedError()
+
+
 @register(primops.return_)
 def return_(x):
     """Implement `return_`."""

--- a/myia/validate.py
+++ b/myia/validate.py
@@ -125,6 +125,9 @@ whitelist = frozenset({
     P.casttag,
     P.tagged,
     P.unsafe_static_cast,
+    P.conv2d,
+    P.conv2d_input_grad,
+    P.conv2d_weight_grad,
 })
 
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -2278,3 +2278,47 @@ def test_is(x, y):
 )
 def test_is_not(x, y):
     return x is not y
+
+
+@infer(
+    (af32_of(1, 3, 4, 5), af32_of(3, 1, 3, 3), Shp(2, 3), Shp(3, 2),
+     Shp(3, 4), u64, af32_of(1, 3, 2, 1)),
+    (af32_of(2, 3, 4, 5), af32_of(3, 1, 3, 3), Shp(2, 3), Shp(3, 2),
+     Shp(3, 4), u64, af32_of(2, 3, 2, 1)),
+    (af32_of(2, 3, 4, 5), af32_of(3, 1, 3, 3), Shp(2, 3, 4), Shp(3, 2),
+     Shp(3, 4), u64, InferenceError),
+    (af32_of(2, 3, 4, 5), af32_of(3, 1, 3, 3), Shp(2, 3), Shp(3, 2, 4),
+     Shp(3, 4), u64, InferenceError),
+    (af32_of(2, 3, 4, 5), af32_of(3, 1, 3, 3), Shp(2, 3), Shp(3, 2),
+     Shp(3, 4, 2), u64, InferenceError),
+)
+def test_conv2d(i, w, s, p, d, g):
+    return P.conv2d(i, w, s, p, d, g)
+
+
+@infer(
+    (Shp(1, 3, 4, 5), af32_of(3, 1, 3, 3), af32_of(1, 3, 2, 1), Shp(2, 3),
+     Shp(3, 2), Shp(3, 4), S(3, u64), af32_of(1, 3, 4, 5)),
+    (Shp(2, 3, 4, 5), af32_of(3, 1, 3, 3), af32_of(2, 3, 2, 1), Shp(2, 3),
+     Shp(3, 2), Shp(3, 4), S(3, u64), af32_of(2, 3, 4, 5)),
+    (Shp(2, 6, 4, 5), af32_of(3, 2, 3, 3), af32_of(2, 3, 2, 1), Shp(2, 3),
+     Shp(3, 2), Shp(3, 4), S(3, u64), af32_of(2, 6, 4, 5)),
+    (Shp(2, 1, 4, 5), af32_of(3, 1, 3, 3), af32_of(2, 3, 2, 1), Shp(2, 3),
+     Shp(3, 2), Shp(3, 4), S(1, u64), af32_of(2, 1, 4, 5)),
+)
+def test_conv2d_input_grad(i_s, w, g_o, s, p, d, g):
+    return P.conv2d_input_grad(i_s, w, g_o, s, p, d, g)
+
+
+@infer(
+    (af32_of(1, 3, 4, 5), Shp(3, 1, 3, 3), af32_of(1, 3, 2, 1), Shp(2, 3),
+     Shp(3, 2), Shp(3, 4), S(3, u64), af32_of(3, 1, 3, 3)),
+    (af32_of(2, 3, 4, 5), Shp(3, 1, 3, 3), af32_of(2, 3, 2, 1), Shp(2, 3),
+     Shp(3, 2), Shp(3, 4), S(3, u64), af32_of(3, 1, 3, 3)),
+    (af32_of(2, 6, 4, 5), Shp(3, 2, 3, 3), af32_of(2, 3, 2, 1), Shp(2, 3),
+     Shp(3, 2), Shp(3, 4), S(3, u64), af32_of(3, 2, 3, 3)),
+    (af32_of(2, 1, 4, 5), Shp(3, 1, 3, 3), af32_of(2, 3, 2, 1), Shp(2, 3),
+     Shp(3, 2), Shp(3, 4), S(1, u64), af32_of(3, 1, 3, 3)),
+)
+def test_conv2d_weight_grad(i, w_s, g_o, s, p, d, g):
+    return P.conv2d_weight_grad(i, w_s, g_o, s, p, d, g)


### PR DESCRIPTION
- this includes full forward and backward for all input variations
- currently only supports PyTorch backend
- `await force_pending(engine.check(typ, type_token(arg), typ))` in line 95 of myia/abstract/prim.py 
- @abergeron will do relay backend support before PR is accepted (nnvm backend won't be needed once Arnaud's Backend reorganization (https://github.com/mila-iqia/myia/pull/238) PR is done)