### PR TITLE
Improvements to method resolution on abstract types

### DIFF
--- a/myia/abstract/__init__.py
+++ b/myia/abstract/__init__.py
@@ -96,7 +96,6 @@ from .utils import (  # noqa
     sensitivity_transform,
     split_type,
     type_to_abstract,
-    type_token,
     typecheck,
     union_simplify,
 )

--- a/myia/abstract/data.py
+++ b/myia/abstract/data.py
@@ -242,7 +242,7 @@ class AbstractValue(Interned, PossiblyRecursive):
         self.values = TrackDict(values)
 
     def dtype(self):
-        """Return the type of this scalar."""
+        """Return the type of this AbstractValue."""
         t = self.values[TYPE]
         if isinstance(t, Pending) and t.done():
             t = t.result()

--- a/myia/abstract/data.py
+++ b/myia/abstract/data.py
@@ -507,9 +507,8 @@ class AbstractClassBase(AbstractStructure):
     Attributes:
         tag: A pointer to the original Python class
         attributes: Maps each field name to a corresponding AbstractValue.
-        methods: Maps method names to corresponding functions, which will
-            be parsed and converted by the engine when necessary, with the
-            instance as the first argument.
+        constructor: A function to use to build a Python instance.
+            Defaults to the tag.
 
     """
 

--- a/myia/abstract/data.py
+++ b/myia/abstract/data.py
@@ -10,6 +10,7 @@ from typing import List, Tuple
 import prettyprinter as pp
 from prettyprinter.prettyprinter import pretty_python_value
 
+from .. import dtype
 from ..ir import ANFNode, Constant, Graph, MetaGraph
 from ..prim import Primitive
 from ..utils import (
@@ -24,7 +25,6 @@ from ..utils import (
     Named,
     OrderedSet,
     PossiblyRecursive,
-    dataclass_methods,
     keyword_decorator,
 )
 from .loop import Pending
@@ -241,6 +241,13 @@ class AbstractValue(Interned, PossiblyRecursive):
         super().__init__()
         self.values = TrackDict(values)
 
+    def dtype(self):
+        """Return the type of this scalar."""
+        t = self.values[TYPE]
+        if isinstance(t, Pending) and t.done():
+            t = t.result()
+        return t
+
     def __eqkey__(self):
         return Atom(self, tuple(sorted(self.values.items())))
 
@@ -254,13 +261,6 @@ class AbstractAtom(AbstractValue):
 
 class AbstractScalar(AbstractAtom):
     """Represents a scalar (integer, float, bool, etc.)."""
-
-    def dtype(self):
-        """Return the type of this scalar."""
-        t = self.values[TYPE]
-        if isinstance(t, Pending) and t.done():
-            t = t.result()
-        return t
 
     def __pretty__(self, ctx):
         rval = pretty_type(self.values[TYPE])
@@ -413,9 +413,9 @@ class AbstractStructure(AbstractValue):
 class AbstractTuple(AbstractStructure):
     """Represents a tuple of elements."""
 
-    def __init__(self, elements, values=None):
+    def __init__(self, elements, values={}):
         """Initialize an AbstractTuple."""
-        super().__init__(values or {})
+        super().__init__({TYPE: dtype.Tuple, **values})
         if elements is not ANYTHING:
             elements = list(elements)
         self.elements = elements
@@ -479,9 +479,9 @@ class AbstractDict(AbstractStructure):
 
     """
 
-    def __init__(self, entries, values=None):
+    def __init__(self, entries, values={}):
         """Initalize an AbstractDict."""
-        super().__init__(values or {})
+        super().__init__({TYPE: dtype.Dict, **values})
         self.entries = entries
 
     def children(self):
