### PR TITLE
Merge gradients for aliased parameters

### DIFF
--- a/myia/abstract/__init__.py
+++ b/myia/abstract/__init__.py
@@ -1,7 +1,9 @@
 """Abstract data and type/shape inference."""
 
 from .aliasing import (  # noqa
+    find_aliases,
     generate_getters,
+    ndarray_aliasable,
     setter_from_getter,
 )
 from .data import (  # noqa

--- a/myia/abstract/__init__.py
+++ b/myia/abstract/__init__.py
@@ -2,6 +2,7 @@
 
 from .data import (  # noqa
     ABSENT,
+    ALIASID,
     ANYTHING,
     DATA,
     DEAD,

--- a/myia/abstract/__init__.py
+++ b/myia/abstract/__init__.py
@@ -1,5 +1,9 @@
 """Abstract data and type/shape inference."""
 
+from .aliasing import (  # noqa
+    generate_getters,
+    setter_from_getter,
+)
 from .data import (  # noqa
     ABSENT,
     ALIASID,

--- a/myia/abstract/aliasing.py
+++ b/myia/abstract/aliasing.py
@@ -1,8 +1,103 @@
 """Tools for aliasing detection and handling."""
 
-from . import data as ab
+
+from collections import defaultdict
+from dataclasses import is_dataclass
+
+import numpy as np
+
 from ..prim import ops as P
-from ..utils import overload
+from ..utils import ADT, MyiaInputTypeError, dataclass_fields, overload
+from . import data as ab
+
+
+@overload.wrapper(bootstrap=True, initial_state=set)
+def _explore(__call__, self, v, vseq, path):
+    yield v, vseq, path
+    if id(v) in self.state:
+        return
+    self.state.add(id(v))
+    yield from __call__(self, v, vseq, path)
+
+
+@overload  # noqa: F811
+def _explore(self, v: (list, tuple), vseq, path):
+    vseq = (*vseq, v)
+    for i, x in enumerate(v):
+        yield from self(x, vseq, (*path, i))
+
+
+@overload  # noqa: F811
+def _explore(self, v: dict, vseq, path):
+    vseq = (*vseq, v)
+    for k, x in v.items():
+        yield from self(x, vseq, (*path, k))
+
+
+@overload  # noqa: F811
+def _explore(self, v: object, vseq, path):
+    if is_dataclass(v):
+        vseq = (*vseq, v)
+        for k, x in dataclass_fields(v).items():
+            yield from self(x, vseq, (*path, k))
+
+
+def ndarray_aliasable(v, vseq, path):
+    """Aliasing policy whereas all numpy.ndarray are aliasable.
+
+    Arrays inside a list or ADT are not aliasable.
+    """
+    if isinstance(v, np.ndarray):
+        if any(isinstance(x, (list, ADT)) for x in vseq):
+            return 'X'
+        else:
+            return True
+    return False
+
+
+def find_aliases(obj, aliasable=ndarray_aliasable):
+    """Find aliased data in obj.
+
+    Arguments:
+        ndarray_aliasable: A function with signature
+                ((v, vseq, path) -> True/False/"X")
+            Arguments:
+                v: The potentially aliasable value
+                vseq: The sequence of objects containing v
+                path: The sequence of indexes on the path to v
+            Returns:
+                True: v is aliasable
+                False: v is not aliasable
+                "X": v is aliasable, but it is located in a place where the
+                    aliasing data cannot be used
+
+    """
+    if aliasable is None:
+        return {}, {}
+
+    bad = {}
+    paths = defaultdict(list)
+    for v, vseq, path in _explore(obj, (), ()):
+        al = aliasable(v, vseq, path)
+        if al:
+            if al == 'X':
+                bad[id(v)] = True
+            paths[id(v)].append(path)
+
+    i = 1
+    id_to_aid = {}
+    aid_to_paths = {}
+    for idv, path in paths.items():
+        if len(path) > 1:
+            if bad.get(idv, False):
+                raise MyiaInputTypeError(
+                    'There is aliased data in non-aliasable data types'
+                )
+            id_to_aid[idv] = i
+            aid_to_paths[i] = path
+            i += 1
+
+    return id_to_aid, aid_to_paths
 
 
 @overload(bootstrap=True)

--- a/myia/abstract/aliasing.py
+++ b/myia/abstract/aliasing.py
@@ -1,0 +1,49 @@
+"""Tools for aliasing detection and handling."""
+
+from . import data as ab
+from ..prim import ops as P
+from ..utils import overload
+
+
+@overload(bootstrap=True)
+def generate_getters(self, tup: ab.AbstractTuple, get):
+    """Recursively generate sexps for getting elements of a data structure."""
+    yield tup, get
+    for i, elem in enumerate(tup.elements):
+        geti = (P.tuple_getitem, get, i)
+        yield from self(elem, geti)
+
+
+@overload  # noqa: F811
+def generate_getters(self, dat: ab.AbstractClassBase, get):
+    yield dat, get
+    for k, elem in dat.attributes.items():
+        getk = (P.record_getitem, get, k)
+        yield from self(elem, getk)
+
+
+@overload  # noqa: F811
+def generate_getters(self, dat: ab.AbstractDict, get):
+    yield dat, get
+    for k, elem in dat.entries.items():
+        getk = (P.dict_getitem, get, k)
+        yield from self(elem, getk)
+
+
+@overload  # noqa: F811
+def generate_getters(self, obj: object, get):
+    yield obj, get
+
+
+def setter_from_getter(getter, value):
+    """Generate an expression to set a value from the expression to get it."""
+    setters = {
+        P.tuple_getitem: P.tuple_setitem,
+        P.dict_getitem: P.dict_setitem,
+        P.record_getitem: P.record_setitem,
+    }
+    if isinstance(getter, tuple):
+        oper, elem, i = getter
+        return setter_from_getter(elem, (setters[oper], elem, i, value))
+    else:
+        return value

--- a/myia/abstract/data.py
+++ b/myia/abstract/data.py
@@ -707,10 +707,24 @@ class _ShapeTrack(Track):
     """Represents the SHAPE track, for arrays."""
 
 
+class _AliasIdTrack(Track):
+    """Represents the ALIASID track."""
+
+    def merge(self, recurse, v1, v2, forced, bp):
+        """Merge two values."""
+        if v1 is ABSENT or v2 is ABSENT:
+            return ABSENT
+        return recurse(v1, v2, forced, bp)
+
+    def default(self):
+        return ABSENT
+
+
 VALUE = _ValueTrack('VALUE')
 TYPE = _TypeTrack('TYPE')
 SHAPE = _ShapeTrack('SHAPE')
 DATA = _ValueTrack('DATA')
+ALIASID = _AliasIdTrack('ALIASID')
 
 
 ##########################

--- a/myia/abstract/data.py
+++ b/myia/abstract/data.py
@@ -672,6 +672,10 @@ class Track:
     def __lt__(self, other):
         return self.name < other.name
 
+    def merge(self, recurse, v1, v2, forced, bp):
+        """Merge two values."""
+        return recurse(v1, v2, forced, bp)
+
     def clone(self, v, recurse):
         """Clone the value associated to this Track in a TrackDict."""
         return recurse(v)
@@ -682,6 +686,9 @@ class Track:
         By default, this amounts to a straight copy.
         """
         return recurse(v, *args)
+
+    def default(self):
+        raise ValueError(f'There is no default for track {self}')
 
 
 class _ValueTrack(Track):

--- a/myia/abstract/data.py
+++ b/myia/abstract/data.py
@@ -688,7 +688,8 @@ class Track:
         return recurse(v, *args)
 
     def default(self):
-        raise ValueError(f'There is no default for track {self}')
+        """Return the default value for the track."""
+        raise NotImplementedError(f'There is no default for track {self}')
 
 
 class _ValueTrack(Track):
@@ -712,9 +713,8 @@ class _AliasIdTrack(Track):
 
     def merge(self, recurse, v1, v2, forced, bp):
         """Merge two values."""
-        if v1 is ABSENT or v2 is ABSENT:
-            return ABSENT
-        return recurse(v1, v2, forced, bp)
+        # For the time being we don't propagate ALIASID through merge.
+        return ABSENT
 
     def default(self):
         return ABSENT

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -642,8 +642,8 @@ class Inferrer(Partializable):
             outref: A Reference to the output (could be None)
             argrefs: A tuple of References to the arguments
         """
-        args = tuple([await ref.get() for ref in argrefs])
-        args = await self.normalize_args(args)
+        unnorm_args = tuple([await ref.get() for ref in argrefs])
+        args = await self.normalize_args(unnorm_args)
         if args not in self.cache:
             self.cache[args] = await self.infer(engine, *args)
         return self.cache[args]

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -26,6 +26,7 @@ from ..utils import (
     type_error_nargs,
 )
 from .data import (
+    ALIASID,
     ANYTHING,
     DATA,
     SHAPE,
@@ -558,13 +559,16 @@ def to_abstract(self, v: dict, **kwargs):
 
 
 @overload  # noqa: F811
-def to_abstract(self, v: np.ndarray, **kwargs):
+def to_abstract(self, v: np.ndarray, alias_map={}, **kwargs):
+    tracks = {SHAPE: v.shape}
+    if id(v) in alias_map:
+        tracks[ALIASID] = alias_map[id(v)]
     return AbstractArray(
         AbstractScalar({
             VALUE: ANYTHING,
             TYPE: dtype.np_dtype_to_type(str(v.dtype)),
         }),
-        {SHAPE: v.shape}
+        tracks
     )
 
 

--- a/myia/abstract/utils.py
+++ b/myia/abstract/utils.py
@@ -1044,6 +1044,16 @@ def amerge(self, x1: AbstractClassBase, x2, forced, bp):
 
 
 @overload  # noqa: F811
+def amerge(self, x1: AbstractDict, x2, forced, bp):
+    args1 = (x1.entries, x1.values)
+    args2 = (x2.entries, x2.values)
+    merged = self(args1, args2, forced, bp)
+    if forced or merged is args1:
+        return x1
+    return type(x1)(*merged)
+
+
+@overload  # noqa: F811
 def amerge(self, x1: AbstractJTagged, x2, forced, bp):
     args1 = x1.element
     args2 = x2.element

--- a/myia/abstract/utils.py
+++ b/myia/abstract/utils.py
@@ -885,6 +885,8 @@ def amerge(__call__, self, x1, x2, forced=False, bind_pending=True,
     self.state[keypair] = x1 if forced else ABSENT
     rval = helper()
     self.state[keypair] = rval
+    if forced:
+        assert rval is x1
     return rval
 
 
@@ -1091,8 +1093,8 @@ def bind(loop, committed, resolved, pending):
         resolved.append(result)
         if not pending:
             v = amergeall()
-            if rval is not None and not rval.done():
-                rval.set_result(v)
+            if merged is not None and not merged.done():
+                merged.set_result(v)
 
     for p in pending:
         p.add_done_callback(resolve)
@@ -1121,8 +1123,8 @@ def bind(loop, committed, resolved, pending):
             return -1000
 
     if any(is_simple(x) for x in chain(resolved, pending)):
-        # rval = None because we will not make a new Pending
-        rval = None
+        # merged = None because we will not make a new Pending
+        merged = None
 
         if pending:
             p, *rest = pending
@@ -1131,23 +1133,29 @@ def bind(loop, committed, resolved, pending):
                 p.tie(p2)
 
         if resolved:
-            return resolved[0]
+            rval = resolved[0]
         else:
             for p in pending:
                 if is_simple(p):
-                    return p
-            raise AssertionError('unreachable')
+                    rval = p
+                    break
+            else:
+                raise AssertionError('unreachable')
 
     else:
-        rval = loop.create_pending(
+        merged = loop.create_pending(
             resolve=premature_resolve,
             priority=priority,
         )
-        rval.equiv.update(resolved)
+        merged.equiv.update(resolved)
         for p in pending:
-            rval.tie(p)
+            merged.tie(p)
+        rval = merged
 
+    if committed is None:
         return rval
+    else:
+        return committed
 
 
 ###########################

--- a/myia/ir/utils.py
+++ b/myia/ir/utils.py
@@ -201,7 +201,7 @@ def isomorphic(g1, g2, equiv=None):
 ########
 
 
-def sexp_to_node(sexp, graph, multigraph=False):
+def sexp_to_node(sexp, graph, multigraph=False, sub=None):
     """Convert an s-expression (tuple) to a subgraph.
 
     Args:
@@ -212,6 +212,7 @@ def sexp_to_node(sexp, graph, multigraph=False):
             In short, use multigraph=True to get a subgraph where
             each node can be in a different graph. Otherwise, all
             nodes are required to belong to the same graph.
+        sub: Substitutions to make.
 
     Returns:
         An ANFNode equivalent to the given s-expression.
@@ -219,11 +220,13 @@ def sexp_to_node(sexp, graph, multigraph=False):
     """
     if isinstance(sexp, tuple):
         if multigraph and isinstance(graph, Var):
-            return Apply([sexp_to_node(x, Var('G'), True)
+            return Apply([sexp_to_node(x, Var('G'), True, sub)
                           for x in sexp], graph)
         else:
-            return Apply([sexp_to_node(x, graph, multigraph)
+            return Apply([sexp_to_node(x, graph, multigraph, sub)
                           for x in sexp], graph)
+    elif sub and sexp in sub:
+        return sub[sexp]
     elif isinstance(sexp, Var):
         return VarNode(sexp, graph)
     elif isinstance(sexp, ANFNode):

--- a/myia/macros.py
+++ b/myia/macros.py
@@ -25,6 +25,8 @@ from .utils import (
     Cons,
     Empty,
     InferenceError,
+    MyiaAttributeError,
+    MyiaNameError,
     MyiaTypeError,
     Namespace,
     check_nargs,
@@ -67,10 +69,6 @@ async def apply(info):
                 'Can only expand tuple or dict in function application'
             )
     return g.apply(fnref.node, *expanded)
-
-
-class MyiaAttributeError(InferenceError):
-    """Raised when an attribute is not found in a type or module."""
 
 
 async def _resolve_case(resources, data_t, item_v):
@@ -195,10 +193,6 @@ async def getattr_(info):
         except Exception as e:  # pragma: no cover
             raise InferenceError(f'Unexpected error in getter: {e!r}')
         return Constant(raw)
-
-
-class MyiaNameError(InferenceError):
-    """Raised when a name is not found in scope."""
 
 
 @macro

--- a/myia/macros.py
+++ b/myia/macros.py
@@ -492,6 +492,7 @@ class GradOperation(MetaGraph):
                 for elem, getter in generate_getters(arg, ROOT):
                     aid = elem.values.get(ALIASID, None)
                     if aid is not None:
+                        assert aid is not ANYTHING
                         aliases[aid].append((i, getter))
         aliases = tuple(sorted((k, tuple(v)) for k, v in aliases.items()))
 

--- a/myia/macros.py
+++ b/myia/macros.py
@@ -4,10 +4,22 @@ A macro transforms a subgraph into another. It is run during inference, which
 means it has access to type information.
 """
 
+from collections import defaultdict
 from functools import reduce
 
 from . import abstract, operations
-from .abstract import ANYTHING, TYPE, VALUE, macro, type_token, union_simplify
+from .abstract import (
+    ALIASID,
+    ANYTHING,
+    TYPE,
+    VALUE,
+    generate_getters,
+    macro,
+    setter_from_getter,
+    type_token,
+    union_simplify,
+)
+from .composite import gadd
 from .dtype import Array, Bool, Number
 from .info import About, DebugInfo
 from .ir import (
@@ -18,6 +30,7 @@ from .ir import (
     MetaGraph,
     MultitypeGraph,
     Parameter,
+    sexp_to_node,
 )
 from .prim import ops as P
 from .prim.py_implementations import scalar_cast, scalar_to_array, typeof
@@ -28,6 +41,7 @@ from .utils import (
     MyiaAttributeError,
     MyiaNameError,
     MyiaTypeError,
+    Named,
     Namespace,
     check_nargs,
     core,
@@ -439,6 +453,9 @@ def _scalar_to_array_cast_helper(x, model):
     return scalar_to_array(scalar_cast(x, t.element), typeof(model))
 
 
+ROOT = Named('ROOT')
+
+
 class GradOperation(MetaGraph):
     """Implements the grad(f) operation.
 
@@ -452,7 +469,7 @@ class GradOperation(MetaGraph):
                  return_value=False,
                  always_return_tuple=False,
                  dout_parameter=False,
-                 apply_j=True):
+                 sum_aliases=True):
         """Initialize GradOperation."""
         super().__init__('grad')
         self.fn = fn
@@ -460,7 +477,7 @@ class GradOperation(MetaGraph):
         self.return_value = return_value
         self.always_return_tuple = always_return_tuple
         self.dout_parameter = dout_parameter
-        self.apply_j = apply_j
+        self.sum_aliases = sum_aliases
 
     def make_signature(self, args):
         """Make the signature.
@@ -469,6 +486,15 @@ class GradOperation(MetaGraph):
         generated from self.fn and the second a boolean saying whether there is
         a dout argument or not.
         """
+        aliases = defaultdict(list)
+        if self.sum_aliases:
+            for i, arg in enumerate(args):
+                for elem, getter in generate_getters(arg, ROOT):
+                    aid = elem.values.get(ALIASID, None)
+                    if aid is not None:
+                        aliases[aid].append((i, getter))
+        aliases = tuple(sorted((k, tuple(v)) for k, v in aliases.items()))
+
         if (len(args) > 0
                 and isinstance(args[-1], abstract.AbstractKeywordArgument)
                 and args[-1].key == 'dout'):
@@ -487,7 +513,7 @@ class GradOperation(MetaGraph):
             sig = self.fn.make_signature(args)
         else:
             sig = (len(args),)
-        return sig, dout
+        return sig, dout, aliases
 
     def generate_graph(self, sig):
         """Make the graph for the grad.
@@ -500,7 +526,7 @@ class GradOperation(MetaGraph):
         first element will be the return value of the function. The other
         elements will be the gradients.
         """
-        gsig, dout = sig
+        gsig, dout, aliases = sig
         if isinstance(self.fn, (Graph, MetaGraph)):
             g = self.fn.generate_graph(gsig)
             dbg = g.debug
@@ -545,9 +571,7 @@ class GradOperation(MetaGraph):
             df = Graph()
             df.set_flags('core', 'reference')
 
-        jf = g
-        if self.apply_j:
-            jf = df.apply(P.J, jf)
+        jf = df.apply(P.J, g)
 
         params = []
         for orig_p in orig_parameters:
@@ -574,11 +598,24 @@ class GradOperation(MetaGraph):
             direct_return = False
 
         bapp = df.apply(bprop, bprop_arg)
-        elems = []
-        if self.return_value:
-            elems.append(out)
-        for idx in wrt:
-            elems.append(df.apply(P.tuple_getitem, bapp, idx + 1))
+        all_results = [df.apply(P.tuple_getitem, bapp, idx + 1)
+                       for idx in range(nargs)]
+
+        adjusted = {i: all_results[i] for i in range(nargs)}
+        for aid, equivs in aliases:
+            contribs = []
+            for i, entry in equivs:
+                node = sexp_to_node(entry, df, sub={ROOT: all_results[i]})
+                contribs.append(node)
+            combined = reduce(lambda x, y: df.apply(gadd, x, y), contribs)
+
+            for i, entry in equivs:
+                setter = setter_from_getter(entry, combined)
+                node = sexp_to_node(setter, df, sub={ROOT: adjusted[i]})
+                adjusted[i] = node
+
+        elems = [out] if self.return_value else []
+        elems += [adjusted[idx] for idx in wrt]
 
         if len(elems) == 1 and direct_return:
             df.output = elems[0]

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -358,11 +358,15 @@ sub_usub_map = on_array_map(sub_usub)
 #########################
 
 
+def _elim_distribute_condition(equiv):
+    return equiv[X].shape is not None and equiv[X].shape == equiv[C].value
+
+
 # distribute(x, shp) => x when x.shape == shp
 elim_distribute = psub(
     pattern=(P.distribute, X, C),
     replacement=X,
-    condition=lambda equiv: equiv[X].shape == equiv[C].value,
+    condition=_elim_distribute_condition,
     name='elim_distribute'
 )
 

--- a/myia/opt/opt.py
+++ b/myia/opt/opt.py
@@ -87,7 +87,7 @@ class PatternSubstitutionOptimization:
         else:
             return None
 
-    def __str__(self):
+    def __str__(self):  # pragma: no cover
         return f'<PatternSubstitutionOptimization {self.name}>'
 
     __repr__ = __str__

--- a/myia/opt/opt.py
+++ b/myia/opt/opt.py
@@ -87,7 +87,7 @@ class PatternSubstitutionOptimization:
         else:
             return None
 
-    def __str__(self):  # pragma: no cover
+    def __str__(self):
         return f'<PatternSubstitutionOptimization {self.name}>'
 
     __repr__ = __str__

--- a/myia/prim/ops.py
+++ b/myia/prim/ops.py
@@ -75,16 +75,20 @@ casttag = Primitive('casttag')
 
 
 make_tuple = Primitive('make_tuple')
-make_dict = Primitive('make_dict')
-make_record = Primitive('make_record')
 tuple_getitem = Primitive('tuple_getitem')
-dict_getitem = Primitive('dict_getitem')
-array_getitem = Primitive('array_getitem')
 tuple_setitem = Primitive('tuple_setitem')
-array_setitem = Primitive('array_setitem')
+tuple_len = Primitive('tuple_len')
+
+make_dict = Primitive('make_dict')
+dict_getitem = Primitive('dict_getitem')
+dict_setitem = Primitive('dict_setitem')
+
+make_record = Primitive('make_record')
 record_getitem = Primitive('record_getitem')
 record_setitem = Primitive('record_setitem')
-tuple_len = Primitive('tuple_len')
+
+array_getitem = Primitive('array_getitem')
+array_setitem = Primitive('array_setitem')
 array_len = Primitive('array_len')
 
 

--- a/myia/prim/py_implementations.py
+++ b/myia/prim/py_implementations.py
@@ -308,6 +308,12 @@ def tuple_setitem(data, item, value):
                  for i, x in enumerate(data))
 
 
+@py_register(primops.dict_setitem)
+def dict_setitem(data, item, value):
+    """Implement `dict_setitem`."""
+    return {**data, item: value}
+
+
 @register(primops.array_setitem)
 def array_setitem(data, item, value):
     """Implement `list/array_setitem`."""

--- a/myia/utils/__init__.py
+++ b/myia/utils/__init__.py
@@ -3,7 +3,9 @@
 from .env import EnvInstance, SymbolicKeyInstance, newenv, smap  # noqa
 from .errors import (  # noqa
     InferenceError,
+    MyiaAttributeError,
     MyiaInputTypeError,
+    MyiaNameError,
     MyiaShapeError,
     MyiaTypeError,
     TypeMismatchError,

--- a/myia/utils/errors.py
+++ b/myia/utils/errors.py
@@ -36,6 +36,14 @@ class MyiaShapeError(InferenceError):
     """Shape error in a Myia program."""
 
 
+class MyiaAttributeError(InferenceError):
+    """Raised when an attribute is not found in a type or module."""
+
+
+class MyiaNameError(InferenceError):
+    """Raised when a name is not found in scope."""
+
+
 def type_error_nargs(ident, expected, got):
     """Return a MyiaTypeError for number of arguments mismatch."""
     from ..debug.label import label

--- a/tests/prim/test_py_implementations.py
+++ b/tests/prim/test_py_implementations.py
@@ -16,6 +16,7 @@ from myia.prim.py_implementations import (
     bool_eq,
     broadcast_shape,
     dict_getitem,
+    dict_setitem,
     distribute,
     dot,
     embed,
@@ -281,6 +282,13 @@ def test_prim_array_reduce():
 
 def test_prim_dict_getitem():
     assert dict_getitem({'x': 2}, 'x') == 2
+
+
+def test_prim_dict_setitem():
+    d = {'x': 2}
+    d2 = dict_setitem(d, 'x', 3)
+    assert d == {'x': 2}
+    assert d2 == {'x': 3}
 
 
 def test_prim_distribute():

--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -7,6 +7,7 @@ import pytest
 
 from myia import dtype as ty
 from myia.abstract import (
+    ALIASID,
     ANYTHING,
     DEAD,
     TYPE,
@@ -25,6 +26,7 @@ from myia.abstract import (
     PendingFromList,
     Possibilities,
     TaggedPossibilities,
+    TrackDict,
     abstract_clone,
     amerge,
     broaden,
@@ -135,6 +137,16 @@ def test_amerge():
     assert amerge(AbstractError(DEAD),
                   AbstractError(ANYTHING),
                   forced=False) is AbstractError(ANYTHING)
+
+    d1 = {'x': 1}
+    d2 = {'y': 2}
+    with pytest.raises(MyiaTypeError):
+        print(amerge(d1, d2))
+
+    td1 = TrackDict({ALIASID: 1})
+    td2 = TrackDict({})
+    with pytest.raises(MyiaTypeError):
+        print(amerge(td1, td2, forced=True))
 
 
 def test_merge_possibilities():

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -711,6 +711,10 @@ def test_aliasing():
 
 
 def test_aliasing_list():
+    try:
+        import torch
+    except ImportError:
+        pytest.skip('PyTorch not installed')
 
     def g(xs, y):
         res = 0

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -711,10 +711,11 @@ def test_aliasing():
 
 
 def test_aliasing_list():
+    from myia.compile.backends import LoadingError, load_backend
     try:
-        import torch
-    except ImportError:
-        pytest.skip('PyTorch not installed')
+        load_backend('pytorch')
+    except LoadingError:
+        pytest.skip('PyTorch not available')
 
     def g(xs, y):
         res = 0

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 from pytest import mark
 
-from myia.abstract import AbstractJTagged, from_value
+from myia.abstract import AbstractJTagged, from_value, ndarray_aliasable
 from myia.api import myia
 from myia.debug.finite_diff import GradTester, NoTestGrad, clean_args
 from myia.macros import GradOperation, grad
@@ -37,13 +37,14 @@ from myia.prim.py_implementations import (
     scalar_to_array,
     transpose,
 )
-from myia.utils import InferenceError
+from myia.utils import InferenceError, MyiaInputTypeError
 from myia.validate import validate_abstract, whitelist
 
 from .common import (
     AA,
     MA,
     MB,
+    Point3D,
     U,
     countdown,
     f64,
@@ -671,3 +672,102 @@ def test_grad_interface():
 
     with pytest.raises(InferenceError):
         print(gradbad7(x, y, 0))
+
+
+def test_aliasing():
+
+    def _chk(x, y):
+        x1, x2, (x3, x4) = x
+        y1, y2, (y3, y4) = y
+        np.testing.assert_allclose(x1, y1)
+        np.testing.assert_allclose(x2, y2)
+        np.testing.assert_allclose(x3, y3)
+        np.testing.assert_allclose(x4, y4)
+
+    def g(x, y):
+        a, b, (c, d) = x
+        return sum(a + b + c + d + y)
+
+    @myia(alias_tracker=ndarray_aliasable)
+    def f(x, y):
+        return grad(g)(x, y)
+
+    o = np.ones((1, 3))
+
+    a = o * 3
+    b = o * 4
+    c = o * 5
+    d = o * 6
+    e = o * 7
+
+    res1 = f((a, b, (c, d)), e)
+    _chk(res1, (o, o, (o, o)))
+
+    res2 = f((a, a, (a, a)), a)
+    _chk(res2, (5 * o, 5 * o, (5 * o, 5 * o)))
+
+    res3 = f((a, b, (b, a)), a)
+    _chk(res3, (3 * o, 2 * o, (2 * o, 3 * o)))
+
+
+def test_aliasing_list():
+
+    def g(xs, y):
+        res = 0
+        for x in xs:
+            res = res + x
+        return sum(res)
+
+    @myia(backend='pytorch', alias_tracker=ndarray_aliasable)
+    def f(xs, y):
+        return grad(g)(xs, y)
+
+    o = np.ones((1, 3))
+
+    a = o * 3
+    b = o * 4
+    c = o * 5
+    d = o * 6
+    e = o * 7
+
+    res1 = f([a, b, c, d], e)
+    for x in res1:
+        np.testing.assert_allclose(x, o)
+
+    with pytest.raises(MyiaInputTypeError):
+        print(f([a, b, c, a], e))
+
+    with pytest.raises(MyiaInputTypeError):
+        print(f([a, b, c, d], a))
+
+
+def test_aliasing_other():
+
+    def _chk(x, y):
+        np.testing.assert_allclose(x['a'], y['a'])
+        np.testing.assert_allclose(x['b'].x, y['b'].x)
+        np.testing.assert_allclose(x['b'].y, y['b'].y)
+        np.testing.assert_allclose(x['b'].z, y['b'].z)
+
+    def g(x, y):
+        a = x['a']
+        pt = x['b']
+        return sum(a + pt.x + pt.y + pt.z + y)
+
+    @myia(alias_tracker=ndarray_aliasable)
+    def f(xs, y):
+        return grad(g)(xs, y)
+
+    o = np.ones((1, 3))
+
+    a = o * 3
+    b = o * 4
+    c = o * 5
+    d = o * 6
+    e = o * 7
+
+    res1 = f({'a': a, 'b': Point3D(b, c, d)}, e)
+    _chk(res1, {'a': o, 'b': Point3D(o, o, o)})
+
+    res2 = f({'a': a, 'b': Point3D(b, a, d)}, e)
+    _chk(res2, {'a': o * 2, 'b': Point3D(o, o * 2, o)})

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -49,6 +49,7 @@ from myia.prim.py_implementations import (
     bool_or,
     broadcast_shape,
     casttag,
+    dict_setitem,
     distribute,
     dot,
     embed,
@@ -59,6 +60,7 @@ from myia.prim.py_implementations import (
     identity,
     make_record,
     partial as myia_partial,
+    record_setitem,
     reshape,
     scalar_add,
     scalar_cast,
@@ -517,6 +519,13 @@ def test_dict_getitem(d):
        (D(x=i64), 2, InferenceError))
 def test_dict_getitem_nonconst(d, i):
     return d[i]
+
+
+@infer((D(x=i64), f64, D(x=f64)),
+       (D(x=i64, y=f32), f64, D(x=f64, y=f32)),
+       (D(z=i64), f64, InferenceError))
+def test_dict_setitem(d, x):
+    return dict_setitem(d, 'x', x)
 
 
 @infer(
@@ -1916,6 +1925,22 @@ def test_dataclass_wrong_field(pt):
 @infer((Thing(i64), i64))
 def test_dataclass_call(thing):
     return thing()
+
+
+@infer((Thing(i64), f64, Thing(f64)))
+def test_record_setitem(thing, x):
+    return record_setitem(thing, 'contents', x)
+
+
+@infer((Point(i64, i64), i64, Point(i64, i64)),
+       (Point(i64, i64), f64, InferenceError))
+def test_record_setitem_2(pt, x):
+    return record_setitem(pt, 'x', x)
+
+
+@infer((Thing(i64), f64, InferenceError))
+def test_record_setitem_wrong_field(thing, x):
+    return record_setitem(thing, 'shfifty_five', x)
 
 
 hyper_map_notuple = HyperMap(

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -440,6 +440,24 @@ def test_dict2(x, y):
     return {'x': x, 'y': y}
 
 
+@infer((i64, i64, f32, D(x=i64, y=f32)))
+def test_dict_merge(c, x, y):
+    if c == 0:
+        return {'x': 1, 'y': 2}
+    elif c == 1:
+        return {'x': 2, 'y': 4}
+    else:
+        return {'x': x, 'y': y}
+
+
+@infer((B, i64, f32, MyiaTypeError))
+def test_dict_incompatible(c, x, y):
+    if c:
+        return {'x': x, 'y': y}
+    else:
+        return {'x': x, 'yy': y}
+
+
 @infer(
     ((), 0),
     ((1,), 1),


### PR DESCRIPTION
This implements a framework to deal with #239.

The `ALIASID` track can be optionally computed and represents an equivalence class such that if x and y have the same `ALIASID` they must refer to the same object. `grad` takes these into account in order to make sure that df/dx and df/dy are also equal by adding up these contributions.

It is possible to customize the function that determines which data is "aliasable". One is defined, `myia.abstract.aliasing.ndarray_aliasable`, which marks numpy arrays. Data inside lists or ADTs is considered non-aliasable because each element of a list or ADT must be associated to the same AbstractValue and therefore the same `ALIASID`, so there is no way to track aliasing on individual elements.

The PR also adds support for `record_setitem` and `dict_setitem` and makes necessary adjustments to `amerge` and a few other functions.
