### PR TITLE
New testing framework for Myia functions

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -110,36 +110,3 @@ def pytest_runtest_teardown(item):
     if hasattr(item, '_ctxms'):
         for cm in item._ctxms:
             cm.__exit__(None, None, None)
-
-
-class BackendOption:
-    def __init__(self, backend, backend_options):
-        from myia.pipeline import standard_pipeline
-        from myia.compile.backends import load_backend, LoadingError
-        try:
-            self.backend = load_backend(backend, backend_options)
-        except LoadingError as e:
-            pytest.skip(f"Can't load {backend}: {e.__cause__}")
-        self.pip = standard_pipeline.configure({
-            'resources.backend.name': backend,
-            'resources.backend.options': backend_options
-        }).make()
-
-    def convert_args(self, args):
-        from myia.api import to_device
-        return tuple(to_device(arg, self.backend) for arg in args)
-
-
-@pytest.fixture(params=[
-    pytest.param(('nnvm', {'target': 'cpu', 'device_id': 0}), id='nnvm-cpu'),
-    pytest.param(('nnvm', {'target': 'cuda', 'device_id': 0}), id='nnvm-cuda',
-                 marks=pytest.mark.gpu),
-    pytest.param(('relay', {'target': 'cpu', 'device_id': 0}), id='relay-cpu'),
-    pytest.param(('relay', {'target': 'cuda', 'device_id': 0}),
-                 id='relay-cuda', marks=pytest.mark.gpu),
-    pytest.param(('pytorch', {'device': 'cpu'}), id='pytorch-cpu'),
-    pytest.param(('pytorch', {'device': 'cuda'}), id='pytorch-cuda',
-                 marks=pytest.mark.gpu)])
-def backend_opt(request):
-    name, options = request.param
-    return BackendOption(name, options)

--- a/conftest.py
+++ b/conftest.py
@@ -110,3 +110,36 @@ def pytest_runtest_teardown(item):
     if hasattr(item, '_ctxms'):
         for cm in item._ctxms:
             cm.__exit__(None, None, None)
+
+
+class BackendOption:
+    def __init__(self, backend, backend_options):
+        from myia.pipeline import standard_pipeline
+        from myia.compile.backends import load_backend, LoadingError
+        try:
+            self.backend = load_backend(backend, backend_options)
+        except LoadingError as e:
+            pytest.skip(f"Can't load {backend}: {e.__cause__}")
+        self.pip = standard_pipeline.configure({
+            'resources.backend.name': backend,
+            'resources.backend.options': backend_options
+        }).make()
+
+    def convert_args(self, args):
+        from myia.api import to_device
+        return tuple(to_device(arg, self.backend) for arg in args)
+
+
+@pytest.fixture(params=[
+    pytest.param(('nnvm', {'target': 'cpu', 'device_id': 0}), id='nnvm-cpu'),
+    pytest.param(('nnvm', {'target': 'cuda', 'device_id': 0}), id='nnvm-cuda',
+                 marks=pytest.mark.gpu),
+    pytest.param(('relay', {'target': 'cpu', 'device_id': 0}), id='relay-cpu'),
+    pytest.param(('relay', {'target': 'cuda', 'device_id': 0}),
+                 id='relay-cuda', marks=pytest.mark.gpu),
+    pytest.param(('pytorch', {'device': 'cpu'}), id='pytorch-cpu'),
+    pytest.param(('pytorch', {'device': 'cuda'}), id='pytorch-cuda',
+                 marks=pytest.mark.gpu)])
+def backend_opt(request):
+    name, options = request.param
+    return BackendOption(name, options)

--- a/myia/utils/misc.py
+++ b/myia/utils/misc.py
@@ -104,6 +104,10 @@ class HasDefaults:
         """Initialize a HasDefaults."""
         self.name = name
         self.defaults_field = defaults_field
+        self.set_defaults(defaults)
+
+    def set_defaults(self, defaults):
+        """Set the defaults."""
         if isinstance(defaults, dict):
             self._defaults = defaults
         elif isinstance(defaults, str):

--- a/tests/compile/test_backend.py
+++ b/tests/compile/test_backend.py
@@ -26,36 +26,6 @@ from myia.pipeline import standard_pipeline
 from ..common import AN, MA, MB
 
 
-@pytest.fixture(params=[
-    pytest.param(('nnvm', {'target': 'cpu', 'device_id': 0}), id='nnvm-cpu'),
-    pytest.param(('nnvm', {'target': 'cuda', 'device_id': 0}), id='nnvm-cuda',
-                 marks=pytest.mark.gpu),
-    pytest.param(('relay', {'target': 'cpu', 'device_id': 0}), id='relay-cpu'),
-    pytest.param(('relay', {'target': 'cuda', 'device_id': 0}),
-                 id='relay-cuda', marks=pytest.mark.gpu),
-    pytest.param(('pytorch', {'device': 'cpu'}), id='pytorch-cpu'),
-    pytest.param(('pytorch', {'device': 'cuda'}), id='pytorch-cuda',
-                 marks=pytest.mark.gpu)])
-def backend_opt(request):
-    name, options = request.param
-    return BackendOption(name, options)
-
-
-class BackendOption:
-    def __init__(self, backend, backend_options):
-        try:
-            self.backend = load_backend(backend, backend_options)
-        except LoadingError as e:
-            pytest.skip(f"Can't load {backend}: {e.__cause__}")
-        self.pip = standard_pipeline.configure({
-            'resources.backend.name': backend,
-            'resources.backend.options': backend_options
-        }).make()
-
-    def convert_args(self, args):
-        return tuple(to_device(arg, self.backend) for arg in args)
-
-
 def parse_compare(*tests, justeq=False):
     """Decorate a function to run it against pure python.
 

--- a/tests/compile/test_backend.py
+++ b/tests/compile/test_backend.py
@@ -1,5 +1,4 @@
 import math
-from copy import copy
 
 import numpy as np
 import pytest
@@ -23,33 +22,70 @@ from myia.operations import (
 )
 from myia.pipeline import standard_pipeline
 
-from ..common import AN, MA, MB
+from ..common import AN, MA, MB, to_abstract_test
+from ..multitest import Multiple, mt, myia_function_test
 
 
-def parse_compare(*tests, justeq=False):
-    """Decorate a function to run it against pure python.
+class BackendOption:
+    def __init__(self, backend, backend_options):
+        try:
+            self.backend = load_backend(backend, backend_options)
+        except LoadingError as e:
+            pytest.skip(f"Can't load {backend}: {e.__cause__}")
+        self.pip = standard_pipeline.configure({
+            'resources.backend.name': backend,
+            'resources.backend.options': backend_options
+        }).make()
 