@@ -513,13 +513,12 @@ class AbstractClassBase(AbstractStructure):
 
     """
 
-    def __init__(self, tag, attributes, methods, values={}, *,
+    def __init__(self, tag, attributes, *, values={},
                  constructor=None):
         """Initialize an AbstractClass."""
-        super().__init__(values)
+        super().__init__({TYPE: tag, **values})
         self.tag = tag
         self.attributes = attributes
-        self.methods = methods
         if constructor is None:
             constructor = tag
         self.constructor = constructor
@@ -737,13 +736,12 @@ ALIASID = _AliasIdTrack('ALIASID')
 ##########################
 
 
-empty = AbstractADT(Empty, {}, dataclass_methods(Empty))
+empty = AbstractADT(Empty, {})
 
 
 def listof(t):
     """Return the type of a list of t."""
-    rval = AbstractADT.new(Cons, {'head': t, 'tail': None},
-                           dataclass_methods(Cons))
+    rval = AbstractADT.new(Cons, {'head': t, 'tail': None})
     rval.attributes['tail'] = AbstractUnion.new([empty, rval])
     return rval.intern()
 

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -21,7 +21,6 @@ from ..utils import (
     Partializable,
     SymbolicKeyInstance,
     dataclass_fields,
-    dataclass_methods,
     infer_trace,
     is_dataclass_type,
     overload,
@@ -456,8 +455,7 @@ def to_abstract(fn, self, v, **kwargs):
         new_args = {}
         for name, value in dataclass_fields(v).items():
             new_args[name] = self(value, **kwargs)
-        methods = dataclass_methods(type(v))
-        rval = AbstractClass(type(v), new_args, methods)
+        rval = AbstractClass(type(v), new_args)
 
     elif isinstance(v, dtype.TypeMeta):
         rval = AbstractType(v)
@@ -590,7 +588,7 @@ def to_abstract(self, v: ADT, **kwargs):
     new_args = {}
     for name, value in dataclass_fields(v).items():
         new_args[name] = self(value, **kwargs)
-    draft = AbstractADT(type(v), new_args, dataclass_methods(type(v)))
+    draft = AbstractADT(type(v), new_args)
     return normalize_adt(draft)
 
 

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -561,7 +561,7 @@ def to_abstract(self, v: dict, **kwargs):
 
 @overload  # noqa: F811
 def to_abstract(self, v: np.ndarray, alias_map={}, **kwargs):
-    tracks = {SHAPE: v.shape}
+    tracks = {SHAPE: v.shape, TYPE: dtype.NDArray}
     if id(v) in alias_map:
         tracks[ALIASID] = alias_map[id(v)]
     return AbstractArray(

--- a/myia/abstract/prim.py
+++ b/myia/abstract/prim.py
@@ -377,7 +377,6 @@ async def _inf_make_record(self, engine, _cls: AbstractType, *elems):
             name: wrap(elem) if wrap else elem
             for (name, _), elem in zip(expected, elems)
         },
-        cls.methods,
         constructor=cls.constructor
     )
 
@@ -442,7 +441,6 @@ async def _inf_record_setitem(self, engine,
     return type(data)(
         data.tag,
         {**data.attributes, attr_v: value},
-        data.methods,
         constructor=data.constructor
     )
 

--- a/myia/abstract/prim.py
+++ b/myia/abstract/prim.py
@@ -469,9 +469,8 @@ async def _inf_array_len(self, engine, xs: AbstractArray):
 @standard_prim(P.scalar_to_array)
 async def _inf_scalar_to_array(self, engine, a: AbstractScalar, t):
     tp = t.values[VALUE]
-    tp = type(tp)
-    assert issubclass(tp, AbstractArray)
-    return tp(a, {SHAPE: ()})
+    assert isinstance(tp, AbstractArray)
+    return AbstractArray(a, {SHAPE: (), TYPE: tp.dtype()})
 
 
 @standard_prim(P.array_to_scalar)
@@ -553,12 +552,17 @@ async def _inf_array_map(self, engine, fn: AbstractFunction, *arrays):
             raise MyiaShapeError("Expect same shapes for array_map")
 
     for arr in arrays:
-        if type(arrays[0]) != type(arr):
+        if arrays[0].dtype() != arr.dtype():
             raise MyiaTypeError(
-                f'Expect array of type {type(arrays[0])} '
-                f'to have same type as array of type {type(arr)}')
+                f'Expect array of type {arrays[0].dtype()} '
+                f'to have same type as array of type {arr.dtype()}')
 
-    return type(arrays[0])(result, {SHAPE: tuple(rshape)})
+    return type(arrays[0])(
+        result, {
+            SHAPE: tuple(rshape),
+            TYPE: arrays[0].dtype(),
+        }
+    )
 
 
 # TODO: array_scan
@@ -587,7 +591,7 @@ async def _inf_array_reduce(self, engine,
             )
 
     res = await engine.execute(fn, a.element, a.element)
-    return type(a)(res, {SHAPE: shp_v})
+    return type(a)(res, {SHAPE: shp_v, TYPE: a.dtype()})
 
 
 @standard_prim(P.distribute)
@@ -602,7 +606,7 @@ async def _inf_distribute(self, engine, a: AbstractArray, _shp: _shape_type):
     for vs, s in zip(a_shp, shp):
         if vs != s and vs not in (1, ANYTHING) and s not in (1, ANYTHING):
             raise MyiaShapeError("Cannot change shape when distributing")
-    return type(a)(a.element, {SHAPE: shp})
+    return type(a)(a.element, {SHAPE: shp, TYPE: a.dtype()})
 
 
 @standard_prim(P.reshape)
@@ -616,7 +620,7 @@ async def _inf_reshape(self, engine, a: AbstractArray, _shp: _shape_type):
             prod(shp) != prod(a_shp)):
         raise MyiaShapeError("Cannot change the total number of elements "
                              "in reshape")
-    return type(a)(a.element, {SHAPE: shp})
+    return type(a)(a.element, {SHAPE: shp, TYPE: a.dtype()})
 
 
 @standard_prim(P.transpose)
@@ -634,7 +638,7 @@ async def _inf_transpose(self, engine,
             )
 
         shp = tuple(a_shp[i] for i in perm)
-    return type(a)(a.element, {SHAPE: shp})
+    return type(a)(a.element, {SHAPE: shp, TYPE: a.dtype()})
 
 
 @standard_prim(P.dot)
@@ -651,12 +655,12 @@ async def _inf_dot(self, engine, a: AbstractArray, b: AbstractArray):
     engine.abstract_merge(a.element, b.element)
     c_shp = (a_shp[0], b_shp[1])
 
-    if type(a) != type(b):
+    if a.dtype() != b.dtype():
         raise MyiaTypeError(
-            f'Expect array of type {type(a)} '
-            f'to have same type as array of type {type(b)}')
+            f'Expect array of type {a.dtype()} '
+            f'to have same type as array of type {b.dtype()}')
 
-    return type(a)(a.element, {SHAPE: c_shp})
+    return type(a)(a.element, {SHAPE: c_shp, TYPE: a.dtype()})
 
 
 @standard_prim(P.conv2d)
@@ -694,7 +698,8 @@ async def _inf_conv2d(self, engine, input: AbstractArray,
     engine.check(AbstractScalar, input.element, weight.element)
     # ^ TODO: PyTorch also enforces, but might want to change for mixed precis
 
-    return type(weight)(weight.element, {SHAPE: out_shape})
+    return type(weight)(weight.element, {SHAPE: out_shape,
+                                         TYPE: weight.dtype()})
 
 
 @standard_prim(P.conv2d_input_grad)
@@ -707,7 +712,8 @@ async def _inf_conv2d_input_grad(self, engine, input_size: _shape_type,
                                  groups: dtype.UInt[64]):
     input_size_tuple = tuple(
         self.require_constant(i_s, argnum=0) for i_s in input_size.elements)
-    return type(weight)(weight.element, {SHAPE: input_size_tuple})
+    return type(weight)(weight.element, {SHAPE: input_size_tuple,
+                                         TYPE: weight.dtype()})
 
 
 @standard_prim(P.conv2d_weight_grad)
@@ -720,7 +726,8 @@ async def _inf_conv2d_weight_grad(self, engine, input: AbstractArray,
                                   groups: dtype.UInt[64]):
     weight_size_tuple = tuple(
         self.require_constant(w_s, argnum=0) for w_s in weight_size.elements)
-    return type(input)(input.element, {SHAPE: weight_size_tuple})
+    return type(input)(input.element, {SHAPE: weight_size_tuple,
+                                       TYPE: input.dtype()})
 
 ##############
 # Statements #

--- a/myia/abstract/prim.py
+++ b/myia/abstract/prim.py
@@ -53,7 +53,6 @@ from .utils import (
     hastype_helper,
     sensitivity_transform,
     type_to_abstract,
-    type_token,
     typecheck,
 )
 
@@ -92,7 +91,7 @@ class StandardInferrer(Inferrer):
             if typ is None:
                 pass
             elif isinstance(typ, dtype.TypeMeta):
-                await force_pending(engine.check(typ, type_token(arg), typ))
+                await force_pending(engine.check(typ, arg.dtype(), typ))
             elif isinstance(typ, type) and issubclass(typ, AbstractValue):
                 if not isinstance(arg, typ):
                     raise MyiaTypeError(
@@ -741,7 +740,7 @@ class _SwitchInferrer(Inferrer):
         condref, tbref, fbref = check_nargs(P.switch, 3, argrefs)
 
         cond = await condref.get()
-        await force_pending(engine.check(Bool, type_token(cond)))
+        await force_pending(engine.check(Bool, cond.dtype()))
 
         v = cond.values[VALUE]
         if v is True:
@@ -766,7 +765,7 @@ async def _inf_scalar_cast(self, engine,
                            scalar: Number,
                            typ: AbstractType):
     a = type_to_abstract(typ.values[VALUE])
-    t = type_token(a)
+    t = a.dtype()
     engine.check(Number, t)
     values = {**scalar.values, TYPE: t}
     return AbstractScalar(values)

--- a/myia/abstract/utils.py
+++ b/myia/abstract/utils.py
@@ -205,7 +205,7 @@ def pytype_to_abstract(main: np.ndarray, args):
     arg, = args
     arg = type_to_abstract(arg)
     shp = ANYTHING
-    return AbstractArray(arg, {SHAPE: shp})
+    return AbstractArray(arg, {SHAPE: shp, TYPE: dtype.NDArray})
 
 
 @overload  # noqa: F811
@@ -232,6 +232,14 @@ def pytype_to_abstract(main: bool, args):
     })
 
 
+@overload  # noqa: F811
+def pytype_to_abstract(main: AbstractArray, args):
+    return AbstractArray(
+        ANYTHING,
+        values={SHAPE: ANYTHING, TYPE: ANYTHING},
+    )
+
+
 def type_token(x):
     """Build a type from an abstract value."""
     if isinstance(x, AbstractScalar):
@@ -241,6 +249,8 @@ def type_token(x):
     elif isinstance(x, AbstractDict):
         return x.dtype()
     elif isinstance(x, AbstractClassBase):
+        return x.dtype()
+    elif isinstance(x, AbstractArray):
         return x.dtype()
     else:
         return type(x)

--- a/myia/abstract/utils.py
+++ b/myia/abstract/utils.py
@@ -240,22 +240,6 @@ def pytype_to_abstract(main: AbstractArray, args):
     )
 
 
-def type_token(x):
-    """Build a type from an abstract value."""
-    if isinstance(x, AbstractScalar):
-        return x.dtype()
-    elif isinstance(x, AbstractTuple):
-        return x.dtype()
-    elif isinstance(x, AbstractDict):
-        return x.dtype()
-    elif isinstance(x, AbstractClassBase):
-        return x.dtype()
-    elif isinstance(x, AbstractArray):
-        return x.dtype()
-    else:
-        return type(x)
-
-
 ############
 # Checking #
 ############

--- a/myia/compile/backends/__init__.py
+++ b/myia/compile/backends/__init__.py
@@ -181,9 +181,8 @@ class Backend:
     def to_backend_value(self, v, t):
         """Convert an intermediate value to a backend value."""
         from ..utils import BackendValue
-        if (isinstance(v, BackendValue) and
-            v.backend is self and
-                abstract.typecheck(t, v.vm_t)):
+        if isinstance(v, BackendValue):
+            assert v.backend is self
             return v.value
         if (isinstance(t, (abstract.AbstractError, abstract.AbstractType))
                 or v is abstract.DEAD):

--- a/myia/composite.py
+++ b/myia/composite.py
@@ -23,19 +23,7 @@ from .abstract import (
     build_value,
     myia_static,
 )
-from .dtype import (
-    Array,
-    Bool,
-    EnvType,
-    Nil,
-    Number,
-    f32,
-    f64,
-    i8,
-    i16,
-    u8,
-    u16,
-)
+from .dtype import Bool, EnvType, Nil, Number, f32, f64, i8, i16, u8, u16
 from .hypermap import HyperMap, hyper_map
 from .ir import Graph, MetaGraph, MultitypeGraph
 from .prim import ops as P
@@ -116,7 +104,7 @@ class Elemwise(MetaGraph):
 
     def make_signature(self, args):
         """Create the signature: whether arguments are arrays, and shapes."""
-        return tuple((type(arg), arg.values[SHAPE])
+        return tuple((arg.dtype(), arg.values[SHAPE])
                      if isinstance(arg, AbstractArray) else (None, False)
                      for arg in args)
 
@@ -129,7 +117,9 @@ class Elemwise(MetaGraph):
         is_array_op = len(shapes) > 0
         if is_array_op:
             array_types = [t for t, _ in sig if t is not None]
-            array_type = array_types[0](ANYTHING, {SHAPE: ANYTHING})
+            array_type = AbstractArray(
+                ANYTHING, {SHAPE: ANYTHING, TYPE: array_types[0]}
+            )
         params = []
         for i, (t, _) in enumerate(sig):
             p = g.add_parameter()
@@ -537,42 +527,42 @@ def array_usub(xs):
     return array_map(usub, xs)
 
 
-@exp.register(Array)
+@exp.register(AbstractArray)
 @core
 def array_exp(xs):
     """Implementation of `array_exp`."""
     return array_map(scalar_exp, xs)
 
 
-@log.register(Array)
+@log.register(AbstractArray)
 @core
 def array_log(xs):
     """Implementation of `array_log`."""
     return array_map(scalar_log, xs)
 
 
-@sin.register(Array)
+@sin.register(AbstractArray)
 @core
 def array_sin(xs):
     """Implementation of `array_sin`."""
     return array_map(scalar_sin, xs)
 
 
-@cos.register(Array)
+@cos.register(AbstractArray)
 @core
 def array_cos(xs):
     """Implementation of `array_cos`."""
     return array_map(scalar_cos, xs)
 
 
-@tan.register(Array)
+@tan.register(AbstractArray)
 @core
 def array_tan(xs):
     """Implementation of `array_tan`."""
     return array_map(scalar_tan, xs)
 
 
-@tanh.register(Array)
+@tanh.register(AbstractArray)
 @core
 def array_tanh(xs):
     """Implementation of `array_tanh`."""
@@ -677,7 +667,7 @@ def _scalar_zero(x):
     return scalar_cast(0, typeof(x))
 
 
-@_leaf_zeros_like.register(Array)
+@_leaf_zeros_like.register(AbstractArray)
 @core
 def _array_zero(xs):
     scalar_zero = scalar_cast(0, typeof(xs).element)

--- a/myia/dtype.py
+++ b/myia/dtype.py
@@ -155,6 +155,18 @@ class UInt(Number):
     _valid_bits = (8, 16, 32, 64)
 
 
+class Tuple(Object):
+    """Type of a Python tuple."""
+
+
+class Dict(Object):
+    """Type of a Python dict."""
+
+
+class NDArray(Object):
+    """Type of a Numpy array."""
+
+
 class SymbolicKeyType(Object):
     """Type of a SymbolicKeyInstance."""
 

--- a/myia/frontends/pytorch.py
+++ b/myia/frontends/pytorch.py
@@ -128,7 +128,11 @@ blacklist = ('_backend', '_buffers', '_backward_hooks', '_forward_hooks',
 
 @to_abstract.register
 def _to_abstract(self, v: torch.nn.Module, **kwargs):
-    fwd_fn = getattr(type(v), 'forward')
+    from ..pipeline.resources import standard_method_map
+    standard_method_map[type(v)] = {
+        '__call__': getattr(type(v), 'forward'),
+        '__sub__': mod_sub,
+    }
     attrs = {}
     for var_k, var_v in vars(v).items():
         if var_k not in blacklist:
@@ -172,8 +176,7 @@ def _to_abstract(self, v: torch.nn.Module, **kwargs):
                 setattr(v, k, a)
         return v
 
-    return AbstractModule(v.__class__, attrs, {'__call__': fwd_fn,
-                          '__sub__': mod_sub}, constructor=new_module)
+    return AbstractModule(v.__class__, attrs, constructor=new_module)
 
 
 @to_abstract.register  # noqa: F811

--- a/myia/frontends/pytorch.py
+++ b/myia/frontends/pytorch.py
@@ -21,6 +21,7 @@ from ..hypermap import hyper_map
 from ..pipeline.resources import standard_method_map, standard_object_map
 from ..pipeline.steps import convert_arg_array, convert_result_array
 from ..prim import ops as P
+from ..utils import MyiaInputTypeError
 from .pytorch_abstract_types import AbstractModule, PyTorchTensor
 from .pytorch_functions import _sum, conv2d, item, linear, relu, sigmoid
 
@@ -188,9 +189,9 @@ def _to_abstract(self, v: torch.nn.Parameter, **kwargs):
 
 @convert_arg_array.register
 def _convert_arg_array(arg, t: PyTorchTensor, et, orig_t):
-    if isinstance(arg, torch.Tensor):
-        arg = arg.detach().numpy()
-    return arg
+    if not isinstance(arg, torch.Tensor):
+        raise MyiaInputTypeError(f"Expected torch.Tensor but got {arg}.")
+    return arg.detach().numpy()
 
 
 @convert_result_array.register

--- a/myia/frontends/pytorch_abstract_types.py
+++ b/myia/frontends/pytorch_abstract_types.py
@@ -1,7 +1,6 @@
 """Abstract Types for PyTorch Frontend."""
 
 from ..abstract.data import AbstractClassBase
-from ..abstract.infer import ArrayWrapper
 from ..dtype import Object
 
 

--- a/myia/frontends/pytorch_abstract_types.py
+++ b/myia/frontends/pytorch_abstract_types.py
@@ -1,6 +1,12 @@
 """Abstract Types for PyTorch Frontend."""
 
-from ..abstract.data import ANYTHING, SHAPE, AbstractArray, AbstractClassBase
+from ..abstract.data import AbstractClassBase
+from ..abstract.infer import ArrayWrapper
+from ..dtype import Object
+
+
+class PyTorchTensor(Object):
+    """Type of an AbstractArray that behaves like a PyTorch Tensor."""
 
 
 class AbstractModule(AbstractClassBase):
@@ -17,14 +23,3 @@ class AbstractModule(AbstractClassBase):
         (especially for pytorch modules and their contents).
         """
         return self
