### PR TITLE
Make tvm requirements strict

### DIFF
--- a/requirements-cpu.conda
+++ b/requirements-cpu.conda
@@ -1,7 +1,7 @@
 python>=3.7,<3.8a0
 colorama
 numpy
-abergeron::tvm
+abergeron::tvm==0.6dev+2.*
 pytest
 pytest-cov
 pyyaml

--- a/requirements-gpu.conda
+++ b/requirements-gpu.conda
@@ -2,7 +2,7 @@ python>=3.7,<3.8a0
 colorama
 numpy
 abergeron/label/cuda::tvm-libs
-abergeron::tvm
+abergeron::tvm==0.6dev+2.*
 pytest
 pytest-cov
 pyyaml


### PR DESCRIPTION
This is to avoid a mess when a PR updates to an incompatible version of tvm.