-    This will run and compare the function using all available backends.
-    """
-    def decorate(fn):
-        def test(backend_opt, args):
-            if not isinstance(args, tuple):
-                args = (args,)
-            ref_result = fn(*map(copy, args))
-            argspec = tuple(from_value(arg, broaden=True) for arg in args)
-            res = backend_opt.pip(input=fn, argspec=argspec)
-            myia_fn = res['output']
-            myia_args = backend_opt.convert_args(args)
-            myia_result = myia_fn(*myia_args)
-            if justeq:
-                assert ref_result == myia_result
-            else:
-                np.testing.assert_allclose(ref_result, myia_result)
+    def convert_args(self, args):
+        return tuple(to_device(arg, self.backend) for arg in args)
 
-        m = pytest.mark.parametrize('args', list(tests))(test)
-        m.__orig__ = fn
-        return m
-    return decorate
+
+@myia_function_test(id='run_backend')
+def _run_backend(self, fn, args, result=None, abstract=None,
+                 backend=None):
+    backend = BackendOption(*backend)
+
+    if abstract is None:
+        argspec = tuple(from_value(arg, broaden=True)
+                        for arg in args)
+    else:
+        argspec = tuple(to_abstract_test(a) for a in abstract)
+
+    def out():
+        mfn = backend.pip(input=fn, argspec=argspec)
+        myia_args = backend.convert_args(args)
+        rval = mfn['output'](*myia_args)
+        return rval
+
+    if result is None:
+        result = fn(*args)
+
+    self.check(out, result)
+
+
+run_backend = _run_backend.configure(
+    backend=Multiple(
+        pytest.param(('nnvm', {'target': 'cpu', 'device_id': 0}),
+                     id='nnvm-cpu',
+                     marks=pytest.mark.nnvm),
+        pytest.param(('nnvm', {'target': 'cuda', 'device_id': 0}),
+                     id='nnvm-cuda',
+                     marks=[pytest.mark.nnvm, pytest.mark.gpu]),
+        pytest.param(('relay', {'target': 'cpu', 'device_id': 0}),
+                     id='relay-cpu',
+                     marks=pytest.mark.relay),
+        pytest.param(('relay', {'target': 'cuda', 'device_id': 0}),
+                     id='relay-cuda',
+                     marks=[pytest.mark.relay, pytest.mark.gpu]),
+        pytest.param(('pytorch', {'device': 'cpu'}),
+                     id='pytorch-cpu',
+                     marks=pytest.mark.pytorch),
+        pytest.param(('pytorch', {'device': 'cuda'}),
+                     id='pytorch-cuda',
+                     marks=[pytest.mark.pytorch, pytest.mark.gpu])
+    )
+)
 
 
 def test_default_backend():
@@ -97,196 +133,216 @@ def test_backend_error():
     del _backends[name]
 
 
-@parse_compare((2, 3))
+@run_backend(2, 3)
 def test_add(x, y):
     return x + y
 
 
-@parse_compare((2, 3))
+@run_backend(2, 3)
 def test_sub(x, y):
     return x - y
 
 
-@parse_compare((2, 3))
+@run_backend(2, 3)
 def test_mul(x, y):
     return x * y
 
 
 @pytest.mark.xfail(reason="scalar_cast is needed for ints")
-@parse_compare((2, 3), (2.0, 3.0))
+@mt(
+    run_backend(2, 3),
+    run_backend(2.0, 3.0),
+)
 def test_truediv(x, y):
     return x / y
 
 
-@parse_compare((2, 3), (2.0, 3.0))
+@mt(
+    run_backend(2, 3),
+    run_backend(2.0, 3.0)
+)
 def test_floordiv(x, y):
     return x // y
 
 
-@parse_compare((2, 3))
+@run_backend(2, 3)
 def test_mod(x, y):
     return x % y
 
 
-@parse_compare((2.0, 3.0))
+@run_backend(2.0, 3.0)
 def test_pow(x, y):
     return x ** y
 
 
-@parse_compare((2,))
+@run_backend(2)
 def test_uadd(x):
     return +x
 
 
-@parse_compare((2,))
+@run_backend(2)
 def test_usub(x):
     return -x
 
 
-@parse_compare((2.0,))
+@run_backend(2.0)
 def test_exp(x):
     return math.exp(x)
 
 
-@parse_compare((2.0,))
+@run_backend(2.0)
 def test_log(x):
     return math.log(x)
 
 
 @pytest.mark.xfail(reason="not implemented")
-@parse_compare((2.0,))
+@run_backend(2.0)
 def test_tan(x):
     return math.tan(x)
 
 
-@parse_compare((0.3,))
+@run_backend(0.3)
 def test_tanh(x):
     return math.tanh(x)
 
 
-@parse_compare((2, 3))
+@run_backend(2, 3)
 def test_eq(x, y):
     return x == y
 
 
-@parse_compare((2, 3))
+@run_backend(2, 3)
 def test_lt(x, y):
     return x < y
 
 
-@parse_compare((2, 3))
+@run_backend(2, 3)
 def test_gt(x, y):
     return x > y
 
 
-@parse_compare((2, 3))
+@run_backend(2, 3)
 def test_ne(x, y):
     return x != y
 
 
-@parse_compare((2, 3))
+@run_backend(2, 3)
 def test_le(x, y):
     return x <= y
 
 
-@parse_compare((2, 3))
+@run_backend(2, 3)
 def test_ge(x, y):
     return x >= y
 
 
-@parse_compare((True, False), (True, True))
+@mt(
+    run_backend(True, False),
+    run_backend(True, True)
+)
 def test_bool_eq(x, y):
     return x == y
 
 
-@parse_compare((2,))
+@run_backend(2)
 def test_to_array(x):
     return scalar_to_array(x, AN)
 
 
-@parse_compare((False,), (True,))
+@mt(
+    run_backend(False),
+    run_backend(True),
+)
 def test_bool_not(x,):
     return not x
 
 
-@parse_compare((2,))
+@run_backend(2)
 def test_distribute(x):
     return distribute(scalar_to_array(x, AN), (2, 3))
 
 
-@parse_compare((2,))
+@run_backend(2)
 def test_distribute2(x):
     return distribute(scalar_to_array(x, AN), (1,))
 
 
-@parse_compare(np.ones((1, 3)), np.ones((3,)))
+@mt(
+    run_backend(np.ones((1, 3))),
+    run_backend(np.ones((3,))),
+)
 def test_distribute3(x):
     return distribute(x, (2, 3))
 
 
-@parse_compare(MA(2, 3))
+@run_backend(MA(2, 3))
 def test_distribute4(x):
     return distribute(x, (2, 3))
 
 
-@parse_compare(MA(2, 3))
+@run_backend(MA(2, 3))
 def test_reshape(x):
     return reshape(x, (1, 3, 2, 1))
 
 
-@parse_compare(MA(2, 3))
+@run_backend(MA(2, 3))
 def test_reshape2(x):
     return reshape(x, (6,))
 
 
-@parse_compare(MA(1, 3))
+@run_backend(MA(1, 3))
 def test_reshape3(x):
     return reshape(x, (3,))
 
 
-@parse_compare(np.ones((1,)))
+@run_backend(np.ones((1,)))
 def test_reshape4(x):
     return reshape(x, ())
 
 
-@parse_compare((MA(2, 3), MB(3, 4)))
+@run_backend(MA(2, 3), MB(3, 4))
 def test_dot(x, y):
     return dot(x, y)
 
 
-@parse_compare((MA(2, 3), MB(2, 3)),
-               (MA(1, 3), MB(2, 3)),
-               (MA(2, 1), MB(2, 3)))
+@mt(
+    run_backend(MA(2, 3), MB(2, 3)),
+    run_backend(MA(1, 3), MB(2, 3)),
+    run_backend(MA(2, 1), MB(2, 3)),
+)
 def test_array_map(x, y):
     return x + y
 
 
-@parse_compare((MA(2, 3),), (MA(1, 3),))
+@mt(
+    run_backend(MA(2, 3)),
+    run_backend(MA(1, 3)),
+)
 def test_array_reduce(x):
     return array_reduce(scalar_add, x, (1, 3))
 
 
-@parse_compare((MA(2, 3),))
+@run_backend(MA(2, 3))
 def test_array_reduce2(x):
     return array_reduce(scalar_add, x, (3,))
 
 
-@parse_compare((MA(2, 3),))
+@run_backend(MA(2, 3))
 def test_array_reduce3(x):
     return array_reduce(scalar_add, x, ())
 
 
-@parse_compare((MA(2, 3),))
+@run_backend(MA(2, 3))
 def test_transpose(x):
     return transpose(x, (1, 0))
 
 
-@parse_compare((3, 4))
+@run_backend(3, 4)
 def test_make_tuple(a, b):
     return (a, b)
 
 
-@parse_compare((True, 42, 33))
+@run_backend(True, 42, 33)
 def test_call_hof(c, x, y):
     def f1(x):
         return x + y
@@ -303,23 +359,27 @@ def test_call_hof(c, x, y):
     return choose(c)(x) + choose(not c)(x)
 
 
-@parse_compare((None,), (True,), (False,), justeq=True)
+@mt(
+    run_backend(None),
+    run_backend(True),
+    run_backend(False)
+)
 def test_bool_and_nil_args(x):
     return x
 
 
-@parse_compare((None,), justeq=True)
+@run_backend(None)
 def test_True_assign(_x):
     x = True
     return x
 
 
-@parse_compare((None,), justeq=True)
+@run_backend(None)
 def test_False_assign(_x):
     x = False
     return x
 
 
-@parse_compare((np.array(2),))
+@run_backend(np.array(2))
 def test_array_to_scalar(x):
     return x.item()

--- a/tests/frontends/test_pytorch_ops.py
+++ b/tests/frontends/test_pytorch_ops.py
@@ -129,12 +129,6 @@ def fwd_and_bwd(self, fn, args, broad_specs=None, pipeline=standard_pipeline):
     _fwd_and_bwd(fn, args, broad_specs, pipeline)
 
 
-''' # for when test is not product of "name, args"
-def _name_args_helper(name, args):
-    return [(name, args) for arg in args]
-    #'''
-
-
 # THIS TEST ALL OPS that are in dir of "torch" or "torch.tensor"
 # all_torch_ops = dir(torch)
 # all_torch_tensor_ops = dir(torch.Tensor([5.49670]))

--- a/tests/frontends/test_pytorch_ops.py
+++ b/tests/frontends/test_pytorch_ops.py
@@ -3,7 +3,6 @@ from copy import copy
 from types import FunctionType
 
 import pytest
-from pytest import mark
 
 from myia.abstract import AbstractArray, from_value
 from myia.abstract.data import (
@@ -20,17 +19,14 @@ from myia.frontends.pytorch_abstract_types import PyTorchTensor  # noqa: E402
 from myia.pipeline import standard_pipeline
 
 from ..common import MA, f32, to_abstract_test
-from ..multitest import eqtest
-from ..test_grad import grad_pipeline, grad_wrap
+from ..multitest import eqtest, mt, myia_function_test, run
+from ..test_grad import grad_wrap
 
 torch = pytest.importorskip("torch")
 nn = torch.nn
 F = torch.nn.functional
 
 activate_frontend('pytorch')
-
-
-fwd_compile_pipeline = standard_pipeline
 
 
 # Uncomment this line to print values at specific precision
@@ -91,7 +87,14 @@ def make_argspec(args, broad_specs):
                  for bs, arg in zip(broad_specs, clean_args(args)))
 
 
-def _fwd_test(fn, args, broad_specs, pipeline=standard_pipeline):
+def _fwd_and_bwd(fn, args, broad_specs=None, pipeline=standard_pipeline):
+
+    def mksens(s):
+        return AbstractArray(
+            AbstractScalar({TYPE: f32, VALUE: ANYTHING}),
+            {SHAPE: tuple(s), TYPE: PyTorchTensor}
+        )
+
     ref_result = fn(*map(copy, args))
     argspec = make_argspec(args, broad_specs)
     res = pipeline.run(input=fn, argspec=argspec)
@@ -100,128 +103,30 @@ def _fwd_test(fn, args, broad_specs, pipeline=standard_pipeline):
 
     assert eqtest(ref_result, myia_result)
 
-    if not isinstance(ref_result, tuple):
-        ref_result = (ref_result,)
-    if not isinstance(myia_result, tuple):
-        myia_result = (myia_result,)
-    return [getattr(res, 'shape', ()) for res in myia_result]
+    if isinstance(myia_result, tuple):
+        sens_type = AbstractTuple(
+            [mksens(res.shape) for res in myia_result]
+        )
+        sens = tuple(torch.ones(res.shape) for res in myia_result)
 
-
-def _grad_test(fn, obj, args,
-               sens_type,
-               broad_specs,
-               pipeline=grad_pipeline):
+    else:
+        sens_type = mksens(myia_result.shape)
+        sens = torch.ones(myia_result.shape)
 
     pytorch_grads = pt_fn_grads(fn, *args)
 
-    sens_type_shape = sens_type
-    sens1 = []
-    for s in sens_type:
-        sens1.append(
-            AbstractArray(
-                AbstractScalar({TYPE: f32, VALUE: ANYTHING}),
-                {SHAPE: tuple(s), TYPE: PyTorchTensor}
-            )
-        )
-    if len(sens1) == 1:
-        sens_type = sens1[0]
-    else:
-        sens_type = AbstractTuple(sens1)
-
-    pipeline = standard_pipeline
-    pipeline = pipeline.insert_after('parse', grad_wrap=grad_wrap)
-    argspec = make_argspec(args, broad_specs)
+    gpipeline = pipeline.insert_after('parse', grad_wrap=grad_wrap)
     sens_type = to_abstract_test(sens_type)
-    if isinstance(obj, FunctionType):
-        res = pipeline.run(input=obj, argspec=[*argspec, sens_type])
-    else:
-        pip = pipeline.configure(parse=False)
-        res = pip.run(graph=obj, argspec=[*argspec, sens_type])
-
-    sens = tuple(torch.ones(s) for s in sens_type_shape)
-    if len(sens) == 1:
-        sens = sens[0]
+    assert isinstance(fn, FunctionType)
+    res = gpipeline.run(input=fn, argspec=[*argspec, sens_type])
 
     myia_grads = res['output'](*args, sens)
     assert eqtest(pytorch_grads, myia_grads, rtol=1e-05, atol=1e-06)
 
 
-def compare_fwd(*tests, broad_specs=None):
-    """Decorate a function to parse and run it against pure Python.
-
-    Returns a unit test that will parse the function, and then for
-    each `inputs` tuple in `tests` it will check that the pure Python,
-    undecorated function returns that same output.
-
-    This uses the full myia pipeline.
-
-    Arguments:
-        tests: One or more inputs tuple.
-
-    """
-    def decorate(fn):
-        def test(args):
-            if not isinstance(args, tuple):
-                args = (args,)
-
-            _fwd_test(fn, args, broad_specs, pipeline=fwd_compile_pipeline)
-
-        m = mark.parametrize('args', list(tests))(test)
-        m.__orig__ = fn
-        return m
-    return decorate
-
-
-def compare_bwd(*tests, sens_type=None, pipeline=grad_pipeline):
-    """Decorate a function to parse and run it against pure Python.
-
-    Returns a unit test that will parse the function, and then for
-    each `inputs` tuple in `tests` it will check that the pure Python,
-    undecorated function returns that same output.
-
-    Arguments:
-        tests: One or more inputs tuple.
-
-    """
-
-    def decorate(fn):
-        def test(args):
-            if not isinstance(args, tuple):
-                args = (args,)
-
-            _grad_test(fn, fn, args, pipeline=pipeline, sens_type=sens_type)
-
-        m = pytest.mark.parametrize('args', list(tests))(test)
-        m.__orig__ = fn
-        return m
-    return decorate
-
-
-def compare_fwd_and_bwd(*tests, broad_specs=None,
-                        sens_type=None, pipeline=grad_pipeline):
-    """Decorate a function to parse and run it against pure Python.
-
-    Returns a unit test that will parse the function, and then for
-    each `inputs` tuple in `tests` it will check that the pure Python,
-    undecorated function returns that same output.
-
-    Arguments:
-        tests: One or more inputs tuple.
-
-    """
-    def decorate(fn):
-        def test(args):
-            if not isinstance(args, tuple):
-                args = (args,)
-            out_shape = _fwd_test(fn, args, broad_specs=broad_specs,
-                                  pipeline=fwd_compile_pipeline)
-            _grad_test(fn, fn, args, broad_specs=broad_specs,
-                       pipeline=pipeline, sens_type=out_shape)
-
-        m = pytest.mark.parametrize('args', list(tests))(test)
-        m.__orig__ = fn
-        return m
-    return decorate
+@myia_function_test(marks=[pytest.mark.grad], id='grad')
+def fwd_and_bwd(self, fn, args, broad_specs=None, pipeline=standard_pipeline):
+    _fwd_and_bwd(fn, args, broad_specs, pipeline)
 
 
 ''' # for when test is not product of "name, args"
@@ -238,289 +143,207 @@ def _name_args_helper(name, args):
 torch.manual_seed(123)
 
 
-all_torch_ops__1_tensor_arg = all_torch_tensor_ops__1_tensor_arg = \
-    [
-        'exp',
-        'log',
-        'relu',
-        'sigmoid',
-        'sum',
-        'tanh',
-    ]
-
-
-single_tensor_args = (
-    (nn.Parameter(torch.Tensor([2.1]).reshape(()))),
-    (nn.Parameter(torch.Tensor([2.1]))),
-    (nn.Parameter(torch.Tensor([-2.2]))),
-    (nn.Parameter(torch.Tensor(MA(2, 3)))),
+single_tensor_arg_tests = (
+    fwd_and_bwd(nn.Parameter(torch.Tensor([2.1]).reshape(()))),
+    fwd_and_bwd(nn.Parameter(torch.Tensor([2.1]))),
+    fwd_and_bwd(nn.Parameter(torch.Tensor([-2.2]))),
+    fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3)))),
 )
 
 
-@pytest.mark.parametrize(
-    'name,args',
-    [(op, single_tensor_args) for op in all_torch_ops__1_tensor_arg]
-)
-def test_torch_ops__1_tensor_arg(name, args):
-    def fn1(x):
-        return getattr(torch, name)(x)
-
-    if not isinstance(args, tuple):
-        args = (args,)
-
-    for arg in args:
-        out_shape = _fwd_test(fn1, (arg,), broad_specs=None)
-        _grad_test(fn1, fn1, (arg,), broad_specs=None, sens_type=out_shape)
+@mt(*single_tensor_arg_tests)
+def test_torch_exp(x):
+    return torch.exp(x)
 
 
-@pytest.mark.parametrize(
-    'name,args',
-    [(op, single_tensor_args) for op in all_torch_tensor_ops__1_tensor_arg]
-)
-def test_torch_tensor_ops__1_tensor_arg(name, args):
-    def fn1(x):
-        return getattr(x, name)()
-
-    if not isinstance(args, tuple):
-        args = (args,)
-
-    for arg in args:
-        out_shape = _fwd_test(fn1, (arg,), broad_specs=None)
-        _grad_test(fn1, fn1, (arg,), broad_specs=None, sens_type=out_shape)
+@mt(*single_tensor_arg_tests)
+def test_torch_log(x):
+    return torch.log(x)
 
 
-all_torch_ops__1_tensor_arg__fwd_only = \
-    all_torch_tensor_ops__1_tensor_arg__fwd_only = \
-    [
-    ]
+@mt(*single_tensor_arg_tests)
+def test_torch_relu(x):
+    return torch.relu(x)
 
 
-all_torch_ops__1_tensor_arg__fwd_only.extend([
-    # 'zeros_like',  # zl currently only works with pt backend
-])
+@mt(*single_tensor_arg_tests)
+def test_torch_sigmoid(x):
+    return torch.sigmoid(x)
 
 
-all_torch_tensor_ops__1_tensor_arg__fwd_only.extend([
-])
-
-'''
-@pytest.mark.parametrize(
-    'name,args',
-    [(op, single_tensor_args) for op in all_torch_ops__1_tensor_arg__fwd_only]
-    )
-def test_torch_ops__1_tensor_arg__fwd_only(name, args):
-    def fn1(x):
-        return getattr(torch, name)(x)
-
-    if not isinstance(args, tuple):
-        args = (args,)
-
-    for arg in args:
-        _fwd_test(fn1, (arg,))
-#'''
-
-
-'''
-@pytest.mark.parametrize(
-    'name,args',
-    [(op, single_tensor_args) for op
-     in all_torch_tensor_ops__1_tensor_arg__fwd_only]
-    )
-def test_torch_tensor_ops__1_tensor_arg__fwd_only(name, args):
-    def fn1(x):
-        return getattr(x, name)()
-
-    if not isinstance(args, tuple):
-        args = (args,)
-
-    for arg in args:
-        _fwd_test(fn1, (arg,))
-#'''
-
-
-all_torch_tensor_ops__1_tensor_arg_1D_and_lower__fwd_only = \
-    [
-        'item',
-    ]
-
-
-single_tensor_args__1D_and_lower = (
-    (nn.Parameter(torch.Tensor([2.1]).reshape(()))),
-    (nn.Parameter(torch.Tensor([2.1]))),
-)
-
-
-@pytest.mark.parametrize(
-    'name,args',
-    [(op, single_tensor_args__1D_and_lower) for op
-     in all_torch_tensor_ops__1_tensor_arg_1D_and_lower__fwd_only]
-)
-def test_torch_item__fwd_only(name, args):
-    def fn1(x):
-        return getattr(x, name)()
-
-    if not isinstance(args, tuple):
-        args = (args,)
-
-    for arg in args:
-        _fwd_test(fn1, (arg,), broad_specs=None)
-
-
-all_torch_ops__2_args = all_torch_tensor_ops____2_args = \
-    [
-        'reshape',
-        'sum',  # version with dim arg to reduce over
-        't',
-        'view',
-    ]
+@mt(*single_tensor_arg_tests)
+def test_torch_tanh(x):
+    return torch.tanh(x)
 
 
 # KEEP THESE IN ALPHABETICAL ORDER ####################################
 
 
-@compare_fwd((nn.Parameter(torch.Tensor(MA(2, 3)))))
+@run(nn.Parameter(torch.Tensor(MA(2, 3))))
 def test_torch_tensor_argmax_1_arg(x):
     return torch.argmax(x)
 
 
-@compare_fwd((nn.Parameter(torch.Tensor(MA(2, 3))), 1, True),
-             (nn.Parameter(torch.Tensor(MA(2, 3))), 0, True),
-             broad_specs=(True, False, False))
+@mt(
+    run(nn.Parameter(torch.Tensor(MA(2, 3))), 1, True),
+    run(nn.Parameter(torch.Tensor(MA(2, 3))), 0, True),
+    broad_specs=(True, False, False),
+)
 def test_torch_tensor_argmax_3_arg(x, y, z):
     return torch.argmax(x, y, z)
 
 
-@compare_fwd_and_bwd((nn.Parameter(torch.Tensor(MA(3, 4))),
-                     torch.tensor([[0, 1, 2, 0], [0, 0, 0, 1]])))
+@fwd_and_bwd(nn.Parameter(torch.Tensor(MA(3, 4))),
+             torch.tensor([[0, 1, 2, 0], [0, 0, 0, 1]]))
 def test_torch_gather(x, index):
     return torch.gather(x, 0, index)
 
 
-@compare_fwd_and_bwd((nn.Parameter(torch.randn(2, 4, 3))))
+@mt(
+    run(nn.Parameter(torch.Tensor([2.1]).reshape(()))),
+    run(nn.Parameter(torch.Tensor([2.1]))),
+)
+def test_torch_item(x):
+    return x.item()
+
+
+@fwd_and_bwd(nn.Parameter(torch.randn(2, 4, 3)))
 def test_torch_tensor_get(x):
     return x[:, -3:-1:2, -2]
 
 
-@compare_fwd_and_bwd((nn.Parameter(torch.randn(2, 4, 3))))
+@fwd_and_bwd(nn.Parameter(torch.randn(2, 4, 3)))
 def test_torch_tensor_get2(x):
     return x[1, 2]
 
 
-@compare_fwd_and_bwd((nn.Parameter(torch.Tensor(MA(2, 3))), 0),
-                     (nn.Parameter(torch.Tensor(MA(2, 3))), 1),
-                     (nn.Parameter(torch.Tensor(MA(2, 3))), -1),
-                     broad_specs=(True, False))
+@mt(
+    fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))), 0),
+    fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))), 1),
+    fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))), -1),
+    broad_specs=(True, False)
+)
 def test_torch_log_softmax(x, y):
     return torch.log_softmax(x, y)
 
 
-@compare_fwd_and_bwd((nn.Parameter(torch.Tensor(MA(2, 3))), 0),
-                     (nn.Parameter(torch.Tensor(MA(2, 3))), 1),
-                     (nn.Parameter(torch.Tensor(MA(2, 3))), -1),
-                     broad_specs=(True, False))
+@mt(
+    fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))), 0),
+    fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))), 1),
+    fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))), -1),
+    broad_specs=(True, False)
+)
 def test_torch_functional_log_softmax(x, y):
     return torch.nn.functional.log_softmax(x, y)
 
 
-@compare_fwd_and_bwd((nn.Parameter(torch.randn(2, 4, 3))))
+@fwd_and_bwd(nn.Parameter(torch.randn(2, 4, 3)))
 def test_torch_tensor_max_1_arg(x):
     return torch.max(x)
 
 
-@compare_fwd_and_bwd((nn.Parameter(torch.randn(2, 4, 3)), -1, True),
-                     (nn.Parameter(torch.randn(2, 4, 3)), 1, True),
-                     (nn.Parameter(torch.randn(4)), 0, True),
-                     broad_specs=(True, False, False))
+@mt(
+    fwd_and_bwd(nn.Parameter(torch.randn(2, 4, 3)), -1, True),
+    fwd_and_bwd(nn.Parameter(torch.randn(2, 4, 3)), 1, True),
+    fwd_and_bwd(nn.Parameter(torch.randn(4)), 0, True),
+    broad_specs=(True, False, False)
+)
 def test_torch_tensor_max_3_arg(x, y, z):
     return torch.max(x, y, z)[0]
 
 
-@compare_fwd_and_bwd((nn.Parameter(torch.randn(2, 4, 3, 5)), False),
-                     (nn.Parameter(torch.tensor([[[[1., 2., 3., 4.],
-                      [5., 6., 7., 8.], [13., 14., 15., 16.],
-                      [9., 10., 11., 12.]]]])),
-                      False),
-                     broad_specs=(True, False, False, False, False,
-                                  False, True))
+@mt(
+    fwd_and_bwd(nn.Parameter(torch.randn(2, 4, 3, 5)), False),
+    fwd_and_bwd(nn.Parameter(torch.tensor([[[[1., 2., 3., 4.],
+                [5., 6., 7., 8.], [13., 14., 15., 16.],
+                [9., 10., 11., 12.]]]])),
+                False),
+    broad_specs=(True, False, False, False, False, False, True)
+)
 def test_torch_max_pool2d(x, ri):
     return torch.nn.functional.max_pool2d(x, (2, 2), (1, 1),
                                           0, 1, False, ri)
 
 
-@compare_fwd((nn.Parameter(torch.randn(2, 4, 3, 5)), True),
-             (nn.Parameter(torch.tensor([[[[1., 2., 3., 4.],
-              [5., 6., 7., 8.], [13., 14., 15., 16.],
-              [9., 10., 11., 12.]]]])),
-              True),
-             broad_specs=(True, False, False, False, False,
-                          False, True))
+@mt(
+    run(nn.Parameter(torch.randn(2, 4, 3, 5)), True),
+    run(nn.Parameter(torch.tensor([[[[1., 2., 3., 4.],
+        [5., 6., 7., 8.], [13., 14., 15., 16.],
+        [9., 10., 11., 12.]]]])),
+        True),
+    broad_specs=(True, False, False, False, False, False, True)
+)
 def test_torch_max_pool2d_return_indices(x, ri):
     return torch.nn.functional.max_pool2d(x, (2, 2), (1, 1),
                                           0, 1, False, ri)
 
 
-@compare_fwd_and_bwd((nn.Parameter(torch.Tensor(MA(2, 3))),
-                     torch.tensor([1, 2])))
+@fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))),
+             torch.tensor([1, 2]))
 def test_torch_nll_loss(x, y):
     return torch.nn.functional.nll_loss(x, y)
 
 
-@compare_fwd_and_bwd((nn.Parameter(torch.Tensor(MA(2, 3))),
-                      torch.tensor([1, 2]), 'none'),
-                     (nn.Parameter(torch.Tensor(MA(2, 3))),
-                      torch.tensor([1, 2]), 'sum'),
-                     (nn.Parameter(torch.Tensor(MA(2, 3))),
-                      torch.tensor([1, 2]), 'mean'),
-                     broad_specs=(True, True, False))
+@mt(
+    fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))),
+                torch.tensor([1, 2]), 'none'),
+    fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))),
+                torch.tensor([1, 2]), 'sum'),
+    fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))),
+                torch.tensor([1, 2]), 'mean'),
+    broad_specs=(True, True, False)
+)
 def test_torch_nll_loss_reduce_options(x, y, z):
     return torch.nn.functional.nll_loss(x, y, reduction=z)
 
 
-@compare_fwd_and_bwd((nn.Parameter(torch.Tensor(torch.randn(2, 3, 4, 5)))))
+@fwd_and_bwd(nn.Parameter(torch.Tensor(torch.randn(2, 3, 4, 5))))
 def test_torch_tensor_permute(x):
     return x.permute((0, 3, 2, 1))
 
 
-@compare_fwd_and_bwd((nn.Parameter(torch.Tensor(MA(1, 3)))))
+@fwd_and_bwd(nn.Parameter(torch.Tensor(MA(1, 3))))
 def test_torch_tensor_pow(x):
     return x ** 2
 
 
-@compare_fwd_and_bwd((nn.Parameter(torch.Tensor(MA(2, 3))), (-1,)),
-                     (nn.Parameter(torch.Tensor(MA(2, 3))), (6,)),
-                     (nn.Parameter(torch.Tensor(MA(2, 3))), (2, 3)),
-                     (nn.Parameter(torch.Tensor(MA(2, 1))), (2,)),
-                     broad_specs=(True, False))
+@mt(
+    fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))), (-1,)),
+    fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))), (6,)),
+    fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))), (2, 3)),
+    fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 1))), (2,)),
+    broad_specs=(True, False)
+)
 def test_torch_tensor_reshape(x, y):
     return x.reshape(y)
 
 
-@compare_fwd_and_bwd((nn.Parameter(torch.Tensor(MA(3, 4))),
-                     torch.tensor([[0, 1, 2, 0], [0, 0, 0, 1]]),
-                     nn.Parameter(torch.Tensor(MA(2, 4)))))
+@fwd_and_bwd(nn.Parameter(torch.Tensor(MA(3, 4))),
+             torch.tensor([[0, 1, 2, 0], [0, 0, 0, 1]]),
+             nn.Parameter(torch.Tensor(MA(2, 4))))
 def test_torch_scatter(x, index, src):
     return torch.scatter(x, 0, index, src)
 
 
-@compare_fwd_and_bwd((nn.Parameter(torch.Tensor(MA(3, 4))),
-                     torch.tensor([[0, 1, 2, 0], [0, 0, 0, 1]]),
-                     nn.Parameter(torch.Tensor(MA(2, 4)))))
+@fwd_and_bwd(nn.Parameter(torch.Tensor(MA(3, 4))),
+             torch.tensor([[0, 1, 2, 0], [0, 0, 0, 1]]),
+             nn.Parameter(torch.Tensor(MA(2, 4))))
 def test_torch_scatter_add(x, index, src):
     return torch.scatter_add(x, 0, index, src)
 
 
-@compare_fwd_and_bwd((nn.Parameter(torch.Tensor(MA(3, 4))),
-                     torch.tensor([[0, 1, 2, 0], [0, 0, 0, 1]]),
-                     nn.Parameter(torch.Tensor([2.1]).reshape(()))))
+@fwd_and_bwd(nn.Parameter(torch.Tensor(MA(3, 4))),
+             torch.tensor([[0, 1, 2, 0], [0, 0, 0, 1]]),
+             nn.Parameter(torch.Tensor([2.1]).reshape(())))
 def test_torch_scatter_broadcast_source(x, index, src):
     return torch.scatter(x, 0, index, src)
 
 
 # TODO: Need dtype attr for xtype.NDArray to support nonpytorch scalar src
 """
