### PR TITLE
docstring fix in find_aliases and other small fixes.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,7 +96,7 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/myia/abstract/aliasing.py
+++ b/myia/abstract/aliasing.py
@@ -41,7 +41,6 @@ def _explore(self, v: object, vseq, path):
         for k, x in dataclass_fields(v).items():
             yield from self(x, vseq, (*path, k))
 
-
 def ndarray_aliasable(v, vseq, path):
     """Aliasing policy whereas all numpy.ndarray are aliasable.
 
@@ -56,21 +55,21 @@ def ndarray_aliasable(v, vseq, path):
 
 
 def find_aliases(obj, aliasable=ndarray_aliasable):
-    """Find aliased data in obj.
+    """
+    Find aliased data in obj.
 
-    Arguments:
-        ndarray_aliasable: A function with signature
-                ((v, vseq, path) -> True/False/"X")
-            Arguments:
-                v: The potentially aliasable value
-                vseq: The sequence of objects containing v
-                path: The sequence of indexes on the path to v
-            Returns:
-                True: v is aliasable
-                False: v is not aliasable
-                "X": v is aliasable, but it is located in a place where the
-                    aliasing data cannot be used
+    :param ndarray_aliasable: A function with signature
+       ((v, vseq, path) -> True/False/"X")
 
+       where:
+
+          v: The potentially aliasable value
+          vseq: The sequence of objects containing v
+          path: The sequence of indexes on the path to v
+
+    :return: True: v is aliasable, False: v is not aliasable, "X": v is 
+       aliasable, but it is located in a place where the aliasing data
+       cannot be used.
     """
     if aliasable is None:
         return {}, {}


### PR DESCRIPTION
In the context of regenerating the Myia documentation, I started looking at the definitions. Here are a few little tweaks to get rid of doc compilation issues.