### PR TITLE
Fix name resolution bug in parser

### DIFF
--- a/myia/parser.py
+++ b/myia/parser.py
@@ -284,6 +284,11 @@ class Parser:
         function_block.mature()
         function_block.graph.debug.name = node.name
 
+        # Use the same priority as python where an argument with the
+        # same name will mask the function.
+        graph = function_block.graph
+        function_block.write(node.name, Constant(graph), track=False)
+
         # Process arguments and their defaults
         args = node.args.args
         nondefaults = [None] * (len(args) - len(node.args.defaults))
@@ -331,8 +336,6 @@ class Parser:
         else:
             kwarg_node = None
 
-        graph = function_block.graph
-        function_block.write(node.name, Constant(graph), track=False)
         self.process_statements(function_block, node.body)
         if function_block.graph.return_ is None:
             raise MyiaSyntaxError("Function doesn't return a value",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -134,6 +134,14 @@ def test_parametric():
     assert raw_parse(j).kwarg == 'kwargs'
 
 
+def test_fn_param_same_name():
+    def a(a):
+        return a + 1
+
+    fa = raw_parse(a)
+    assert fa.output.inputs[1] is fa.parameters[0]
+
+
 def test_unsupported_AST__error():
     def a1():
         import builtins  # noqa: F401


### PR DESCRIPTION
When a function and its parameter have the same name, we overwrite the parameter with the function.  Python uses the parameter instead. I did a quick fix to use python's order.

This is still vulnerable to something like this:

```python
def test_shadow_fn():
    def a(x):
        return a(x + 1)

    b = a

    def a(x):
        return x

    return b(2)
```
Python returns 3, myia loops infinitely.