-
-
-class AbstractPyTorchTensor(AbstractArray):
-    """Represents a PyTorch Tensor."""
-
-    def __init__(self, element, values):
-        """Initialize an AbstractPyTorchTensor."""
-        super().__init__(element, values)
-
-
-APT = AbstractPyTorchTensor(ANYTHING, {SHAPE: ANYTHING})

--- a/myia/frontends/pytorch_functions.py
+++ b/myia/frontends/pytorch_functions.py
@@ -16,11 +16,11 @@
 #############################################################################
 
 from .. import composite as C, dtype as D
+from ..abstract import AbstractArray
 from ..composite import core
 from ..hypermap import hyper_map
 from ..ir import MultitypeGraph
 from ..prim import ops as P
-from .pytorch_abstract_types import APT
 
 # This import is for WIP
 # from ..dtype import Bool, Int
@@ -138,7 +138,7 @@ def _softmax(x, d, dt):
 _sum = MultitypeGraph('_sum')
 
 
-@_sum.register(APT)
+@_sum.register(AbstractArray)
 @core
 def __sum(x):
 

--- a/myia/macros.py
+++ b/myia/macros.py
@@ -13,6 +13,7 @@ from .abstract import (
     ANYTHING,
     TYPE,
     VALUE,
+    AbstractArray,
     generate_getters,
     macro,
     setter_from_getter,
@@ -20,7 +21,7 @@ from .abstract import (
     union_simplify,
 )
 from .composite import gadd
-from .dtype import Array, Bool, Number
+from .dtype import Bool, Number
 from .info import About, DebugInfo
 from .ir import (
     CloneRemapper,
@@ -461,11 +462,11 @@ def _scalar_cast_helper(x, model):
     return scalar_cast(x, t)
 
 
-@_cast_helper.register(Number, Array)
+@_cast_helper.register(Number, AbstractArray)
 @core
 def _scalar_to_array_cast_helper(x, model):
     t = typeof(model)
-    return scalar_to_array(scalar_cast(x, t.element), typeof(model))
+    return scalar_to_array(scalar_cast(x, t.element), t)
 
 
 ROOT = Named('ROOT')

--- a/myia/macros.py
+++ b/myia/macros.py
@@ -14,6 +14,9 @@ from .abstract import (
     TYPE,
     VALUE,
     AbstractArray,
+    Pending,
+    build_value,
+    find_coherent_result,
     generate_getters,
     macro,
     setter_from_getter,
@@ -115,9 +118,6 @@ async def _resolve_case(resources, data, data_t, item_v):
 @macro
 async def getattr_(info):
     """Get an attribute from an object."""
-    from .abstract import build_value, ANYTHING, find_coherent_result, \
-        Pending
-
     r_data, r_attr = check_nargs('getattr', 2, info.argrefs)
     data, attr = info.abstracts
 

--- a/myia/macros.py
+++ b/myia/macros.py
@@ -104,6 +104,8 @@ async def _resolve_case(resources, data, data_t, item_v):
                 return ('field', item_v)
             elif hasattr(data_t, item_v):
                 return ('method', getattr(data_t, item_v))
+            else:
+                return ('no_method',)
         else:
             return ('no_method',)
 

--- a/myia/opt/clean.py
+++ b/myia/opt/clean.py
@@ -7,7 +7,6 @@ from ..abstract import (
     ANYTHING,
     TYPE,
     VALUE,
-    AbstractArray,
     AbstractClassBase,
     AbstractDict,
     AbstractKeywordArgument,
@@ -195,12 +194,6 @@ def simplify_types(root, manager):
         elif node.is_apply(P.string_eq):
             new_node = node.graph.apply(P.scalar_eq,
                                         node.inputs[1], node.inputs[2])
-
-        elif (node.is_constant(AbstractArray) and
-                type(node.value) is not AbstractArray):
-            new_node = Constant(
-                AbstractArray(node.value.element, node.value.values))
-            keep_abstract = False
 
         elif node.is_apply(P.make_kwarg):
             new_node = node.inputs[2]

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -2,10 +2,7 @@
 
 from .. import operations
 from ..abstract import (
-    ANYTHING,
     DEAD,
-    SHAPE,
-    AbstractArray,
     AbstractFunction,
     AbstractJTagged,
     abstract_clone,
@@ -81,9 +78,6 @@ def M(mg):
 def primset_var(*prims):
     """Create a variable that matches a Primitive node."""
     return var(lambda node: node.is_constant() and node.value in prims)
-
-
-AA = AbstractArray(ANYTHING, {SHAPE: ANYTHING})
 
 
 ###############################
@@ -415,18 +409,20 @@ def unfuse_composite(optimizer, node, equiv):
     """
     # This has to be defined inline because of circular imports
     class UnfuseRemapper(BasicRemapper):
-        def __init__(self, g, shape):
+        def __init__(self, g, reference):
             super().__init__(
                 graphs=g.graphs_used.keys() | {g},
                 relation='unfused'
             )
-            self.shape = shape
+            self.reference = reference
 
         def asarray(self, ng, i):
             if i.is_constant():
-                return ng.apply(P.distribute, ng.apply(P.scalar_to_array, i,
-                                                       AA),
-                                self.shape)
+                typ = (self.reference.abstract
+                       or ng.apply(P.typeof, self.reference))
+                return ng.apply(P.distribute,
+                                ng.apply(P.scalar_to_array, i, typ),
+                                ng.apply(P.shape, self.reference))
             else:
                 return i
 
@@ -444,7 +440,7 @@ def unfuse_composite(optimizer, node, equiv):
 
     g = equiv[G].value
     xs = equiv[Xs]
-    r = UnfuseRemapper(g, xs[0].shape)
+    r = UnfuseRemapper(g, xs[0])
     r.run()
     ng = r.get_graph(g)
     return node.graph.apply(ng, *xs)
@@ -481,7 +477,8 @@ def simplify_array_map(optimizer, node, equiv):
         elif x.is_constant() \
                 and issubclass(type_token(x.abstract), Number):
             shp = (P.shape, xs[0])
-            sexp = (P.distribute, (P.scalar_to_array, x, AA), shp)
+            typ = xs[0].abstract or (P.typeof, xs[0])
+            sexp = (P.distribute, (P.scalar_to_array, x, typ), shp)
             return sexp_to_node(sexp, node.graph)
         else:
             # Raise a semi-rare exception that won't hide bugs

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -1,12 +1,7 @@
 """Library of optimizations."""
 
 from .. import operations
-from ..abstract import (
-    DEAD,
-    AbstractFunction,
-    AbstractJTagged,
-    abstract_clone,
-)
+from ..abstract import DEAD, AbstractFunction, AbstractJTagged, abstract_clone
 from ..composite import gadd, zeros_like
 from ..dtype import Number
 from ..ir import (

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -6,7 +6,6 @@ from ..abstract import (
     AbstractFunction,
     AbstractJTagged,
     abstract_clone,
-    type_token,
 )
 from ..composite import gadd, zeros_like
 from ..dtype import Number
@@ -475,7 +474,7 @@ def simplify_array_map(optimizer, node, equiv):
             idx = g.parameters.index(x)
             return xs[idx]
         elif x.is_constant() \
-                and issubclass(type_token(x.abstract), Number):
+                and issubclass(x.abstract.dtype(), Number):
             shp = (P.shape, xs[0])
             typ = xs[0].abstract or (P.typeof, xs[0])
             sexp = (P.distribute, (P.scalar_to_array, x, typ), shp)

--- a/myia/pipeline/resources.py
+++ b/myia/pipeline/resources.py
@@ -5,7 +5,7 @@ from types import FunctionType
 
 import numpy as np
 
-from .. import abstract, composite as C, dtype, macros as M, operations, parser
+from .. import composite as C, dtype, macros as M, operations, parser
 from ..abstract import InferenceEngine
 from ..ir import Graph, clone
 from ..monomorphize import monomorphize
@@ -241,7 +241,7 @@ standard_method_map = TypeMap({
         '__getitem__': P.dict_getitem,
         'values': M.dict_values,
     },
-    abstract.AbstractArray: {
+    dtype.NDArray: {
         '__add__': C.add,
         '__sub__': C.sub,
         '__mul__': C.mul,
@@ -336,7 +336,7 @@ class ConverterResource(PipelineResource):
             bool: dtype.Bool,
             int: dtype.Int,
             float: dtype.Float,
-            np.ndarray: abstract.AbstractArray,
+            np.ndarray: dtype.NDArray,
             np.int8: dtype.Int,
             np.int16: dtype.Int,
             np.int32: dtype.Int,

--- a/myia/pipeline/resources.py
+++ b/myia/pipeline/resources.py
@@ -228,7 +228,7 @@ standard_method_map = TypeMap({
         '__bool__': C.float_bool,
         '__myia_to_array__': P.scalar_to_array,
     },
-    abstract.AbstractTuple: {
+    dtype.Tuple: {
         '__len__': P.tuple_len,
         '__add__': C.tuple_concat,
         '__getitem__': C.tuple_get,
@@ -237,7 +237,7 @@ standard_method_map = TypeMap({
         '__myia_next__': C.tuple_next,
         '__myia_hasnext__': C.tuple_hasnext,
     },
-    abstract.AbstractDict: {
+    dtype.Dict: {
         '__getitem__': P.dict_getitem,
         'values': M.dict_values,
     },
@@ -344,7 +344,8 @@ class ConverterResource(PipelineResource):
             np.float16: dtype.Float,
             np.float32: dtype.Float,
             np.float64: dtype.Float,
-            tuple: abstract.AbstractTuple,
+            tuple: dtype.Tuple,
+            dict: dtype.Dict,
         }
         mmap = self.resources.method_map
         for t1, t2 in type_map.items():

--- a/myia/pipeline/steps.py
+++ b/myia/pipeline/steps.py
@@ -567,12 +567,8 @@ def convert_arg(self, arg, orig_t: AbstractClassBase):
         return res
 
 
-@overload  # noqa: F811
-def convert_arg(self, arg, orig_t: AbstractArray):
-    et = orig_t.element
-    assert isinstance(et, AbstractScalar)
-    et = et.values[TYPE]
-    assert issubclass(et, dtype.Number)
+@overload
+def convert_arg_array(arg, t: dtype.NDArray, et, orig_t):
     if not isinstance(arg, np.ndarray):
         raise MyiaInputTypeError(f"Expected array but got {arg}.")
     if arg.dtype != dtype.type_to_np_dtype(et):
@@ -585,6 +581,16 @@ def convert_arg(self, arg, orig_t: AbstractArray):
         raise MyiaInputTypeError(
             f"Expected array with shape {shp}, but got {arg.shape}.")
     return arg
+
+
+@overload  # noqa: F811
+def convert_arg(self, arg, orig_t: AbstractArray):
+    et = orig_t.element
+    assert isinstance(et, AbstractScalar)
+    et = et.values[TYPE]
+    assert issubclass(et, dtype.Number)
+    t = orig_t.dtype()
+    return convert_arg_array[t](arg, t, et, orig_t)
 
 
 @overload  # noqa: F811
@@ -668,13 +674,14 @@ def convert_result(self, arg, orig_t, vm_t: AbstractScalar):
 
 
 @overload
-def convert_result_array(arg, orig_t: AbstractArray):
+def convert_result_array(arg, orig_t: dtype.NDArray):
     return arg
 
 
 @overload  # noqa: F811
 def convert_result(self, arg, orig_t, vm_t: AbstractArray):
-    return convert_result_array(arg, orig_t)
+    t = orig_t.dtype()
+    return convert_result_array[t](arg, t)
 
 
 @overload  # noqa: F811

--- a/myia/pipeline/steps.py
+++ b/myia/pipeline/steps.py
@@ -570,16 +570,7 @@ def convert_arg(self, arg, orig_t: AbstractClassBase):
 @overload
 def convert_arg_array(arg, t: dtype.NDArray, et, orig_t):
     if not isinstance(arg, np.ndarray):
-        raise MyiaInputTypeError(f"Expected array but got {arg}.")
-    if arg.dtype != dtype.type_to_np_dtype(et):
-        raise MyiaInputTypeError(
-            f"Expected array of type {dtype.type_to_np_dtype(et)}, "
-            f"but got {arg.dtype}.")
-    shp = orig_t.values[SHAPE]
-    if (shp is not ANYTHING and
-            arg.shape != shp):
-        raise MyiaInputTypeError(
-            f"Expected array with shape {shp}, but got {arg.shape}.")
+        raise MyiaInputTypeError(f"Expected numpy.ndarray but got {arg}.")
     return arg
 
 
@@ -590,7 +581,18 @@ def convert_arg(self, arg, orig_t: AbstractArray):
     et = et.values[TYPE]
     assert issubclass(et, dtype.Number)
     t = orig_t.dtype()
-    return convert_arg_array[t](arg, t, et, orig_t)
+    arg = convert_arg_array[t](arg, t, et, orig_t)
+    arg_dtype = dtype.np_dtype_to_type(str(arg.dtype))
+    if arg_dtype != et:
+        raise MyiaInputTypeError(
+            f"Expected array of type {et}, but got {arg_dtype}."
+        )
+    shp = orig_t.values[SHAPE]
+    if (shp is not ANYTHING and arg.shape != shp):
+        raise MyiaInputTypeError(
+            f"Expected array with shape {shp}, but got {arg.shape}."
+        )
+    return arg
 
 
 @overload  # noqa: F811

--- a/myia/prim/py_implementations.py
+++ b/myia/prim/py_implementations.py
@@ -333,13 +333,12 @@ def _vm_record_getitem(vm, data, attr):
     """Implement `record_getitem`."""
     from types import MethodType, BuiltinMethodType
     from ..vm import Partial
-    from ..abstract import type_token
     # I don't know how else to get a reference to this type
     method_wrapper_type = type((0).__add__)
     try:
         x = getattr(data, attr)
     except AttributeError:
-        t = type_token(typeof(data))
+        t = typeof(data).dtype()
         mmap = vm.convert.resources.method_map[t]
         if attr in mmap:
             return Partial(vm.convert(mmap[attr]), [data], vm)

--- a/myia/utils/__init__.py
+++ b/myia/utils/__init__.py
@@ -61,7 +61,6 @@ from .misc import (  # noqa
     TaggedValue,
     core,
     dataclass_fields,
-    dataclass_methods,
     is_dataclass_type,
     keyword_decorator,
     list_str,

--- a/myia/utils/misc.py
+++ b/myia/utils/misc.py
@@ -3,7 +3,6 @@
 import builtins
 import functools
 from dataclasses import dataclass
-from types import FunctionType
 from typing import Any, Dict, List, TypeVar
 
 builtins_d = vars(builtins)

--- a/myia/utils/misc.py
+++ b/myia/utils/misc.py
@@ -384,13 +384,6 @@ def is_dataclass_type(cls):
     return isinstance(cls, type) and hasattr(cls, '__dataclass_fields__')
 
 
-def dataclass_methods(dc):
-    """Returns a dataclass's method dictionary."""
-    return {name: getattr(dc, name)
-            for name in dir(dc)
-            if isinstance(getattr(dc, name), (FunctionType, property))}
-
-
 def dataclass_fields(dc):
     """Returns a dataclass's fields dictionary."""
     return {name: getattr(dc, name)

--- a/tests/common.py
+++ b/tests/common.py
@@ -30,13 +30,7 @@ from myia.composite import ArithmeticData
 from myia.dtype import Bool, Nil, Number, f16, f32, f64, i16, i32, i64, u64
 from myia.ir import MultitypeGraph
 from myia.prim.py_implementations import hastype, tagged
-from myia.utils import (
-    ADT,
-    EnvInstance,
-    dataclass_fields,
-    dataclass_methods,
-    overload,
-)
+from myia.utils import ADT, EnvInstance, dataclass_fields, overload
 
 B = Bool
 Bot = AbstractBottom()
@@ -193,7 +187,7 @@ def to_abstract_test(self, x: object):
         new_args = {}
         for name, value in dataclass_fields(x).items():
             new_args[name] = self(value)
-        return AbstractClass(type(x), new_args, dataclass_methods(type(x)))
+        return AbstractClass(type(x), new_args)
     elif getattr(x, '__origin__') is dtype.External:
         arg, = x.__args__
         return AbstractExternal({VALUE: ANYTHING, TYPE: arg})

--- a/tests/common.py
+++ b/tests/common.py
@@ -35,7 +35,8 @@ from myia.utils import ADT, EnvInstance, dataclass_fields, overload
 B = Bool
 Bot = AbstractBottom()
 EmptyTuple = typing.Tuple[()]
-AA = AbstractArray(ANYTHING, {SHAPE: ANYTHING})
+AA = AbstractArray(ANYTHING, {SHAPE: ANYTHING, TYPE: ANYTHING})
+AN = AbstractArray(ANYTHING, {SHAPE: ANYTHING, TYPE: dtype.NDArray})
 
 
 ###########################
@@ -47,7 +48,7 @@ def arr_of(t, shp, value):
     return AbstractArray(AbstractScalar({
         VALUE: value,
         TYPE: t,
-    }), {SHAPE: shp})
+    }), {SHAPE: shp, TYPE: dtype.NDArray})
 
 
 def ai64_of(*shp, value=ANYTHING):
@@ -144,7 +145,7 @@ def to_abstract_test(self, x: np.ndarray):
             VALUE: ANYTHING,
             TYPE: dtype.np_dtype_to_type(str(x.dtype)),
         }),
-        {SHAPE: x.shape}
+        {SHAPE: x.shape, TYPE: dtype.NDArray}
     )
 
 

