### PR TITLE
Support for isinstance

### DIFF
--- a/myia/abstract/data.py
+++ b/myia/abstract/data.py
@@ -243,7 +243,7 @@ class AbstractValue(Interned, PossiblyRecursive):
 
     def dtype(self):
         """Return the type of this AbstractValue."""
-        t = self.values[TYPE]
+        t = self.values.get(TYPE, None)
         if isinstance(t, Pending) and t.done():
             t = t.result()
         return t

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -370,6 +370,10 @@ class InferenceEngine:
             * A callable that returns a boolean
         """
         if isinstance(predicate, dtype.TypeMeta):
+            if isinstance(x, AbstractValue):
+                x = x.dtype()
+                if x is None:
+                    return False
             return issubclass(x, predicate)
         elif isinstance(predicate, type):
             return isinstance(x, predicate)

--- a/myia/abstract/prim.py
+++ b/myia/abstract/prim.py
@@ -99,6 +99,8 @@ class StandardInferrer(Inferrer):
                     )
             elif callable(typ):
                 await force_pending(engine.check(typ, arg))
+            else:
+                raise AssertionError(f'Invalid annotation: {typ}')
         return await self._infer(self, engine, *args)
 
     def require_constant(self, a, *, argnum, range=None):

--- a/myia/macros.py
+++ b/myia/macros.py
@@ -328,7 +328,8 @@ async def user_switch(info):
 
         xg = xref.node.graph
         cg = condref.node.graph
-        cond_trials = [cond_trial(cg, t) for t in fulltype.options]
+        cond_trials = [cond_trial(cg, t) for t in
+                       await force_pending(fulltype.options)]
         results = [await engine.ref(node, condref.context).get()
                    for node in cond_trials]
 

--- a/myia/macros.py
+++ b/myia/macros.py
@@ -174,10 +174,7 @@ async def getattr_(info):
             currg = falseg
         return rval
 
-    try:
-        data_t = data.dtype()
-    except KeyError:
-        data_t = None
+    data_t = data.dtype()
     attr_v = build_value(attr, default=ANYTHING)
     g = info.outref.node.graph
 

--- a/myia/pipeline/resources.py
+++ b/myia/pipeline/resources.py
@@ -70,6 +70,7 @@ scalar_object_map = {
     range: C.range_,
     zip: C.zip_,
     enumerate: C.enumerate_,
+    isinstance: M.isinstance_,
 }
 
 
@@ -146,6 +147,7 @@ standard_object_map = {
     range: C.range_,
     zip: C.zip_,
     enumerate: C.enumerate_,
+    isinstance: M.isinstance_,
 }
 
 standard_method_map = TypeMap({

--- a/myia/utils/misc.py
+++ b/myia/utils/misc.py
@@ -46,6 +46,9 @@ class Cons(ADT):
             curr = curr.tail
         return rval
 
+    def __bool__(self):
+        return True
+
     def __len__(self):
         return 1 + len(self.tail)
 
@@ -74,6 +77,9 @@ class Empty(ADT):
 
     def __iter__(self):
         return iter(())
+
+    def __bool__(self):
+        return False
 
     def __len__(self):
         return 0

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1170,6 +1170,11 @@ def test_isinstance(x):
     return f(x)
 
 
+@infer_std((i64, InferenceError))
+def test_isinstance_bad(x):
+    return isinstance(x, (int, 3))
+
+
 @infer_std(
     (U(i64, (i64, i64)), i64),
     (U(i64, (f64, i64)), InferenceError),

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1140,7 +1140,7 @@ def test_hastype_2(x):
     return f(x)
 
 
-@infer(
+@infer_std(
     (i64, i64),
     (f64, f64),
     ((i64, i64), i64),
@@ -1158,10 +1158,10 @@ def test_isinstance(x):
             else:
                 return f(x[0]) + f(x[1:])
         elif isinstance(x, list):
-            if isinstance(x, Empty):
-                return 0
-            else:
+            if x:
                 return f(x.head) + f(x.tail)
+            else:
+                return 0
         elif isinstance(x, Point):
             return f(x.x) * f(x.y)
         else:

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1140,6 +1140,36 @@ def test_hastype_2(x):
     return f(x)
 
 
+@infer(
+    (i64, i64),
+    (f64, f64),
+    ((i64, i64), i64),
+    ((i64, f64), InferenceError),
+    ([f64], f64),
+    (Point(i64, i64), i64),
+)
+def test_isinstance(x):
+    def f(x):
+        if isinstance(x, (int, float)):
+            return x
+        elif isinstance(x, tuple):
+            if len(x) == 0:
+                return 0
+            else:
+                return f(x[0]) + f(x[1:])
+        elif isinstance(x, list):
+            if isinstance(x, Empty):
+                return 0
+            else:
+                return f(x.head) + f(x.tail)
+        elif isinstance(x, Point):
+            return f(x.x) * f(x.y)
+        else:
+            return None
+
+    return f(x)
+
+
 @infer_std(
     (U(i64, (i64, i64)), i64),
     (U(i64, (f64, i64)), InferenceError),


### PR DESCRIPTION
Unlike `hastype`, `isinstance` tries to mirror the Python semantics exactly.
