### PR TITLE
Reorganize simplify_types

### DIFF
--- a/myia/frontends/pytorch.py
+++ b/myia/frontends/pytorch.py
@@ -16,8 +16,8 @@ from ..abstract.data import (
 )
 from ..abstract.infer import to_abstract
 from ..hypermap import hyper_map
-from ..pipeline.resources import standard_method_map, standard_object_map
-from ..pipeline.steps import convert_arg_array, convert_result_array
+from ..pipeline.standard import standard_method_map, standard_object_map
+from ..pipeline.steps import convert_arg, convert_result
 from ..prim import ops as P
 from ..utils import MyiaInputTypeError, core
 from ..xtype import Bool, Float, Int, NDArray, UInt
@@ -186,13 +186,13 @@ def _to_abstract(self, v: torch.nn.Parameter, **kwargs):
     )
 
 
-@convert_arg_array.register
-def _convert_arg_array(arg, t: PyTorchTensor, et, orig_t):
+@convert_arg.register
+def _convert_arg(self, arg, t: PyTorchTensor):
     if not isinstance(arg, torch.Tensor):
         raise MyiaInputTypeError(f"Expected torch.Tensor but got {arg}.")
     return arg.detach().numpy()
 
 
-@convert_result_array.register
-def _convert_result_array(arg, orig_t: PyTorchTensor):
+@convert_result.register
+def _convert_result(self, arg, orig_t, vm_t: PyTorchTensor):
     return torch.from_numpy(arg)

--- a/myia/opt/__init__.py
+++ b/myia/opt/__init__.py
@@ -1,6 +1,5 @@
 """Optimization submodule."""
 