-@compare_fwd_and_bwd((nn.Parameter(torch.Tensor(MA(3, 4))),
+@fwd_and_bwd(nn.Parameter(torch.Tensor(MA(3, 4))),
               torch.tensor([[0, 1, 2, 0], [0, 0, 0, 1]]),
-              1.23))
+              1.23)
 def test_torch_scatter_broadcast_source_nonpytorch_scalar(x, index, src):
     return torch.scatter(x, 0, index, src)
 # """
@@ -528,80 +351,86 @@ def test_torch_scatter_broadcast_source_nonpytorch_scalar(x, index, src):
 
 # TODO: NotImplementedError: <_ast.Subscript object at 0x*>
 """
-@compare_fwd((nn.Parameter(torch.randn(2, 4, 3)),
-             nn.Parameter(torch.Tensor(torch.randn(1)))))
+@run(nn.Parameter(torch.randn(2, 4, 3)),
+     nn.Parameter(torch.Tensor(torch.randn(1))))
 def test_torch_tensor_set(x, y):
     x[0] = y
     return x
 # """
 
 
-@compare_fwd_and_bwd((nn.Parameter(torch.Tensor(MA(2, 3))), 0),
-                     (nn.Parameter(torch.Tensor(MA(2, 3))), 1),
-                     (nn.Parameter(torch.Tensor(MA(2, 3))), -1),
-                     broad_specs=(True, False))
+@mt(
+    fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))), 0),
+    fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))), 1),
+    fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))), -1),
+    broad_specs=(True, False)
+)
 def test_torch_softmax(x, y):
     return torch.softmax(x, y)
 
 
-@compare_fwd_and_bwd((nn.Parameter(torch.Tensor(MA(1, 2))), -1),
-                     (nn.Parameter(torch.Tensor(MA(2, 1))), 0),
-                     (nn.Parameter(torch.Tensor(MA(2, 1))), 1),
-                     broad_specs=(True, False))
+@mt(
+    fwd_and_bwd(nn.Parameter(torch.Tensor(MA(1, 2))), -1),
+    fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 1))), 0),
+    fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 1))), 1),
+    broad_specs=(True, False)
+)
 def test_torch_tensor_squeeze(x, y):
     return x.squeeze(y)
 
 
-@compare_fwd_and_bwd((nn.Parameter(torch.Tensor(MA(2, 1)))),
-                     broad_specs=(True, False))
+@fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 1))),
+             broad_specs=(True, False))
 def test_torch_tensor_squeeze_all(x):
     return x.squeeze()
 
 
-@compare_fwd_and_bwd((nn.Parameter(torch.Tensor(MA(2, 3)))))
+@fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))))
 def test_torch_sum(x):
     return torch.sum(x)
 
 
-@compare_fwd((nn.Parameter(torch.Tensor(MA(2, 3)))))
+@run(nn.Parameter(torch.Tensor(MA(2, 3))))
 def test_torch_sum_dtype_fwd(x):
     return torch.sum(x, dtype=torch.float64)
 
 
 """ # TODO: implement bwd for array_cast
-@compare_fwd_and_bwd((nn.Parameter(torch.Tensor(MA(2, 3)))))
+@fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))))
 def test_torch_sum_dtype(x):
     return torch.sum(x, dtype=torch.float64)
 """
 
 
-@compare_fwd_and_bwd((nn.Parameter(torch.Tensor(MA(2, 3)))))
+@fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))))
 def test_torch_sum_dim(x):
     return torch.sum(x, -1)
 
 
-@compare_fwd_and_bwd((nn.Parameter(torch.Tensor(MA(2, 3))), 1, True),
-                     (nn.Parameter(torch.Tensor(MA(2, 3))), 0, False),
-                     broad_specs=(True, False, False))
+@mt(
+    fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))), 1, True),
+    fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))), 0, False),
+    broad_specs=(True, False, False)
+)
 def test_torch_sum_dim_keepdim(x, y, z):
     return torch.sum(x, y, z)
 
 
-@compare_fwd_and_bwd((nn.Parameter(torch.Tensor(torch.randn(2, 3, 4, 5)))))
+@fwd_and_bwd(nn.Parameter(torch.Tensor(torch.randn(2, 3, 4, 5))))
 def test_torch_sum_multi_dim(x):
     return torch.sum(x, (1, 3))
 
 