--- a/tests/compile/test_backend.py
+++ b/tests/compile/test_backend.py
@@ -23,7 +23,7 @@ from myia.prim.py_implementations import (
     transpose,
 )
 
-from ..common import AA, MA, MB
+from ..common import AN, MA, MB
 
 
 @pytest.fixture(params=[
@@ -229,7 +229,7 @@ def test_bool_eq(x, y):
 
 @parse_compare((2,))
 def test_to_array(x):
-    return scalar_to_array(x, AA)
+    return scalar_to_array(x, AN)
 
 
 @parse_compare((False,), (True,))
@@ -239,12 +239,12 @@ def test_bool_not(x,):
 
 @parse_compare((2,))
 def test_distribute(x):
-    return distribute(scalar_to_array(x, AA), (2, 3))
+    return distribute(scalar_to_array(x, AN), (2, 3))
 
 
 @parse_compare((2,))
 def test_distribute2(x):
-    return distribute(scalar_to_array(x, AA), (1,))
+    return distribute(scalar_to_array(x, AN), (1,))
 
 
 @parse_compare(np.ones((1, 3)), np.ones((3,)))

--- a/tests/frontends/test_pytorch.py
+++ b/tests/frontends/test_pytorch.py
@@ -1001,3 +1001,12 @@ def test_conv_grad_errors():
     with pytest.raises(ValueError):
         conv2d_input(input_size, weight, torch.ones(9, 9, 9, 9),
                      (2, 3), (3, 2), (3, 4), 3)
+
+
+def test_switch_input_types():
+    @myia
+    def f(x):
+        return x * x
+
+    f(torch.ones((2, 2)))
+    f(np.ones((2, 2)))

--- a/tests/frontends/test_pytorch_ops.py
+++ b/tests/frontends/test_pytorch_ops.py
@@ -6,12 +6,11 @@ import numpy as np
 import pytest
 from pytest import mark
 
-from myia.abstract import from_value
+from myia.abstract import AbstractArray, from_value
 from myia.abstract.data import ANYTHING, SHAPE, TYPE, VALUE, AbstractScalar
 from myia.debug.finite_diff import clean_args
 from myia.frontends import activate_frontend  # noqa: E402
-from myia.frontends.pytorch_abstract_types import \
-    AbstractPyTorchTensor  # noqa: E402
+from myia.frontends.pytorch_abstract_types import PyTorchTensor  # noqa: E402
 from myia.pipeline import standard_pipeline
 
 from ..common import MA, f32, to_abstract_test
@@ -95,10 +94,14 @@ def pt_fn_grads(fn, *args, **kwargs):
         output, args, torch.ones(output.shape))
 
 
-APT_loss = AbstractPyTorchTensor(
-    AbstractScalar({TYPE: f32, VALUE: ANYTHING}), {SHAPE: (1,)})
-APT_0d_loss = AbstractPyTorchTensor(
-    AbstractScalar({TYPE: f32, VALUE: ANYTHING}), {SHAPE: ()})
+APT_loss = AbstractArray(
+    AbstractScalar({TYPE: f32, VALUE: ANYTHING}),
+    {SHAPE: (1,), TYPE: PyTorchTensor}
+)
+APT_0d_loss = AbstractArray(
+    AbstractScalar({TYPE: f32, VALUE: ANYTHING}),
+    {SHAPE: (), TYPE: PyTorchTensor}
+)
 
 
 def _fwd_test(fn, args, pipeline=standard_pipeline,
@@ -132,8 +135,10 @@ def _grad_test(fn, obj, args,
     elif sens_type == (1,):
         sens_type = APT_loss
     else:
-        sens_type = AbstractPyTorchTensor(
-            AbstractScalar({TYPE: f32, VALUE: ANYTHING}), {SHAPE: sens_type})
+        sens_type = AbstractArray(
+            AbstractScalar({TYPE: f32, VALUE: ANYTHING}),
+            {SHAPE: sens_type, TYPE: PyTorchTensor}
+        )
 
     pipeline = standard_pipeline
     pipeline = pipeline.insert_after('parse', grad_wrap=grad_wrap)

--- a/tests/opt/test_lib.py
+++ b/tests/opt/test_lib.py
@@ -19,10 +19,11 @@ from myia.prim.py_implementations import (
     switch,
     transpose,
     tuple_setitem,
+    typeof,
 )
 from myia.utils import newenv
 
-from ..common import AA, af64_of, f64, i64, to_abstract_test
+from ..common import af64_of, f64, i64, to_abstract_test
 from .test_opt import _check_opt
 
 #######################
@@ -384,6 +385,7 @@ def test_simplify_array_map_3():
 
 
 def test_simplify_array_map_4():
+    arr_t = af64_of(3, 5)
 
     def before(xs):
         def f(x):
@@ -391,11 +393,11 @@ def test_simplify_array_map_4():
         return array_map(f, xs)
 
     def after(xs):
-        return distribute(scalar_to_array(3, AA), shape(xs))
+        return distribute(scalar_to_array(3, arr_t), shape(xs))
 
     _check_opt(before, after,
                lib.simplify_array_map,
-               argspec=[af64_of(3, 5)],
+               argspec=[arr_t],
                argspec_after=False)
 
 
@@ -443,14 +445,14 @@ def test_unfuse_composite_constant():
         return array_map(p1, x)
 
     def after(x):
-        def up1(x):
-            return array_map(scalar_add, x,
-                             distribute(scalar_to_array(1, AA), (2, 3)))
+        def up1(x2):
+            return array_map(scalar_add, x2,
+                             distribute(scalar_to_array(1, typeof(x)),
+                                        shape(x)))
         return up1(x)
 
     _check_opt(before, after,
-               lib.unfuse_composite,
-               argspec=[af64_of(2, 3)])
+               lib.unfuse_composite)
 
 
 ######################

--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -200,8 +200,8 @@ def test_merge_edge_cases():
     b = AbstractJTagged(123)
     assert amerge(a, b) is a
 
-    a = AbstractClass(object, {'x': ANYTHING, 'y': ANYTHING}, {})
-    b = AbstractClass(object, {'x': 123, 'y': ANYTHING}, {})
+    a = AbstractClass(object, {'x': ANYTHING, 'y': ANYTHING})
+    b = AbstractClass(object, {'x': 123, 'y': ANYTHING})
     assert amerge(a, b) is a
 
 
@@ -266,8 +266,8 @@ def test_abstract_clone():
     s2 = S(t=ty.Int[64])
     assert upcast(s1, 64) is s2
 
-    a1 = T([s1, AbstractClass(object, {'field': s1}, {})])
-    a2 = T([s2, AbstractClass(object, {'field': s2}, {})])
+    a1 = T([s1, AbstractClass(object, {'field': s1})])
+    a2 = T([s2, AbstractClass(object, {'field': s2})])
     assert upcast(a1, 64) is a2
 
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -79,7 +79,7 @@ from myia.prim.py_implementations import (
 from myia.utils import InferenceError, MyiaTypeError, newenv
 
 from .common import (
-    AA,
+    AN,
     JT,
     TU,
     B,
@@ -1642,7 +1642,7 @@ def test_scalar_cast(x, t):
     ((i64,), InferenceError)
 )
 def test_scalar_to_array(x):
-    return scalar_to_array(x, AA)
+    return scalar_to_array(x, AN)
 
 
 @infer(


### PR DESCRIPTION
Based on #259 

* Remove `methods` field from `AbstractClassBase`. It is unnecessary.
* Method resolution now *always* relies on `a.values[TYPE]`
* Remove the `type_token` function
* Replace `AbstractPyTorchTensor` by `AbstractArray(..., {TYPE: PyTorchTensor})`
* Remove overloads in the pytorch frontend that are now unnecessary.