-from .clean import simplify_types, str_to_tag, type_to_tag  # noqa
 from .cse import CSE, cse  # noqa
 from .dde import DeadDataElimination  # noqa
 from .opt import (  # noqa

--- a/myia/pipeline/steps.py
+++ b/myia/pipeline/steps.py
@@ -419,6 +419,16 @@ class SlowdownWarning(UserWarning):
 
 @to_canonical.variant_wrapper
 def convert_arg(fn, self, arg, orig_t):
+    """Check and convert an argument to the canonical representation.
+
+    Arguments:
+        arg: The argument to convert.
+        orig_t: The type of the argument as returned by to_abstract.
+
+    Returns:
+        A version of the argument where classes/dicts become tuples
+        and unions are properly tagged.
+    """
     if isinstance(arg, BackendValue):
         if not typecheck(orig_t, arg.orig_t):
             raise MyiaInputTypeError("Bad type for backend value.")
@@ -435,6 +445,17 @@ def convert_arg(self, arg, t: xtype.NDArray):
 
 @from_canonical.variant
 def convert_result(self, arg, orig_t, vm_t: xtype.NDArray):
+    """Convert an argument back from the canonical representation.
+
+    Arguments:
+        res: The canonical argument to convert.
+        orig_t: The original type of the argument as returned by to_abstract.
+        vm_t: The canonical type as computed by simplify_types from orig_t.
+
+    Returns:
+        An argument where tuples are converted to the classes/dicts they
+        came from and unions are untagged.
+    """
     return arg
 
 

--- a/myia/pipeline/steps.py
+++ b/myia/pipeline/steps.py
@@ -30,11 +30,13 @@ from ..opt import (
     LocalPassOptimizer,
     NodeMap,
     lib as optlib,
+)
+from ..simplify_types import (
+    _strmap_tag,
     simplify_types,
     str_to_tag,
     type_to_tag,
 )
-from ..opt.clean import _strmap_tag
 from ..utils import (
     Cons,
     Empty,

--- a/myia/pipeline/steps.py
+++ b/myia/pipeline/steps.py
@@ -8,19 +8,7 @@ from itertools import count
 import numpy as np
 
 from .. import xtype
-from ..abstract import (
-    ANYTHING,
-    AbstractArray,
-    AbstractClassBase,
-    AbstractDict,
-    AbstractScalar,
-    AbstractTaggedUnion,
-    AbstractTuple,
-    AbstractUnion,
-    empty,
-    find_aliases,
-    typecheck,
-)
+from ..abstract import AbstractTuple, find_aliases, typecheck
 from ..cconv import closure_convert
 from ..compile import BackendValue
 from ..ir import Graph
@@ -31,22 +19,8 @@ from ..opt import (
     NodeMap,
     lib as optlib,
 )
-from ..simplify_types import (
-    _strmap_tag,
-    simplify_types,
-    str_to_tag,
-    type_to_tag,
-)
-from ..utils import (
-    Cons,
-    Empty,
-    MyiaInputTypeError,
-    Partializable,
-    TaggedValue,
-    overload,
-    overload_wrapper,
-    tracer,
-)
+from ..simplify_types import from_canonical, simplify_types, to_canonical
+from ..utils import MyiaInputTypeError, Partializable, overload, tracer
 from ..validate import validate
 
 #############
@@ -443,7 +417,7 @@ class SlowdownWarning(UserWarning):
 #####################################
 
 
-@overload_wrapper(bootstrap=True)
+@to_canonical.variant_wrapper
 def convert_arg(fn, self, arg, orig_t):
     if isinstance(arg, BackendValue):
         if not typecheck(orig_t, arg.orig_t):
@@ -453,183 +427,15 @@ def convert_arg(fn, self, arg, orig_t):
 
 
 @overload  # noqa: F811
-def convert_arg(self, arg, orig_t: AbstractTuple):
-    if not isinstance(arg, tuple):
-        raise MyiaInputTypeError('Expected tuple')
-    oe = orig_t.elements
-    if len(arg) != len(oe):
-        raise MyiaInputTypeError(f'Expected {len(oe)} elements')
-    return tuple(self(x, o) for x, o in zip(arg, oe))
-
-
-@overload  # noqa: F811
-def convert_arg(self, arg, orig_t: AbstractDict):
-    if not isinstance(arg, dict):
-        raise MyiaInputTypeError('Expected dict')
-    types = orig_t.entries
-    if len(arg) != len(types):
-        raise MyiaInputTypeError(
-            "Dictionary input doesn't have the expected size"
-        )
-    if set(arg.keys()) != set(types.keys()):
-        raise MyiaInputTypeError("Mismatched keys for input dictionary.")
-    return tuple(self(arg[k], o) for k, o in orig_t.entries.items())
-
-
-@overload  # noqa: F811
-def convert_arg(self, arg, orig_t: AbstractClassBase):
-    if orig_t.tag is Empty:
-        if arg != []:
-            raise MyiaInputTypeError(f'Expected empty list')
-        return ()
-    elif orig_t.tag is Cons:
-        if arg == []:
-            raise MyiaInputTypeError(f'Expected non-empty list')
-        if not isinstance(arg, list):
-            raise MyiaInputTypeError(f'Expected list')
-        ot = orig_t.attributes['head']
-        li = list(self(x, ot) for x in arg)
-        rval = TaggedValue(type_to_tag(empty), ())
-        for elem in reversed(li):
-            rval = TaggedValue(type_to_tag(orig_t), (elem, rval))
-        return rval.value
-    else:
-        if not isinstance(arg, orig_t.tag):
-            raise MyiaInputTypeError(f'Expected {orig_t.tag.__qualname__}')
-        arg = tuple(getattr(arg, attr) for attr in orig_t.attributes)
-        oe = list(orig_t.attributes.values())
-        res = tuple(self(x, o) for x, o in zip(arg, oe))
-        return res
-
-
-@overload
-def convert_arg_array(arg, t: xtype.NDArray, et, orig_t):
+def convert_arg(self, arg, t: xtype.NDArray):
     if not isinstance(arg, np.ndarray):
         raise MyiaInputTypeError(f"Expected numpy.ndarray but got {arg}.")
     return arg
 
 
-@overload  # noqa: F811
-def convert_arg(self, arg, orig_t: AbstractArray):
-    et = orig_t.element
-    assert isinstance(et, AbstractScalar)
-    et = et.xtype()
-    assert issubclass(et, xtype.Number)
-    t = orig_t.xtype()
-    arg = convert_arg_array[t](arg, t, et, orig_t)
-    arg_dtype = xtype.np_dtype_to_type(str(arg.dtype))
-    if arg_dtype != et:
-        raise MyiaInputTypeError(
-            f"Expected array of type {et}, but got {arg_dtype}."
-        )
-    shp = orig_t.xshape()
-    if (shp is not ANYTHING and arg.shape != shp):
-        raise MyiaInputTypeError(
-            f"Expected array with shape {shp}, but got {arg.shape}."
-        )
+@from_canonical.variant
+def convert_result(self, arg, orig_t, vm_t: xtype.NDArray):
     return arg
-
-
-@overload  # noqa: F811
-def convert_arg(self, arg, orig_t: AbstractUnion):
-    for opt in orig_t.options:
-        try:
-            value = self(arg, opt)
-            tag = type_to_tag(opt)
-        except TypeError:
-            continue
-        return TaggedValue(tag, value)
-    else:
-        opts = ", ".join(map(str, orig_t.options))
-        raise MyiaInputTypeError(f'Expected one of {opts}, not {arg}')
-
-
-@overload  # noqa: F811
-def convert_arg(self, arg, orig_t: AbstractScalar):
-    t = orig_t.xtype()
-    if issubclass(t, xtype.Int):
-        if not isinstance(arg, (int, np.integer)):
-            raise MyiaInputTypeError(f'Expected int')
-    elif issubclass(t, xtype.Float):
-        if not isinstance(arg, (float, np.floating)):
-            raise MyiaInputTypeError(f'Expected float')
-    elif issubclass(t, xtype.Bool):
-        if not isinstance(arg, bool):
-            raise MyiaInputTypeError(f'Expected bool')
-    elif issubclass(t, xtype.Nil):
-        if arg is not None:
-            raise MyiaInputTypeError(f'Expected None')
-    elif issubclass(t, xtype.String):
-        if not isinstance(arg, str):
-            raise MyiaInputTypeError(f'Expected string')
-    else:
-        raise MyiaInputTypeError(f'Invalid type: {t}')
-    expected_value = orig_t.xvalue()
-    if expected_value is not ANYTHING and expected_value != arg:
-        raise MyiaInputTypeError(f'Invalid value: {arg}')
-    if issubclass(t, xtype.String):
-        arg = str_to_tag(arg)
-    return arg
-
-
-@overload(bootstrap=True)
-def convert_result(self, res, orig_t, vm_t: AbstractTuple):
-    # If the EraseClass opt was applied, orig_t may be Class
-    orig_is_class = isinstance(orig_t, AbstractClassBase)
-    if orig_is_class:
-        if orig_t.tag in (Empty, Cons):
-            rval = []
-            while res:
-                value = self(res[0], orig_t.attributes['head'],
-                             vm_t.elements[0])
-                rval.append(value)
-                res = res[1].value
-            return rval
-    orig_is_dict = isinstance(orig_t, AbstractDict)
-    if orig_is_class:
-        oe = orig_t.attributes.values()
-    elif orig_is_dict:
-        oe = orig_t.entries.values()
-    else:
-        oe = orig_t.elements
-    ve = vm_t.elements
-    tup = tuple(self(x, o, v)
-                for x, o, v in zip(res, oe, ve))
-    if orig_is_class:
-        return orig_t.constructor(*tup)
-    elif orig_is_dict:
-        return dict(zip(orig_t.entries.keys(), tup))
-    else:
-        return tup
-
-
-@overload  # noqa: F811
-def convert_result(self, arg, orig_t, vm_t: AbstractScalar):
-    if orig_t.xtype() == xtype.String:
-        arg = _strmap_tag[arg]
-    return arg
-
-
-@overload
-def convert_result_array(arg, orig_t: xtype.NDArray):
-    return arg
-
-
-@overload  # noqa: F811
-def convert_result(self, arg, orig_t, vm_t: AbstractArray):
-    t = orig_t.xtype()
-    return convert_result_array[t](arg, t)
-
-
-@overload  # noqa: F811
-def convert_result(self, arg, orig_t, vm_t: AbstractTaggedUnion):
-    assert isinstance(orig_t, AbstractUnion)
-    for typ in orig_t.options:
-        tag = type_to_tag(typ)
-        if tag == arg.tag:
-            return self(arg.value, typ, vm_t.options.get(tag))
-    else:
-        raise AssertionError(f'Badly formed TaggedValue')
 
 
 def step_wrap(resources,

--- a/myia/simplify_types.py
+++ b/myia/simplify_types.py
@@ -265,6 +265,16 @@ def simplify_types(root, manager):
 
 @overload(bootstrap=True)
 def to_canonical(self, arg, orig_t: AbstractTuple):
+    """Check and convert an argument to the canonical representation.
+
+    Arguments:
+        arg: The argument to convert.
+        orig_t: The type of the argument as returned by to_abstract.
+
+    Returns:
+        A version of the argument where classes/dicts become tuples
+        and unions are properly tagged.
+    """
     if not isinstance(arg, tuple):
         raise MyiaInputTypeError('Expected tuple')
     oe = orig_t.elements
@@ -366,6 +376,17 @@ def to_canonical(self, arg, orig_t: AbstractScalar):
 
 @overload(bootstrap=True)
 def from_canonical(self, res, orig_t, vm_t: AbstractTuple):
+    """Convert an argument back from the canonical representation.
+
+    Arguments:
+        res: The canonical argument to convert.
+        orig_t: The original type of the argument as returned by to_abstract.
+        vm_t: The canonical type as computed by simplify_types from orig_t.
+
+    Returns:
+        An argument where tuples are converted to the classes/dicts they
+        came from and unions are untagged.
+    """
     # If the EraseClass opt was applied, orig_t may be Class
     orig_is_class = isinstance(orig_t, AbstractClassBase)
     if orig_is_class:

--- a/myia/simplify_types.py
+++ b/myia/simplify_types.py
@@ -3,7 +3,7 @@
 import weakref
 from itertools import count
 
-from ..abstract import (
+from .abstract import (
     ANYTHING,
     TYPE,
     VALUE,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,8 +10,8 @@ from myia.pipeline import (
 )
 from myia.pipeline.steps import convert_arg, convert_result
 from myia.prim.py_implementations import tuple_getitem
-from myia.utils import InferenceError, TaggedValue, newenv
-from myia.xtype import Bool, EnvType
+from myia.utils import InferenceError, TaggedValue
+from myia.xtype import Bool
 
 from .common import (
     D,
@@ -106,8 +106,6 @@ def test_convert_arg():
         _convert([], [f64])
     with pytest.raises(TypeError):
         _convert([1, 2], [])
-    with pytest.raises(TypeError):
-        _convert(newenv, EnvType)
 
     # Class -> Tuple conversion
 


### PR DESCRIPTION
* `myia.opt.clean` is moved to `myia.opt.simplify_types`
* Most of `convert_arg` and `convert_result` is moved to `from_canonical` and `to_canonical` in `simplify_types`. `convert_arg` and `convert_result` remain as variants of these, to take care of the conversion for `BackendValue` and various array types.