-@compare_fwd_and_bwd((nn.Parameter(torch.Tensor(torch.randn(2, 4, 3, 5)))))
+@fwd_and_bwd(nn.Parameter(torch.Tensor(torch.randn(2, 4, 3, 5))))
 def test_torch_tensor_transpose(x):
     return x.transpose(3, 1)
 
 
-@compare_fwd(())
+@run()
 def test_torch_zeros():
     return torch.zeros(2, 3)
 
 
-@compare_fwd(())
+@run()
 def test_torch_zeros_dtype():
     return torch.zeros(2, 3, dtype=torch.float64)

--- a/tests/multitest.py
+++ b/tests/multitest.py
@@ -90,7 +90,7 @@ class MyiaFunctionTest(Partializable):
         return self.runtest(self, fn, **self.spec)
 
     def __call__(self, fn):
-        return mt(self)
+        return mt(self)(fn)
 
 
 class myia_function_test:

--- a/tests/multitest.py
+++ b/tests/multitest.py
@@ -97,7 +97,7 @@ class MyiaFunctionTest:
         if isinstance(expected, type) and issubclass(expected, Exception):
             try:
                 res = run()
-            except expected as err:
+            except expected:
                 pass
             else:
                 raise Exception(

--- a/tests/multitest.py
+++ b/tests/multitest.py
@@ -1,4 +1,5 @@
 
+from itertools import product
 from types import FunctionType
 
 import numpy as np
@@ -9,6 +10,8 @@ from myia.pipeline import standard_debug_pipeline, standard_pipeline
 from myia.utils import keyword_decorator, merge, overload
 
 from .common import to_abstract_test
+
+ParameterSet = type(pytest.param(1234))
 
 
 @overload
@@ -37,6 +40,17 @@ run_pipeline = standard_pipeline
 run_debug_pipeline = standard_debug_pipeline
 
 
+class Multiple:
+    def __init__(self, *params, **options):
+        self.options = []
+        for i, param in enumerate(params):
+            assert isinstance(param, ParameterSet)
+            self.options.append(
+                (self, param.id, param.marks, param.values[0])
+            )
+        self.options += [(self, id, [], v) for id, v in options.items()]
+
+
 def mt(*tests, **kwargs):
     def deco(fn):
         def runtest(test):
@@ -44,7 +58,7 @@ def mt(*tests, **kwargs):
         pytests = []
         for test in tests:
             test = test.configure(**kwargs)
-            pytests.append(test.make_param())
+            pytests += test.generate_params()
         runtest = pytest.mark.parametrize('test', pytests)(runtest)
         return runtest
     return deco
@@ -86,11 +100,33 @@ class MyiaFunctionTest:
                     f'Mismatch: expected {expected}, got {res}'
                 )
 
-    def make_param(self):
-        p = pytest.param(self,
-                         marks=self.spec.get('marks', []),
-                         id=self.spec.get('id', None))
-        return p
+    def generate_params(self):
+        marks = self.spec.get('marks', [])
+        id = self.spec.get('id', 'test')
+        spec = dict(self.spec)
+        for key in ('marks', 'id'):
+            if key in spec:
+                del spec[key]
+
+        multis = [(k, v) for k, v in self.spec.items()
+                  if isinstance(v, Multiple)]
+        options = list(product(*[v.options for _, v in multis]))
+        params = []
+        for option in options:
+            curr_spec = dict(spec)
+            curr_ids = []
+            curr_marks = list(marks)
+            for (spec_k, _), opt_info in zip(multis, option):
+                mul, opt_id, opt_marks, value = opt_info
+                curr_spec[spec_k] = value
+                curr_ids.append(opt_id)
+                curr_marks += opt_marks
+            curr_ids.append(id)
+            p = pytest.param(self.configure(**curr_spec),
+                             marks=curr_marks, id="-".join(curr_ids))
+            params.append(p)
+
+        return params
 
     def run(self, fn):
         spec = dict(self.spec)

--- a/tests/multitest.py
+++ b/tests/multitest.py
@@ -35,10 +35,6 @@ infer_pipeline = standard_pipeline.select(
     'resources', 'parse', 'infer'
 )
 
-run_pipeline = standard_pipeline
-
-run_debug_pipeline = standard_debug_pipeline
-
 
 class Multiple:
     def __init__(self, *params, **options):
@@ -176,12 +172,14 @@ def infer(self, fn, args, result=None, pipeline=infer_pipeline):
 
 
 @myia_function_test(marks=[pytest.mark.run], id='run')
-def run(self, fn, args, result=None, abstract=None,
-        validate=True, pipeline=run_pipeline):
+def run(self, fn, args, result=None, abstract=None, broad_specs=None,
+        validate=True, pipeline=standard_pipeline):
 
     if abstract is None:
-        argspec = tuple(from_value(arg, broaden=True)
-                        for arg in args)
+        if broad_specs is None:
+            broad_specs = (True,) * len(args)
+        argspec = tuple(from_value(arg, broaden=bs)
+                        for bs, arg in zip(broad_specs, args))
     else:
         argspec = tuple(to_abstract_test(a) for a in abstract)
 
@@ -200,4 +198,4 @@ def run(self, fn, args, result=None, abstract=None,
     self.check(out, result)
 
 
-run_debug = run.configure(pipeline=run_debug_pipeline, validate=False)
+run_debug = run.configure(pipeline=standard_debug_pipeline, validate=False)

--- a/tests/multitest.py
+++ b/tests/multitest.py
@@ -1,0 +1,151 @@
+
+from types import FunctionType
+
+import numpy as np
+import pytest
+
+from myia.lib import concretize_abstract, from_value
+from myia.pipeline import standard_debug_pipeline, standard_pipeline
+from myia.utils import Partializable, overload
+
+from .common import to_abstract_test
+
+
+@overload
+def eqtest(t1: tuple, t2, **kwargs):
+    return (isinstance(t2, tuple)
+            and all(eqtest(x1, x2, **kwargs) for x1, x2 in zip(t1, t2)))
+
+
+@overload  # noqa: F811
+def eqtest(a1: (np.ndarray, int, float), a2,
+           rtol=1e-5, atol=1e-8, **kwargs):
+    return np.allclose(a1, a2, rtol=rtol, atol=atol)
+
+
+@overload  # noqa: F811
+def eqtest(x: object, y, **kwargs):
+    return x == y
+
+
+infer_pipeline = standard_pipeline.select(
+    'resources', 'parse', 'infer'
+)
+
+run_pipeline = standard_pipeline
+
+run_debug_pipeline = standard_debug_pipeline
+
+
+def mt(*tests):
+    def deco(fn):
+        def runtest(test):
+            test.run(fn)
+        pytests = [
+            pytest.param(test, marks=test.marks, id=test.id)
+            for test in tests
+        ]
+        runtest = pytest.mark.parametrize('test', pytests)(runtest)
+        return runtest
+    return deco
+
+
+class MyiaFunctionTest(Partializable):
+
+    def __init__(self, runtest, args, kwargs, marks=[], id=None):
+        self.spec = {'args': args, **kwargs}
+        self.runtest = runtest
+        self.name = runtest.__qualname__
+        if not isinstance(marks, (list, tuple)):
+            marks = [marks]
+        marks.append(getattr(pytest.mark, self.name))
+        self.marks = marks
+        self.id = id or self.name
+
+    def check(self, run, expected):
+        if isinstance(expected, type) and issubclass(expected, Exception):
+            try:
+                res = run()
+            except expected as err:
+                pass
+            else:
+                raise Exception(
+                    f'Expected an error of type {expected}, '
+                    f'but got result {res}'
+                )
+        else:
+            res = run()
+            if isinstance(expected, FunctionType):
+                if not expected(res):
+                    raise Exception(
+                        f'Failed the result check function'
+                    )
+
+            elif not eqtest(res, expected):
+                raise Exception(
+                    f'Mismatch: expected {expected}, got {res}'
+                )
+
+    def run(self, fn):
+        return self.runtest(self, fn, **self.spec)
+
+    def __call__(self, fn):
+        return mt(self)
+
+
+class myia_function_test:
+    def __init__(self, runtest, spec={}):
+        self.runtest = runtest
+        self.spec = spec
+
+    def configure(self, **spec):
+        return myia_function_test(self.runtest, {**self.spec, **spec})
+
+    def xfail(self, *args, **kwargs):
+        return self(*args, **kwargs, marks=[pytest.mark.xfail])
+
+    def __call__(self, *args, marks=[], id=None, **kwargs):
+        kwargs = {**self.spec, **kwargs}
+        return MyiaFunctionTest(self.runtest, args, kwargs, marks, id)
+
+
+@myia_function_test
+def infer(self, fn, args, result=None, pipeline=infer_pipeline):
+    args = [to_abstract_test(arg) for arg in args]
+
+    def out():
+        pip = pipeline.make()
+        res = pip(input=fn, argspec=args)
+        rval = res['outspec']
+        rval = concretize_abstract(rval)
+        return rval
+
+    self.check(out, to_abstract_test(result))
+
+
+@myia_function_test
+def run(self, fn, args, result=None, abstract=None,
+        validate=True, pipeline=run_pipeline):
+
+    if abstract is None:
+        argspec = tuple(from_value(arg, broaden=True)
+                        for arg in args)
+    else:
+        argspec = tuple(to_abstract_test(a) for a in abstract)
+
+    if not validate:
+        pipeline = pipeline.configure(validate=False)
+
+    def out():
+        pip = pipeline.make()
+        mfn = pip(input=fn, argspec=argspec)
+        rval = mfn['output'](*args)
+        return rval
+
+    if result is None:
+        result = fn(*args)
+
+    self.check(out, result)
+
+
+run_debug = run.configure(pipeline=run_debug_pipeline, validate=False)

--- a/tests/prim/test_py_implementations.py
+++ b/tests/prim/test_py_implementations.py
@@ -42,7 +42,7 @@ from myia.operations import (
     tuple_getitem,
     tuple_setitem,
 )
-from myia.pipeline import scalar_debug_pipeline, standard_debug_pipeline
+from myia.pipeline import scalar_debug_pipeline
 from myia.utils import assert_scalar, newenv
 
 from ..common import AA, f16, i64, to_abstract_test

--- a/tests/prim/test_py_implementations.py
+++ b/tests/prim/test_py_implementations.py
@@ -46,142 +46,231 @@ from myia.pipeline import scalar_debug_pipeline, standard_debug_pipeline
 from myia.utils import assert_scalar, newenv
 
 from ..common import AA, f16, i64, to_abstract_test
-from ..test_lang import parse_compare
+from ..multitest import mt, run_debug
+from ..test_lang import run_lang
 
 
-@parse_compare((2, 7), (4, -6))
+@mt(
+    run_lang(2, 7),
+    run_lang(4, -6),
+)
 def test_prim_add(x, y):
     return x + y
 
 
-@parse_compare((2, 7), (4, -6))
+@mt(
+    run_lang(2, 7),
+    run_lang(4, -6),
+)
 def test_prim_sub(x, y):
     return x - y
 
 
-@parse_compare((2, 7), (4, -6))
+@mt(
+    run_lang(2, 7),
+    run_lang(4, -6),
+)
 def test_prim_mul(x, y):
     return x * y
 
 
-@parse_compare((2.0, 7.0), (4.0, -6.0), (-11, 2),
-               pipeline=standard_debug_pipeline)
+@mt(
+    run_debug(2.0, 7.0),
+    run_debug(4.0, -6.0),
+    run_debug(-11, 2),
+)
 def test_prim_truediv(x, y):
     return x / y
 
 
-@parse_compare((2, 7), (4, -6), (-11, 2), (-11.0, 2.0), (0, -1),
-               pipeline=standard_debug_pipeline)
+@mt(
+    run_debug(2, 7),
+    run_debug(4, -6),
+    run_debug(-11, 2),
+    run_debug(-11.0, 2.0),
+    run_debug(0, -1),
+)
 def test_prim_floordiv(x, y):
     return x // y
 
 
-@parse_compare((2, 7), (4, -6))
+@mt(
+    run_lang(2, 7),
+    run_lang(4, -6),
+)
 def test_prim_mod(x, y):
     return x % y
 
 
-@parse_compare((2, 7), (4, -6))
+@mt(
+    run_lang(2, 7),
+    run_lang(4, -6),
+)
 def test_prim_pow(x, y):
     return x ** y
 
 
-@parse_compare(-2, 2.3, -0.6, pipeline=scalar_debug_pipeline)
+@mt(
+    run_debug(-2),
+    run_debug(2.3),
+    run_debug(-0.6),
+)
 def test_prim_floor(x):
     return math.floor(x)
 
 
-@parse_compare((2, 7), (4, -6.0), (0, -1), (-3.2, 0.0))
+@mt(
+    run_lang(2, 7),
+    run_lang(4, -6.0),
+    run_lang(0, -1),
+    run_lang(-3.2, 0.0),
+)
 def test_prim_max(x, y):
     return scalar_max(x, y)
 
 
-@parse_compare(-2, 2.3, -0.6)
+@mt(
+    run_lang(-2),
+    run_lang(2.3),
+    run_lang(-0.6),
+)
 def test_prim_trunc(x):
     return math_trunc(x)
 
 
-@parse_compare(2, -6)
+@mt(
+    run_lang(2),
+    run_lang(-6),
+)
 def test_prim_uadd(x):
     return +x
 
 
-@parse_compare(2, -6)
+@mt(
+    run_lang(2),
+    run_lang(-6),
+)
 def test_prim_usub(x):
     return -x
 
 
-@parse_compare(13, 0, -3)
+@mt(
+    run_lang(13),
+    run_lang(0),
+    run_lang(-3),
+)
 def test_prim_exp(x):
     return math_exp(x)
 
 
-@parse_compare(13, 1)
+@mt(
+    run_lang(13),
+    run_lang(1),
+)
 def test_prim_log(x):
     return math_log(x)
 
 
-@parse_compare(13, -3)
+@mt(
+    run_lang(13),
+    run_lang(-3),
+)
 def test_prim_sin(x):
     return math_sin(x)
 
 
-@parse_compare(13, -3)
+@mt(
+    run_lang(13),
+    run_lang(-3),
+)
 def test_prim_cos(x):
     return math_cos(x)
 
 
-@parse_compare(13, -3)
+@mt(
+    run_lang(13),
+    run_lang(-3),
+)
 def test_prim_tan(x):
     return math_tan(x)
 
 
-@parse_compare(-0.1, 0.3)
+@mt(
+    run_lang(-0.1),
+    run_lang(0.3),
+)
 def test_prim_tanh(x):
     return math_tanh(x)
 
 
-@parse_compare((2, 7), (4, -6))
+@mt(
+    run_lang(2, 7),
+    run_lang(4, -6),
+)
 def test_prim_eq(x, y):
     return x == y
 
 
-@parse_compare((2, 7), (4, -6))
+@mt(
+    run_lang(2, 7),
+    run_lang(4, -6),
+)
 def test_prim_lt(x, y):
     return x < y
 
 
-@parse_compare((2, 7), (4, -6))
+@mt(
+    run_lang(2, 7),
+    run_lang(4, -6),
+)
 def test_prim_gt(x, y):
     return x > y
 
 
-@parse_compare((2, 7), (4, -6))
+@mt(
+    run_lang(2, 7),
+    run_lang(4, -6),
+)
 def test_prim_ne(x, y):
     return x != y
 
 
-@parse_compare((2, 7), (4, -6))
+@mt(
+    run_lang(2, 7),
+    run_lang(4, -6),
+)
 def test_prim_le(x, y):
     return x <= y
 
 
-@parse_compare((2, 7), (4, -6))
+@mt(
+    run_lang(2, 7),
+    run_lang(4, -6),
+)
 def test_prim_ge(x, y):
     return x >= y
 
 
-@parse_compare((True,), (False,))
+@mt(
+    run_lang(True),
+    run_lang(False),
+)
 def test_prim_not_(x):
     return not x
 
 
-@parse_compare((2, 7), (4, -6))
+@mt(
+    run_lang(2, 7),
+    run_lang(4, -6),
+)
 def test_prim_tuple(x, y):
     return x, y
 
 
-@parse_compare(((1, 2, 3), 0), ((4, -6, 7), 2))
+@mt(
+    run_lang((1, 2, 3), 0),
+    run_lang((4, -6, 7), 2),
+)
 def test_prim_tuple_getitem(data, item):
     return tuple_getitem(data, item)
 
@@ -303,7 +392,7 @@ def test_prim_dot():
     assert (res == ref).all()
 
 
-@parse_compare((40,),)
+@run_lang(40)
 def test_prim_partial(x):
     def f(a, b):
         return a + b

--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -12,6 +12,7 @@ from myia.abstract import (
     DEAD,
     TYPE,
     VALUE,
+    AbstractBottom,
     AbstractClass,
     AbstractError,
     AbstractFunction,
@@ -240,6 +241,9 @@ def test_repr():
     tu1 = AbstractTaggedUnion([[13, s2], [4, to_abstract_test(i16)]])
     assert repr(tu1) == \
         'AbstractTaggedUnion(U(4 :: Int[16], 13 :: Float[32]))'
+
+    bot = AbstractBottom()
+    assert repr(bot) == 'AbstractBottom(⊥)'
 
 
 def test_repr_recursive():

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -14,7 +14,6 @@ from myia.pipeline import standard_pipeline
 from .common import MA, MB, Point, make_tree, sumtree
 from .multitest import mt, run
 
-
 run_no_opt = run.configure(
     pipeline=standard_pipeline.configure({'opt.phases.main': []})
 )

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -14,60 +14,49 @@ from myia.pipeline import standard_pipeline
 from .common import MA, MB, Point, make_tree, sumtree
 from .multitest import mt, run
 
-compile_pipeline = standard_pipeline
+
+run_no_opt = run.configure(
+    pipeline=standard_pipeline.configure({'opt.phases.main': []})
+)
 
 
-def parse_compare(*entries, optimize=True):
-    """Decorate a function to parse and run it against pure Python.
-
-    Returns a unit test that will parse the function, and then for
-    each `inputs` tuple in `tests` it will check that the pure Python,
-    undecorated function returns that same output.
-
-    This uses the full myia pipeline.
-
-    Arguments:
-        tests: One or more inputs tuple.
-
-    """
-    pipeline = compile_pipeline if optimize else \
-        compile_pipeline.configure({'opt.phases.main': []})
-
-    mtentries = []
-    for args in entries:
-        if not isinstance(args, tuple):
-            args = (args,)
-        mtentry = run(*args, result=None, pipeline=pipeline)
-        mtentries.append(mtentry)
-    return mt(*mtentries)
-
-
-@parse_compare((2, 3))
+@run(2, 3)
 def test_simple(x, y):
     return x + y
 
 
-@parse_compare((42,))
+@run(42)
 def test_constant(x):
     return x == 42
 
 
-@parse_compare((False, True), (True, True), (True, False), (False, False))
+@mt(
+    run(False, True),
+    run(True, True),
+    run(True, False),
+    run(False, False)
+)
 def test_bool_and(x, y):
     return bool_and(x, y)
 
 
-@parse_compare((22,), (3.0,))
+@mt(
+    run(22),
+    run(3.0),
+)
 def test_dict(v):
     return {'x': v}
 
 
-@parse_compare({'x': 22, 'y': 3.0})
+@run({'x': 22, 'y': 3.0})
 def test_dict_getitem(d):
     return d['x']
 
 
-@parse_compare((33, 42), (42, 33))
+@mt(
+    run(33, 42),
+    run(42, 33),
+)
 def test_if(x, y):
     if x > y:
         return x - y
@@ -75,7 +64,10 @@ def test_if(x, y):
         return y - x
 
 
-@parse_compare((33, 42), (44, 42))
+@mt(
+    run(33, 42),
+    run(44, 42),
+)
 def test_if_nottail(x, y):
     def cap(x):
         if x > 42:
@@ -84,7 +76,7 @@ def test_if_nottail(x, y):
     return y - cap(x)
 
 
-@parse_compare((42, 33))
+@run(42, 33)
 def test_call(x, y):
     def f(x):
         return x * x
@@ -92,7 +84,7 @@ def test_call(x, y):
     return f(x) + f(y)
 
 
-@parse_compare((42,))
+@run(42)
 def test_tailcall(x):
     def fsum(x, a):
         if x == 1:
@@ -102,7 +94,10 @@ def test_tailcall(x):
     return fsum(x, 1)
 
 
-@parse_compare((-1,), (1,))
+@mt(
+    run(-1),
+    run(1),
+)
 def test_callp(x):
     def fn(f, x):
         return f(x)
@@ -113,7 +108,7 @@ def test_callp(x):
     return fn(f, -42)
 
 
-@parse_compare((True, 42, 33))
+@run(True, 42, 33)
 def test_call_hof(c, x, y):
     def f1(x, y):
         return x + y
@@ -130,7 +125,7 @@ def test_call_hof(c, x, y):
     return choose(c)(x, y) + choose(not c)(x, y)
 
 
-@parse_compare((15, 17), optimize=False)
+@run_no_opt(15, 17)
 def test_partial_prim(x, y):
     return partial(scalar_add, x)(y)
 
@@ -148,35 +143,39 @@ def test_switch_nontail():
 
     i64 = from_value(1, broaden=True)
     argspec = (i64, i64)
-    myia_fn = compile_pipeline.run(input=fn,
-                                   argspec=argspec)['output']
+    myia_fn = standard_pipeline.run(input=fn,
+                                    argspec=argspec)['output']
 
     for test in [(6, 23, 23**2), (67, 23, 67**2)]:
         *args, expected = test
         assert myia_fn(*args) == expected
 
 
-@parse_compare((None,),
-               (42,))
+@mt(
+    run(None),
+    run(42),
+)
 def test_is_(x):
     return x is None
 
 
-@parse_compare((None,),
-               (42,))
+@mt(
+    run(None),
+    run(42),
+)
 def test_is_not(x):
     return x is not None
 
 
-@parse_compare((make_tree(3, 1),))
+@run(make_tree(3, 1))
 def test_sumtree(t):
     return sumtree(t)
 
 
-@parse_compare(
-    (1, 1.7, Point(3, 4), (8, 9)),
-    (0, 1.7, Point(3, 4), (8, 9)),
-    (-1, 1.7, Point(3, 4), (8, 9)),
+@mt(
+    run(1, 1.7, Point(3, 4), (8, 9)),
+    run(0, 1.7, Point(3, 4), (8, 9)),
+    run(-1, 1.7, Point(3, 4), (8, 9)),
 )
 def test_tagged(c, x, y, z):
     if c > 0:
@@ -187,30 +186,36 @@ def test_tagged(c, x, y, z):
         return tagged(z)
 
 
-@parse_compare(('hey', 2), ('idk', 5))
+@mt(
+    run('hey', 2),
+    run('idk', 5),
+)
 def test_string_eq(s, x):
     if s == 'idk':
         x = x + 1
     return x
 
 
-@parse_compare(('hey', 2), ('idk', 5))
+@mt(
+    run('hey', 2),
+    run('idk', 5),
+)
 def test_string_ne(s, x):
     if s != 'idk':
         x = x + 1
     return x
 
 
-@parse_compare(('hey',))
+@run('hey')
 def test_string_return(s):
     return s
 
 
-@parse_compare((MA(4, 5)))
+@run(MA(4, 5))
 def test_array_getitem(x):
     return array_getitem(x, (0, 1), (3, 5), (2, 3))
 
 
-@parse_compare((MA(4, 5), MB(2, 2)))
+@run(MA(4, 5), MB(2, 2))
 def test_array_setitem(x, v):
     return array_setitem(x, (0, 1), (3, 5), (2, 3), v)

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -175,27 +175,12 @@ def _grad_test(fn, obj, args,
 
 
 @myia_function_test
-def gradient(self, fn, args, argspec=None,
+def gradient(self, fn, args, abstract=None,
              rel_error=1e-3, pipeline=grad_pipeline):
     _grad_test(fn, fn, args,
                pipeline=pipeline,
                rel_error=rel_error,
-               argspec=argspec)
-
-
-def grad_test(*tests,
-              pipeline=grad_pipeline,
-              rel_error=1e-3,
-              argspec=None):
-    """Tests the gradient of a function."""
-    mtentries = []
-    for args in tests:
-        if not isinstance(args, tuple):
-            args = (args,)
-        mtentry = gradient(*args, pipeline=pipeline,
-                           rel_error=rel_error, argspec=argspec)
-        mtentries.append(mtentry)
-    return mt(*mtentries)
+               argspec=abstract)
 
 
 prim_tests = {
@@ -219,36 +204,39 @@ def test_prim_grads(prim, cases):
         _grad_test(pyi[prim], prim, case)
 
 
-@grad_test((13.0, 14.0))
+@gradient(13.0, 14.0)
 def test_null(x, y):
     """Test null gradient."""
     return 10.0 + 28.0 / 43.0
 
 
-@grad_test((1.0, 4.0), (5.0, -13.0))
+@mt(
+    gradient(1.0, 4.0),
+    gradient(5.0, -13.0),
+)
 def test_grad_add(x, y):
     return x + y
 
 
-@grad_test((3.0, 4.0))
+@gradient(3.0, 4.0)
 def test_grad_expr(x, y):
     return x**3.0 * y**4.0
 
 
-@grad_test((3.0,))
+@gradient(3.0)
 def test_constant(x):
     """Test the use of a literal in the expression."""
     return 18.0 * x
 
 
-@grad_test((3.0,))
+@gradient(3.0)
 def test_dup_args_in_call(x):
     """The naive gradient update rule fails when a function's arguments
     contain the same variable more than once."""
     return x * x
 
 
-@grad_test((3.0,))
+@gradient(3.0)
 def test_quadruple_args_in_call(x):
     """Test that duplicated arguments still cause no problem even if
     there are four of them."""
@@ -257,24 +245,24 @@ def test_quadruple_args_in_call(x):
     return g(x, x, x, x)
 
 
-@grad_test((3.0, 5.0))
+@gradient(3.0, 5.0)
 def test_tuples(x, y):
     tup = x + y, x * y
     z = tup[0] + tup[1]
     return z
 
 
-@grad_test((Point(3.0, 5.0),), pipeline=standard_pipeline)
+@gradient(Point(3.0, 5.0), pipeline=standard_pipeline)
 def test_dataclass(pt):
     return pt.x * pt.y
 
 
-@grad_test((Point(3.0, 5.0),), pipeline=standard_pipeline)
+@gradient(Point(3.0, 5.0), pipeline=standard_pipeline)
 def test_dataclass_2(pt):
     return pt.abs()
 
 
-@grad_test((4.0, 5.0))
+@gradient(4.0, 5.0)
 def test_hof(a, b):
     """Test higher order functions."""
     def f(g, x):
@@ -286,7 +274,7 @@ def test_hof(a, b):
     return f(g, a) + f(g, b)
 
 
-@grad_test((4.0, 5.0))
+@gradient(4.0, 5.0)
 def test_hof_tup(a, b):
     """Test higher order functions."""
     def f(gh, x, y):
@@ -297,7 +285,7 @@ def test_hof_tup(a, b):
     return f((scalar_add, scalar_mul), a, b)
 
 
-@grad_test((4.0, 5.0))
+@gradient(4.0, 5.0)
 def test_simple_closure(a, b):
     """Test some trivial closures."""
     def f():
@@ -308,7 +296,7 @@ def test_simple_closure(a, b):
     return f() * g()
 
 
-@grad_test((4.0,))
+@gradient(4.0)
 def test_closure(a):
     """This is the closure test in the paper."""
     def x1(b):
@@ -321,7 +309,10 @@ def test_closure(a):
     return x3
 
 
-@grad_test((4.0, 5.0), (6.4, -7.8))
+@mt(
+    gradient(4.0, 5.0),
+    gradient(6.4, -7.8),
+)
 def test_if(a, b):
     # This is max, but what this is really testing is the most basic
     # if statement, so I prefer to name the test 'test_if'
@@ -331,7 +322,10 @@ def test_if(a, b):
         return b
 
 
-@grad_test((4.0, 5.0), (6.4, -7.8))
+@mt(
+    gradient(4.0, 5.0),
+    gradient(6.4, -7.8),
+)
 def test_if2(a, b):
     if a > b:
         return a * a
@@ -339,7 +333,7 @@ def test_if2(a, b):
         return b + b
 
 
-@grad_test(4.1,)
+@gradient(4.1)
 def test_fact(x):
     def fact(n):
         if n <= 1:
@@ -349,7 +343,7 @@ def test_fact(x):
     return fact(x)
 
 
-@grad_test((4.1,), pipeline=standard_pipeline)
+@gradient(4.1, pipeline=standard_pipeline)
 def test_fact_opt(x):
     def fact(n=x):
         if n <= 1:
@@ -359,7 +353,7 @@ def test_fact_opt(x):
     return fact()
 
 
-@grad_test((4.0,))
+@gradient(4.0)
 def test_while(x):
     rval = x
     while rval < 100:
@@ -367,7 +361,7 @@ def test_while(x):
     return rval
 
 
-@grad_test((4.0, 5.0, 2.0),)
+@gradient(4.0, 5.0, 2.0)
 def test_while_2(x, y, z):
     rval = 0
     # Cannot compare to 0 or finite diff is unstable
@@ -377,7 +371,7 @@ def test_while_2(x, y, z):
     return rval
 
 
-@grad_test(2.0,)
+@gradient(2.0,)
 def test_pow10(x):
     v = x
     j = 0
@@ -390,8 +384,8 @@ def test_pow10(x):
     return v
 
 
-@grad_test(([1.0, 2.0, 3.0, 4.0],),
-           pipeline=standard_debug_pipeline.configure(validate=False))
+@gradient([1.0, 2.0, 3.0, 4.0],
+          pipeline=standard_debug_pipeline.configure(validate=False))
 def test_list_while(xs):
     y = 1.0
     index = 0
@@ -401,7 +395,7 @@ def test_list_while(xs):
     return y
 
 
-@grad_test(([1.0, 2.0, 3.0, 4.0],), pipeline=standard_pipeline)
+@gradient([1.0, 2.0, 3.0, 4.0], pipeline=standard_pipeline)
 def test_list_for(xs):
     y = 1
     for x in xs:
@@ -409,8 +403,8 @@ def test_list_for(xs):
     return y
 
 
-@grad_test(4.5,
-           pipeline=standard_debug_pipeline.configure(validate=False))
+@gradient(4.5,
+          pipeline=standard_debug_pipeline.configure(validate=False))
 def test_exception(x):
     if x > 0:
         return x
@@ -418,7 +412,7 @@ def test_exception(x):
         raise Exception("oh no")
 
 
-@grad_test(4.5,)
+@gradient(4.5)
 def test_nested_closure(x):
     a = x * x
 
@@ -434,7 +428,7 @@ def test_nested_closure(x):
     return f()()
 
 
-@grad_test((4.5, 6.7),)
+@gradient(4.5, 6.7)
 def test_functions_in_tuples(x, y):
     tup = scalar_add, scalar_mul
     f, g = tup
@@ -442,7 +436,7 @@ def test_functions_in_tuples(x, y):
 
 
 @mark.xfail(reason="A DummyInferrer ends up being called")
-@grad_test((4.5, 6.7),)
+@gradient(4.5, 6.7)
 def test_closures_in_tuples(x, y):
     def f():
         return x * y
@@ -455,14 +449,14 @@ def test_closures_in_tuples(x, y):
     return ff() + gg()
 
 
-@grad_test((MA(2, 3), MB(2, 3)),)
+@gradient(MA(2, 3), MB(2, 3))
 def test_array_operations(xs, ys):
     div = array_map(scalar_div, xs, ys)
     sm = array_reduce(scalar_add, div, ())
     return array_to_scalar(sm)
 
 
-@grad_test((3.1, 7.6),)
+@gradient(3.1, 7.6)
 def test_array_operations_distribute(x, y):
     xs = distribute(scalar_to_array(x, AA), (4, 3))
     ys = distribute(scalar_to_array(y, AA), (4, 3))
@@ -471,7 +465,7 @@ def test_array_operations_distribute(x, y):
     return array_to_scalar(sm)
 
 
-@grad_test((MA(2, 3), MB(2, 3)),)
+@gradient(MA(2, 3), MB(2, 3))
 def test_array_operations_reshape(xs, ys):
     xs = reshape(xs, (6,))
     ys = reshape(ys, (6,))
@@ -480,21 +474,21 @@ def test_array_operations_reshape(xs, ys):
     return array_to_scalar(sm)
 
 
-@grad_test((MA(2, 3), MB(2, 3)),)
+@gradient(MA(2, 3), MB(2, 3))
 def test_array_operations_std(xs, ys):
     div = xs / ys
     sm = array_reduce(scalar_add, div, ())
     return array_to_scalar(sm)
 
 
-@grad_test((MA(2, 3), MB(3, 4)),)
+@gradient(MA(2, 3), MB(3, 4))
 def test_dot(x, y):
     d = dot(x, y)
     sm = array_reduce(scalar_add, d, ())
     return array_to_scalar(sm)
 
 
-@grad_test((MA(3, 4), MB(2, 3)),)
+@gradient(MA(3, 4), MB(2, 3))
 def test_transpose(x, y):
     xt = transpose(x, (1, 0))
     yt = transpose(y, (1, 0))
@@ -503,7 +497,7 @@ def test_transpose(x, y):
     return array_to_scalar(sm)
 
 
-@grad_test((MA(3, 4), MB(2, 3), NoTestGrad(1), NoTestGrad(0)),)
+@gradient(MA(3, 4), MB(2, 3), NoTestGrad(1), NoTestGrad(0))
 def test_transpose2(x, y, axis1, axis2):
     perm = (scalar_cast(axis1, u64),
             scalar_cast(axis2, u64))
@@ -514,11 +508,11 @@ def test_transpose2(x, y, axis1, axis2):
     return array_to_scalar(sm)
 
 
-@grad_test(
-    (4.5,),
-    ((5.5, 1.3),),
+@mt(
+    gradient(4.5,),
+    gradient(5.5, 1.3),
     pipeline=standard_pipeline,
-    argspec=(U(f64, (f64, f64)),)
+    abstract=(U(f64, (f64, f64)),)
 )
 def test_union(x):
     if isinstance(x, float):
@@ -528,18 +522,18 @@ def test_union(x):
         return a * b
 
 
-@grad_test(
-    (make_tree(3, 1.0),),
-    (countdown(3.0),),
+@mt(
+    gradient(make_tree(3, 1.0)),
+    gradient(countdown(3.0)),
     pipeline=standard_pipeline,
 )
 def test_sumtree(x):
     return sumtree(x)
 
 
-@grad_test(
-    (make_tree(3, 1.0), 1.0),
-    (countdown(4.0), 1.0),
+@mt(
+    gradient(make_tree(3, 1.0), 1.0),
+    gradient(countdown(4.0), 1.0),
     pipeline=standard_pipeline,
 )
 def test_reducetree(t, init):

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -174,9 +174,19 @@ def _grad_test(fn, obj, args,
     gtest.assert_match()
 
 
-@myia_function_test
+@myia_function_test(marks=[pytest.mark.grad], id='grad')
 def gradient(self, fn, args, abstract=None,
              rel_error=1e-3, pipeline=grad_pipeline):
+    """Test the gradient of a Myia function using finite_differences.
+
+    Arguments:
+        fn: The Myia function to test.
+        args: The args for the function.
+        abstract: The argspec. If None, it will be derived automatically from
+            the args.
+        rel_error: The relative tolerance.
+        pipeline: The pipeline to use.
+    """
     _grad_test(fn, fn, args,
                pipeline=pipeline,
                rel_error=rel_error,
@@ -509,8 +519,8 @@ def test_transpose2(x, y, axis1, axis2):
 
 
 @mt(
-    gradient(4.5,),
-    gradient(5.5, 1.3),
+    gradient(4.5),
+    gradient((5.5, 1.3)),
     pipeline=standard_pipeline,
     abstract=(U(f64, (f64, f64)),)
 )

--- a/tests/test_lang.py
+++ b/tests/test_lang.py
@@ -1,7 +1,7 @@
 
 from pytest import mark
 
-from myia.pipeline import scalar_debug_pipeline, standard_debug_pipeline
+from myia.pipeline import scalar_debug_pipeline
 
 from .common import Point, mysum
 from .multitest import mt, run, run_debug
@@ -386,7 +386,7 @@ def test_closure(x):
 
 
 def test_closure_recur():
-    # This cannot run with parse_compare since we need to reference the
+    # This cannot run with run_lang since we need to reference the
     # top-level function
 
     def f(x, y):

--- a/tests/test_lang.py
+++ b/tests/test_lang.py
@@ -4,33 +4,13 @@ from pytest import mark
 from myia.pipeline import scalar_debug_pipeline, standard_debug_pipeline
 
 from .common import Point, mysum
-from .multitest import mt, run
+from .multitest import mt, run, run_debug
 
 lang_pipeline = scalar_debug_pipeline \
     .select('resources', 'parse', 'resolve', 'export')
 
 
-run_lang = run.configure(result=None, pipeline=lang_pipeline)
-
-
-def parse_compare(*entries, pipeline=lang_pipeline):
-    """Decorate a function to parse and run it against pure Python.
-
-    Returns a unit test that will parse the function, and then for
-    each `inputs` tuple in `tests` it will check that the pure Python,
-    undecorated function returns that same output.
-
-    Arguments:
-        tests: One or more inputs tuple.
-
-    """
-    mtentries = []
-    for args in entries:
-        if not isinstance(args, tuple):
-            args = (args,)
-        mtentry = run_lang(*args, pipeline=pipeline)
-        mtentries.append(mtentry)
-    return mt(*mtentries)
+run_lang = run.configure(pipeline=lang_pipeline)
 
 
 #############
@@ -38,7 +18,7 @@ def parse_compare(*entries, pipeline=lang_pipeline):
 #############
 
 
-@parse_compare(())
+@run_lang()
 def test_constant():
     return 1
 
@@ -48,12 +28,18 @@ def test_constant():
 ###################
 
 
-@parse_compare((1, 4), (5, -13))
+@mt(
+    run_lang(1, 4),
+    run_lang(5, -13),
+)
 def test_prim_add(x, y):
     return x + y
 
 
-@parse_compare(1, -13)
+@mt(
+    run_lang(1),
+    run_lang(-13),
+)
 def test_prim_addct(x):
     return x + 1
 
@@ -63,24 +49,24 @@ def test_prim_addct(x):
 #############
 
 
-@parse_compare(2)
+@run_lang(2)
 def test_parameter(x):
     return x
 
 
-@parse_compare((4, 6))
+@run_lang(4, 6)
 def test_variable(x, y):
     z = x + y
     return z
 
 
-@parse_compare((4, 6))
+@run_lang(4, 6)
 def test_multiple_targets(x, y):
     a, b = c = x, y
     return (a, b, c)
 
 
-@parse_compare(2)
+@run_lang(2)
 def test_multiple_variables(x):
     y = x + 1
     z = x + 2
@@ -88,7 +74,7 @@ def test_multiple_variables(x):
     return w + x + y + z
 
 
-@parse_compare(13)
+@run_lang(13)
 def test_shadow_variable(x):
     x = x * 2
     x = x + 7
@@ -99,7 +85,7 @@ def test_shadow_variable(x):
 c = 2
 
 
-@parse_compare(5)
+@run_lang(5)
 def test_globals(x):
     return x + c
 
@@ -108,12 +94,12 @@ def _f(x):
     return x + 2
 
 
-@parse_compare(5)
+@run_lang(5)
 def test_call_global(x):
     return _f(x)
 
 
-@parse_compare((4, 7))
+@run_lang(4, 7)
 def test_swap(x, y):
     x, y = y + 3, x - 8
     return x, y
@@ -125,37 +111,37 @@ def test_swap(x, y):
 
 
 @mark.skip(reason='This test requires the inference step')
-@parse_compare(13)
+@run_lang(13)
 def test_list(x):
     return [x, x + 1, x + 2]
 
 
-@parse_compare(2, pipeline=scalar_debug_pipeline)
+@run_debug(2)
 def test_dict(x):
     return {'x': x}
 
 
-@parse_compare(13)
+@run_lang(13)
 def test_tuple(x):
     return x, x + 1, x + 2
 
 
-@parse_compare(((1, 2, 3, 4),))
+@run_lang((1, 2, 3, 4))
 def test_getitem(x):
     return x[1]
 
 
-@parse_compare((Point(x=5, y=2)), pipeline=scalar_debug_pipeline)
+@run_debug(Point(x=5, y=2))
 def test_getattr(pt):
     return pt.x
 
 
-@parse_compare((Point(x=5, y=2)), pipeline=scalar_debug_pipeline)
+@run_debug(Point(x=5, y=2))
 def test_getattr_function(pt):
     return getattr(pt, 'x')
 
 
-@parse_compare((2, 3), pipeline=scalar_debug_pipeline)
+@run_debug(2, 3)
 def test_method(x, y):
     return x.__add__(y)
 
@@ -165,7 +151,11 @@ def test_method(x, y):
 ################
 
 
-@parse_compare(-10, 0, 10)
+@mt(
+    run_lang(-10),
+    run_lang(0),
+    run_lang(10),
+)
 def test_if(x):
     if x > 0:
         return 1
@@ -173,7 +163,13 @@ def test_if(x):
         return -1
 
 
-@parse_compare(-100, -5, 5, 100, 0)
+@mt(
+    run_lang(-100),
+    run_lang(-5),
+    run_lang(5),
+    run_lang(100),
+    run_lang(0),
+)
 def test_nested_if(x):
     if x < 0:
         if x < -10:
@@ -189,7 +185,11 @@ def test_nested_if(x):
         return 5
 
 
-@parse_compare(-1, 0, 1)
+@mt(
+    run_lang(-1),
+    run_lang(0),
+    run_lang(1),
+)
 def test_if2(x):
     if x > 0:
         a = 10
@@ -200,7 +200,11 @@ def test_if2(x):
     return a + b
 
 
-@parse_compare(-1, 0, 1)
+@mt(
+    run_lang(-1),
+    run_lang(0),
+    run_lang(1),
+)
 def test_if3(x):
     a = 10
     b = 20
@@ -209,14 +213,20 @@ def test_if3(x):
     return a + b
 
 
-@parse_compare(1, -1)
+@mt(
+    run_lang(1),
+    run_lang(-1),
+)
 def test_multiple_return(x):
     if x > 0:
         return 1
     return 2
 
 
-@parse_compare((7, 3), (1, 3))
+@mt(
+    run_lang(7, 3),
+    run_lang(1, 3),
+)
 def test_max(x, y):
     if x > y:
         return x
@@ -224,32 +234,58 @@ def test_max(x, y):
         return y
 
 
-@parse_compare((7, 3), (-1, 3))
+@mt(
+    run_lang(7, 3),
+    run_lang(-1, 3),
+)
 def test_ifexpr(x, y):
     return x * x if x > 0 else y * y
 
 
-@parse_compare((7, 3), (1, 3))
+@mt(
+    run_lang(7, 3),
+    run_lang(1, 3),
+)
 def test_max_expr(x, y):
     return x if x > y else y
 
 
-@parse_compare((7, 3), (-1, 3), (-3, 1), (-1, -1))
+@mt(
+    run_lang(7, 3),
+    run_lang(-1, 3),
+    run_lang(-3, 1),
+    run_lang(-1, -1),
+)
 def test_and(x, y):
     return x > 0 and y > 0
 
 
-@parse_compare((7, 3), (-1, 3), (-3, 1), (-1, -1))
+@mt(
+    run_lang(7, 3),
+    run_lang(-1, 3),
+    run_lang(-3, 1),
+    run_lang(-1, -1),
+)
 def test_or(x, y):
     return x > 0 or y > 0
 
 
-@parse_compare((7, 3), (-1, 3), (-3, 1), (-1, -1))
+@mt(
+    run_lang(7, 3),
+    run_lang(-1, 3),
+    run_lang(-3, 1),
+    run_lang(-1, -1),
+)
 def test_band(x, y):
     return (x > 0) & (y > 0)
 
 
-@parse_compare((7, 3), (-1, 3), (-3, 1), (-1, -1))
+@mt(
+    run_lang(7, 3),
+    run_lang(-1, 3),
+    run_lang(-3, 1),
+    run_lang(-1, -1),
+)
 def test_bor(x, y):
     return (x > 0) | (y > 0)
 
@@ -259,14 +295,17 @@ def test_bor(x, y):
 ###################
 
 
-@parse_compare((100, 10), (50, 7))
+@mt(
+    run_lang(100, 10),
+    run_lang(50, 7),
+)
 def test_while(x, y):
     while x > 0:
         x = x - y
     return x
 
 
-@parse_compare((10, 10))
+@run_lang(10, 10)
 def test_nested_while(x, y):
     result = 0
     i = x
@@ -279,7 +318,7 @@ def test_nested_while(x, y):
     return result
 
 
-@parse_compare(10)
+@run_lang(10)
 def test_return_in_while(x):
     while x > 0:
         x = x - 1
@@ -287,7 +326,7 @@ def test_return_in_while(x):
     return -1
 
 
-@parse_compare(10)
+@run_lang(10)
 def test_return_in_double_while(x):
     while x > 0:
         while x > 0:
@@ -296,7 +335,7 @@ def test_return_in_double_while(x):
     return -1
 
 
-@parse_compare(10)
+@run_lang(10)
 def test_if_return_in_while(x):
     while x > 0:
         if x == 5:
@@ -311,7 +350,7 @@ def test_if_return_in_while(x):
 #################
 
 
-@parse_compare(((1, 2, 3, 4),), pipeline=standard_debug_pipeline)
+@run_debug((1, 2, 3, 4))
 def test_for(xs):
     result = 0
     for x in xs:
@@ -324,7 +363,7 @@ def test_for(xs):
 ############
 
 
-@parse_compare(())
+@run_lang()
 def test_nested():
     x = 2
 
@@ -333,7 +372,7 @@ def test_nested():
     return g()
 
 
-@parse_compare(50)
+@run_lang(50)
 def test_closure(x):
     def g(y):
         # Closes over x
@@ -367,7 +406,7 @@ def test_closure_recur():
     assert py_result == myia_result
 
 
-@parse_compare(())
+@run_lang()
 def test_closure2():
     def g(x):
         def f():
@@ -376,7 +415,7 @@ def test_closure2():
     return g(2)()
 
 
-@parse_compare(1)
+@run_lang(1)
 def test_closure3(x):
     def g():
         def h():
@@ -385,7 +424,7 @@ def test_closure3(x):
     return g()()
 
 
-@parse_compare(7)
+@run_lang(7)
 def test_closure4(x):
     def f():
         return x
@@ -397,14 +436,14 @@ def test_closure4(x):
     return g(5)
 
 
-@parse_compare(2)
+@run_lang(2)
 def test_fn1(x):
     def g(x):
         return x
     return g(x)
 
 
-@parse_compare(())
+@run_lang()
 def test_fn2():
     def g(x):
         def f():
@@ -413,7 +452,7 @@ def test_fn2():
     return g(2)
 
 
-@parse_compare(())
+@run_lang()
 def test_fn3():
     def g(x):
         def f():
@@ -422,7 +461,7 @@ def test_fn3():
     return g(2)
 
 
-@parse_compare(())
+@run_lang()
 def test_fn4():
     def g(x):
         y = x + 1
@@ -433,7 +472,7 @@ def test_fn4():
     return g(2)
 
 
-@parse_compare(())
+@run_lang()
 def test_fn5():
     def g(x):
         def f(y):
@@ -447,13 +486,13 @@ def test_fn5():
 ###########
 
 
-@parse_compare((5,))
+@run_lang(5)
 def test_lambda(x):
     f = lambda y: x + y  # noqa
     return f(x)
 
 
-@parse_compare((5,))
+@run_lang(5)
 def test_lambda2(x):
     f = lambda y, z: x + y * z  # noqa
     return f(10, x)
@@ -464,7 +503,7 @@ def test_lambda2(x):
 #############
 
 
-@parse_compare(10)
+@run_lang(10)
 def test_rec1(x):
     def f(x):
         if x >= 0:
@@ -479,7 +518,7 @@ def test_rec1(x):
 #############
 
 
-@parse_compare((2, 3, 4), pipeline=scalar_debug_pipeline)
+@run_debug(2, 3, 4)
 def test_multitype(x, y, z):
     return mysum(x) * mysum(x, y) * mysum(x, y, z)
 
@@ -489,7 +528,10 @@ def test_multitype(x, y, z):
 ###############
 
 
-@parse_compare(2, 1)
+@mt(
+    run_lang(2),
+    run_lang(1),
+)
 def test_pow8(x):
     i = 0
     while i < 3:
@@ -498,7 +540,10 @@ def test_pow8(x):
     return x
 
 
-@parse_compare(2, 3)
+@mt(
+    run_lang(2),
+    run_lang(3),
+)
 def test_pow10(x):
     v = x
     j = 0
@@ -511,7 +556,12 @@ def test_pow10(x):
     return v
 
 
-@parse_compare(0, 1, 4, 10)
+@mt(
+    run_lang(0),
+    run_lang(1),
+    run_lang(4),
+    run_lang(10),
+)
 def test_fact(x):
     def fact(n):
         if n <= 1:
@@ -521,6 +571,6 @@ def test_fact(x):
     return fact(x)
 
 
-@parse_compare(42)
+@run_lang(42)
 def test_record(x):
     return Point(x, x)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -13,7 +13,7 @@ from myia.xtype import Array
 
 from .common import MA, MB, MC, MD, af32_of, af64_of
 from .multitest import mt, run
-from .test_grad import grad_test
+from .test_grad import gradient
 from .test_infer import infer_standard
 
 MA = MA * 0.1
@@ -121,8 +121,8 @@ def test_backward_infer(model, x, y):
     return grad(cost)(model, x, y)
 
 
-@grad_test((make_model(), MC(3, 6), MD(3, 8)),
-           pipeline=standard_pipeline,
-           rel_error=1e-1)
+@gradient(make_model(), MC(3, 6), MD(3, 8),
+          pipeline=standard_pipeline,
+          rel_error=1e-1)
 def test_backward_specialize(model, x, y):
     return cost(model, x, y)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -12,8 +12,7 @@ from myia.utils import InferenceError
 from myia.xtype import Array
 
 from .common import MA, MB, MC, MD, af32_of, af64_of
-from .multitest import mt
-from .test_compile import parse_compare
+from .multitest import mt, run
 from .test_grad import grad_test
 from .test_infer import infer_standard
 
@@ -99,13 +98,10 @@ def cost(model, x, y):
                    result=af32_of(3, 8)),
     infer_standard(make_model(), MC(3, 9),
                    result=InferenceError),
+
+    run(make_model(), MC(3, 6)),
 )
-def test_forward_infer(model, x):
-    return model.apply(x)
-
-
-@parse_compare((make_model(), MC(3, 6)))
-def test_forward_specialize(model, x):
+def test_forward(model, x):
     return model.apply(x)
 
 

--- a/tests/test_monomorphize.py
+++ b/tests/test_monomorphize.py
@@ -67,6 +67,10 @@ specialize = specializer_decorator(specialize_pipeline)
 specialize_std = specializer_decorator(specialize_pipeline_std)
 
 
+mono_scalar = run.configure(pipeline=specialize_pipeline)
+mono_standard = run.configure(pipeline=specialize_pipeline_std)
+
+
 int1 = 13
 int2 = 21
 
@@ -89,9 +93,14 @@ pt1 = Point(10, 20)
 pt2 = Point(100, 200)
 
 
-@specialize((int1, int2_np64), (int1_np64, int2_np64),
-            (fp1, fp2_np64), (fp1_np64, fp2_np64),
-            (fp1_np32, fp2_np32), (int1_np32, int2_np32))
+@mt(
+    mono_scalar(int1, int2_np64),
+    mono_scalar(int1_np64, int2_np64),
+    mono_scalar(fp1, fp2_np64),
+    mono_scalar(fp1_np64, fp2_np64),
+    mono_scalar(fp1_np32, fp2_np32),
+    mono_scalar(int1_np32, int2_np32),
+)
 def test_prim_arithmetic_np_same_precision(x, y):
 
     def test_prim_mul_np(x, y):
@@ -114,22 +123,28 @@ def test_prim_arithmetic_np_same_precision(x, y):
     return _a, _b, _c, _d
 
 
-@specialize((int1, int2),
-            (fp1, fp2))
+@mt(
+    mono_scalar(int1, int2),
+    mono_scalar(fp1, fp2),
+)
 def test_prim_mul(x, y):
     return x * y
 
 
-@specialize((int1, int2),
-            (fp1, int1))
+@mt(
+    mono_scalar(int1, int2),
+    mono_scalar(fp1, int1),
+)
 def test_polymorphic(x, y):
     def helper(a, b):
         return a * a + b * b
     return helper(x, x + x), helper(y, y + y)
 
 
-@specialize((int1, int2),
-            (fp1, int1))
+@mt(
+    mono_scalar(int1, int2),
+    mono_scalar(fp1, int1),
+)
 def test_polymorphic_closure(x, y):
     def construct(z):
         def inner(w):
@@ -138,8 +153,10 @@ def test_polymorphic_closure(x, y):
     return construct(x + x)(x), construct(y + y)(y)
 
 
-@specialize((True, int1, int2),
-            (True, fp1, int1))
+@mt(
+    mono_scalar(True, int1, int2),
+    mono_scalar(True, fp1, int1),
+)
 def test_switch_fn(c, x, y):
     def dee(y):
         return y * y
@@ -155,7 +172,10 @@ def test_switch_fn(c, x, y):
     return f(x), f(y)
 
 
-@specialize((int1, int2), (int1, fp1))
+@mt(
+    mono_scalar(int1, int2),
+    mono_scalar(int1, fp1),
+)
 def test_while(n, x):
     rval = x
     while n > 0:
@@ -164,7 +184,10 @@ def test_while(n, x):
     return rval
 
 
-@specialize((int1,), (fp1,))
+@mt(
+    mono_scalar(int1,),
+    mono_scalar(fp1,),
+)
 def test_pow10(x):
     v = x
     j = 0
@@ -177,7 +200,7 @@ def test_pow10(x):
     return v
 
 
-@specialize((int1, fp1))
+@mono_scalar(int1, fp1)
 def test_isinstance(x, y):
     def helper(x):
         if isinstance(x, int):
@@ -190,18 +213,18 @@ def test_isinstance(x, y):
     return helper(x), helper(y), helper(())
 
 
-@specialize((int1, int2))
+@mono_scalar(int1, int2)
 def test_struct(x, y):
     return Point(x, y)
 
 
-@specialize((int1, int2))
+@mono_scalar(int1, int2)
 def test_struct2(x, y):
     p = Point(x, y)
     return p.x + p.y
 
 
-@specialize((np.array([fp1, fp2]),))
+@mono_scalar(np.array([fp1, fp2]))
 def test_array_map(xs):
     def square(x):
         return x * x
@@ -209,8 +232,8 @@ def test_array_map(xs):
     return array_map(square, xs)
 
 
-@specialize((np.array([fp1, fp2]),
-             np.array([int1, int2])))
+@mono_scalar(np.array([fp1, fp2]),
+             np.array([int1, int2]))
 def test_array_map_polymorphic(xs, ys):
     def square(x):
         return x * x
@@ -218,8 +241,8 @@ def test_array_map_polymorphic(xs, ys):
     return array_map(square, xs), array_map(square, ys)
 
 
-@specialize((np.array([fp1, fp2]),
-             np.array([int1, int2])))
+@mono_scalar(np.array([fp1, fp2]),
+             np.array([int1, int2]))
 def test_array_map_polymorphic_indirect(xs, ys):
     def square(x):
         return x * x
@@ -230,8 +253,8 @@ def test_array_map_polymorphic_indirect(xs, ys):
     return helper(square)
 
 
-@specialize((np.array([fp1, fp2]),
-             np.array([int1, int2])))
+@mono_scalar(np.array([fp1, fp2]),
+             np.array([int1, int2]))
 def test_array_reduce_polymorphic_indirect(xs, ys):
     def helper(fn):
         return array_reduce(fn, xs, ()), array_reduce(fn, ys, ())
@@ -239,7 +262,7 @@ def test_array_reduce_polymorphic_indirect(xs, ys):
     return helper(scalar_add)
 
 
-@specialize((int1, np.array([fp1, fp2]),))
+@mono_scalar(int1, np.array([fp1, fp2]))
 def test_array_map_partial(c, xs):
     def square(x):
         return x * x
@@ -254,12 +277,12 @@ def test_array_map_partial(c, xs):
     return fn(xs)
 
 
-@specialize(([fp1, fp2],))
+@mono_scalar([fp1, fp2])
 def test_list_len(xs):
     return len(xs)
 
 
-@specialize(([fp1, fp2],))
+@mono_scalar([fp1, fp2])
 def test_hyper_map(xs):
     def square(x):
         return x * x
@@ -267,7 +290,7 @@ def test_hyper_map(xs):
     return hyper_map(square, xs)
 
 
-@specialize(([fp1, fp2], [int1, int2]))
+@mono_scalar([fp1, fp2], [int1, int2])
 def test_hyper_map_polymorphic(xs, ys):
     def square(x):
         return x * x
@@ -276,7 +299,7 @@ def test_hyper_map_polymorphic(xs, ys):
 
 
 @mark.xfail(reason="Cannot specialize f.")
-@specialize((True, [fp1, fp2], [int1, int2]))
+@mono_scalar(True, [fp1, fp2], [int1, int2])
 def test_hyper_map_polymorphic_2(c, xs, ys):
     def square(x):
         return x * x
@@ -294,12 +317,12 @@ def test_hyper_map_polymorphic_2(c, xs, ys):
     return hyper_map(f, xs), hyper_map(f, ys)
 
 
-@specialize((int1, int2))
+@mono_scalar(int1, int2)
 def test_unused_parameter(x, y):
     return x * x
 
 
-@specialize((int1,))
+@mono_scalar(int1)
 def test_unused_function_parameter(x):
     # The type of square will be AbstractError(DEAD), but that's not really
     # an issue because it is indeed not used, and we can simply replace the
@@ -312,7 +335,7 @@ def test_unused_function_parameter(x):
     return helper(square, x)
 
 
-@specialize((int1,))
+@mono_scalar(int1)
 def test_indirect_primitive(x):
     def add2():
         return scalar_add
@@ -320,7 +343,7 @@ def test_indirect_primitive(x):
     return add2()(x, x)
 
 
-@specialize((int1,))
+@mono_scalar(int1)
 def test_indirect_graph(x):
     def f(x):
         return x * x
@@ -331,7 +354,7 @@ def test_indirect_graph(x):
     return f2()(x)
 
 
-@specialize((True, int1, int2))
+@mono_scalar(True, int1, int2)
 def test_poly_with_constants(c, x, y):
     def f1(x, y):
         return x + y
@@ -348,7 +371,7 @@ def test_poly_with_constants(c, x, y):
     return choose(c)(x, y), choose(not c)(x, y)
 
 
-@specialize((True, int1, int2))
+@mono_scalar(True, int1, int2)
 def test_poly_with_constants2(c, x, y):
     def f1(x, y):
         return x + y
@@ -365,29 +388,38 @@ def test_poly_with_constants2(c, x, y):
     return choose(c)(x, 2), choose(not c)(y, 3)
 
 
-@specialize((int1, int2), (fp1, fp2))
+@mt(
+    mono_scalar(int1, int2),
+    mono_scalar(fp1, fp2),
+)
 def test_method(x, y):
     return x.__add__(y)
 
 
-@specialize((int1, fp1))
+@mono_scalar(int1, fp1)
 def test_method_polymorphic(x, y):
     return x.__add__(x), y.__add__(y)
 
 
-@specialize((int1, fp1))
+@mono_scalar(int1, fp1)
 def test_partial_polymorphic(x, y):
     def f(a, b):
         return a + b
     return partial(f, x)(x), partial(f, y)(y)
 
 
-@specialize((True, int1), (False, int1))
+@mt(
+    mono_scalar(True, int1),
+    mono_scalar(False, int1),
+)
 def test_switch(c, x):
     return switch(c, scalar_usub, scalar_uadd)(x)
 
 
-@specialize((True, int1, int2), (False, int1, int2))
+@mt(
+    mono_scalar(True, int1, int2),
+    mono_scalar(False, int1, int2),
+)
 def test_switch2(c, x, y):
     fn = switch(
         c,
@@ -397,12 +429,12 @@ def test_switch2(c, x, y):
     return fn(y)
 
 
-@specialize((int1, int2, int2))
+@mono_scalar(int1, int2, int2)
 def test_multitype(x, y, z):
     return mysum(x) * mysum(x, y) * mysum(x, y, z)
 
 
-@specialize((int1, int2))
+@mono_scalar(int1, int2)
 def test_closure_stays_in_scope(x, y):
     # The inferrer knows that h(x + y) is the graph for g, but
     # it shouldn't try to replace the expression with that graph,
@@ -419,7 +451,7 @@ def test_closure_stays_in_scope(x, y):
     return h(x + y)()
 
 
-@specialize((int1,))
+@mono_scalar(int1)
 def test_return_closure(x):
     # The specializer should be careful not to replace `f(z - 1)[0]`
     # by a reference to `g`, because `g` is closed over `z` whereas
@@ -435,7 +467,7 @@ def test_return_closure(x):
     return f(x)[1]()
 
 
-@specialize((int1, int2))
+@mono_scalar(int1, int2)
 def test_partial_outside_scope(x, y):
     # The inferrer knows that g(x) is a partial of f, but it can't
     # build it inside the main function.
@@ -449,10 +481,10 @@ def test_partial_outside_scope(x, y):
     return g(x)(y)
 
 
-@specialize_std(
-    (int1,),
-    ([int1, int2],),
-    TypeError((int1, int2),),
+@mt(
+    mono_standard(int1),
+    mono_standard([int1, int2]),
+    mono_standard((int1, int2), result=TypeError),
     abstract=(U(i64, [i64]),)
 )
 def test_union(x):
@@ -462,10 +494,10 @@ def test_union(x):
         return x[0]
 
 
-@specialize_std(
-    (int1, int2),
-    ([int1, int2], int1),
-    TypeError((int1, int2), int1),
+@mt(
+    mono_standard(int1, int2),
+    mono_standard([int1, int2], int1),
+    mono_standard((int1, int2), int1, result=TypeError),
     abstract=(U(i64, f64, [i64]), i64)
 )
 def test_union_nested(x, y):
@@ -477,10 +509,10 @@ def test_union_nested(x, y):
         return x[0]
 
 
-@specialize_std(
-    (int1, int2),
-    ([int1, int2], int1),
-    TypeError((int1, int2), int1),
+@mt(
+    mono_standard(int1, int2),
+    mono_standard([int1, int2], int1),
+    mono_standard((int1, int2), int1, result=TypeError),
     abstract=(U(i64, f64, [i64]), i64)
 )
 def test_union_nested_2(x, y):
@@ -493,10 +525,10 @@ def test_union_nested_2(x, y):
         return x[0]
 
 
-@specialize(
-    (1, fp1, pt1, (int1, int2)),
-    (0, fp1, pt1, (int1, int2)),
-    (-1, fp1, pt1, (int1, int2)),
+@mt(
+    mono_scalar(1, fp1, pt1, (int1, int2)),
+    mono_scalar(0, fp1, pt1, (int1, int2)),
+    mono_scalar(-1, fp1, pt1, (int1, int2)),
 )
 def test_tagged(c, x, y, z):
     if c > 0:
@@ -507,62 +539,57 @@ def test_tagged(c, x, y, z):
         return tagged(z)
 
 
-@specialize(
-    (int1, int2),
-    (pt1, int1),
-    (pt1, pt2),
+@mt(
+    mono_scalar(int1, int2),
+    mono_scalar(pt1, int1),
+    mono_scalar(pt1, pt2),
 )
 def test_hyper_map_scalar_add(x, y):
     return hyper_map(scalar_add, x, y)
 
 
-@specialize((int1,))
+@mono_scalar(int1)
 def test_hyper_map_ct(x):
     return hyper_map(scalar_add, x, 1)
 
 
-@specialize_std(
-    (make_tree(3, 1),),
-    (countdown(10),)
+@mt(
+    mono_standard(make_tree(3, 1)),
+    mono_standard(countdown(10)),
 )
 def test_sumtree(t):
     return sumtree(t)
 
 
-@specialize_std(
-    (make_tree(3, 1),),
-    (countdown(10),)
+@mt(
+    mono_standard(make_tree(3, 1)),
+    mono_standard(countdown(10)),
 )
 def test_reducetree(t):
     return reducetree(scalar_mul, t, 1)
 
 
-@specialize(
-    (make_tree(3, 1),),
-    validate=False
-)
+@mono_scalar(make_tree(3, 1), validate=False)
 def test_hypermap_tree(t):
     return hyper_map(scalar_add, t, t)
 
 
-@specialize_std(((int1, int2), (fp1, fp2)),)
+@mono_standard((int1, int2), (fp1, fp2))
 def test_tuple_surgery(xs, ys):
     return xs[::-1]
 
 
-@specialize(
-    (int1,),
-    (fp1,),
-    (int1, int2),
-    (int1, int2, int1),
+@mt(
+    mono_scalar(int1),
+    mono_scalar(fp1),
+    mono_scalar(int1, int2),
+    mono_scalar(int1, int2, int1),
 )
 def test_default_arg(x, y=3, z=6):
     return x + y + z
 
 
-@specialize(
-    (int1, int2),
-)
+@mono_scalar(int1, int2)
 def test_default_closure(x, y):
     def clos(z=y + y):
         if x > z:
@@ -572,9 +599,7 @@ def test_default_closure(x, y):
     return clos() + clos(x)
 
 
-@specialize(
-    (1, 2, 3, 4, 5),
-)
+@mono_scalar(1, 2, 3, 4, 5)
 def test_varargs(x, *args):
     return args[1]
 
@@ -583,13 +608,13 @@ def _v(x, *args):
     return x + args[-1]
 
 
-@specialize((int1, int2))
+@mono_scalar(int1, int2)
 def test_varargs_2(x, y):
     argos = (1, 2, 3, 4, 5)
     return _v(x, 1, 2, 3) + _v(y, 5) + _v(*argos, 6, *(4, 5))
 
 
-@specialize((int1, int2),)
+@mono_scalar(int1, int2)
 def test_keywords(x, y):
     def fn(albert, beatrice):
         return albert - beatrice
@@ -597,7 +622,7 @@ def test_keywords(x, y):
     return fn(albert=x, beatrice=y) + fn(beatrice=3, albert=7)
 
 
-@specialize((int1, int2),)
+@mono_scalar(int1, int2)
 def test_keywords_2(x, y):
     def fn1(x, albert, beatrice):
         return albert * (x - beatrice)
@@ -610,7 +635,7 @@ def test_keywords_2(x, y):
     return fn(5, albert=x, beatrice=y) + fn(9, albert=3, beatrice=7)
 
 
-@specialize((int1, int2),)
+@mono_scalar(int1, int2)
 def test_keywords_defaults(x, y):
     def fn(albert=1, beatrice=10):
         return albert - beatrice
@@ -618,7 +643,7 @@ def test_keywords_defaults(x, y):
     return fn(beatrice=x + y)
 
 
-@specialize((int1, int2),)
+@mono_scalar(int1, int2)
 def test_kwarg(x, y):
     def fn(albert=1, beatrice=10):
         return albert - beatrice
@@ -629,7 +654,7 @@ def test_kwarg(x, y):
     return proxy(x, beatrice=y), proxy(x, y), proxy(beatrice=x, albert=y)
 
 
-@specialize_std((),)
+@mono_standard()
 def test_reference_bug():
     orig = (4, 1, 6)
     shp = ()
@@ -639,7 +664,7 @@ def test_reference_bug():
     return shp
 
 
-@specialize((int1,),)
+@mono_scalar(int1)
 def test_fib(n):
     a = 1
     b = 1
@@ -648,10 +673,10 @@ def test_fib(n):
     return a
 
 
-@specialize_std(
-    ([11, 22, 33], [44, 55, 66]),
-    ((11, 22, 33), (44, 55, 66)),
-    validate=False
+@mt(
+    mono_standard([11, 22, 33], [44, 55, 66]),
+    mono_standard((11, 22, 33), (44, 55, 66)),
+    validate=False,
 )
 def test_zip_enumerate(xs, ys):
     rval = 0
@@ -667,7 +692,7 @@ def list_reduce(fn, lst, dftl):
     return res
 
 
-@specialize_std(([int1, int2],))
+@mono_standard([int1, int2])
 def test_list_reduce(xs):
     def add(x, y):
         return x + y

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -1,10 +1,7 @@
 import numpy as np
 
 from myia.operations import array_map, array_reduce, array_scan, scalar_usub
-from myia.pipeline import (
-    scalar_debug_compile as compile,
-    standard_debug_pipeline,
-)
+from myia.pipeline import scalar_debug_compile as compile
 
 from .multitest import mt
 from .test_lang import run_debug

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -6,15 +6,22 @@ from myia.pipeline import (
     standard_debug_pipeline,
 )
 
-from .test_lang import parse_compare
+from .multitest import mt
+from .test_lang import run_debug
 
 
-@parse_compare((2, 3), (2.0, 3.0), pipeline=standard_debug_pipeline)
+@mt(
+    run_debug(2, 3),
+    run_debug(2.0, 3.0),
+)
 def test_vm_floordiv(x, y):
     return x // y
 
 
-@parse_compare((2, 3), (2.0, 3.0), pipeline=standard_debug_pipeline)
+@mt(
+    run_debug(2, 3),
+    run_debug(2.0, 3.0),
+)
 def test_vm_truediv(x, y):
     return x / y
 

--- a/tests/utils/test_merge.py
+++ b/tests/utils/test_merge.py
@@ -1,5 +1,14 @@
 
-from myia.utils import DELETE, Merge, Override, Reset, TypeMap, cleanup, merge
+from myia.utils import (
+    DELETE,
+    Merge,
+    Override,
+    Registry,
+    Reset,
+    TypeMap,
+    cleanup,
+    merge,
+)
 
 
 def test_merge():
@@ -17,6 +26,19 @@ def test_merge():
 
     dlt = dict(c=DELETE, d=3)
     assert merge(a, dlt) == dict(a=1, b=2, d=3)
+
+
+def test_merge_registry():
+
+    a = Registry()
+    a.update(dict(a=1, b=2, c=3))
+    b = Registry()
+    b.update(dict(d=4))
+    c = Registry()
+    c.update(dict(a=1, b=2, c=3, d=4))
+
+    assert merge(a, b) == c
+    assert type(merge(a, b)) is Registry
 
 
 def test_merge_subclass():


### PR DESCRIPTION
This consolidates the boilerplate around testing a Myia function into the `tests.multitest` helper module. The `@mt(...)` decorator declares a "multitest", and an arbitrary number of tests can be listed inside it. For example:

```python
@mt(
    # Test type inference
    infer(i64, i64, result=i64),
    infer(f64, i64, result=InferenceError),
    # Compare the result with the Python version of the function
    run(4, 5),
    # Check that the result is as specified, and specify a test id for pytest
    run(10, 32, result=42, id='the_answer'),
    # Check the gradient at the given point using finite differences, and add a pytest mark
    gradient(5.1, 3.4, marks=[pytest.mark.scrumptious]),
)
def test_add(x, y):
    return x + y
```

It is also possible to use `infer`, `run`, etc. as decorators, to run a single test. It is easy to define new decorators to perform other sorts of tests, either using `@myia_test_function`, or using `new_decorator = decorator.configure(**kwargs)` to change the defaults.

The tests define relevant marks, so `pytest -m infer` will run all type inference tests.

All the relevant tests are moved to the new system. The three different versions of `parse_compare` are no more :)
