### PR TITLE
Add dtype macro

### DIFF
--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -6,7 +6,7 @@ from functools import reduce
 
 from .. import operations, xtype
 from ..info import About
-from ..ir import Graph
+from ..ir import Constant, Graph
 from ..operations import primitives as P
 from ..utils import (
     InferenceError,

--- a/myia/abstract/utils.py
+++ b/myia/abstract/utils.py
@@ -293,6 +293,8 @@ def abstract_clone(self, d: TrackDict, *args):
 
 @overload  # noqa: F811
 def abstract_clone(self, x: AbstractTuple, *args):
+    if x.elements is ANYTHING:
+        return (yield AbstractTuple)(ANYTHING)
     return (yield AbstractTuple)(
         [self(y, *args) for y in x.elements],
         self(x.values, *args)

--- a/myia/compile/backends/pytorch.py
+++ b/myia/compile/backends/pytorch.py
@@ -107,7 +107,7 @@ def pytorch_scalar_cast(op):
     """Implementation of scalar_cast."""
     v = op.inputs[1]
     assert op.inputs[2].is_constant()
-    dtype = type_to_np_dtype(op.inputs[2].value)
+    dtype = type_to_np_dtype(op.inputs[2].value.xtype())
 
     def _impl(v):
         return (v.astype(dtype),)
@@ -117,7 +117,7 @@ def pytorch_scalar_cast(op):
 def pytorch_array_cast(op):
     """Implementation of array_cast for pytorch."""
     t = op.inputs[2]
-    dt = _type_map[t.value]
+    dt = _type_map[t.value.xtype()]
 
     def _impl(x):
         return (x.to(dtype=dt),)

--- a/myia/frontends/pytorch.py
+++ b/myia/frontends/pytorch.py
@@ -82,6 +82,7 @@ standard_method_map[PyTorchTensor] = \
     standard_method_map[NDArray].copy()
 standard_method_map[PyTorchTensor].update({
     'dim': operations.ndim,
+    'dtype': property(operations.dtype),
     'argmax': argmax,
     'exp': operations.array_exp,
     'gather': gather,

--- a/myia/frontends/pytorch.py
+++ b/myia/frontends/pytorch.py
@@ -18,6 +18,7 @@ from ..abstract.data import (
 from ..abstract.infer import to_abstract
 from ..hypermap import hyper_map
 from ..operations import primitives as P
+from ..pipeline.resources import default_convert
 from ..pipeline.standard import standard_method_map, standard_object_map
 from ..utils import core
 from ..xtype import NDArray
@@ -197,6 +198,11 @@ def _to_abstract(self, v: torch.nn.Parameter, **kwargs):
         }),
         {SHAPE: tuple(v.shape), TYPE: PyTorchTensor},
     )
+
+
+@default_convert.register  # noqa: F811
+def _default_convert(env, x: torch.dtype):
+    return default_convert(env, pytorch_dtype_to_type(x))
 
 
 __all__ = [

--- a/myia/frontends/pytorch_functions.py
+++ b/myia/frontends/pytorch_functions.py
@@ -27,7 +27,7 @@ from ..ir import Constant
 from ..operations import primitives as P
 from ..utils import MyiaValueError, core
 from ..xtype import TupleT, f32, i64, u64
-from .pytorch_abstract_types import APT, pytorch_dtype_to_type
+from .pytorch_abstract_types import APT
 
 # ############# THESE FUNCTIONS SHOULD BE IN ALPHABETICAL ORDER #############
 

--- a/myia/frontends/pytorch_functions.py
+++ b/myia/frontends/pytorch_functions.py
@@ -34,10 +34,6 @@ from .pytorch_abstract_types import APT, pytorch_dtype_to_type
 
 # HELPER FUNCTIONS ##########################################################
 
-@myia_static
-def _pt_dtype_to_my_dtype(dtype):
-    return pytorch_dtype_to_type(dtype)
-
 
 @macro
 async def _dim_explicit(info, a_shp_ref, dim_ref):
@@ -232,7 +228,7 @@ def log_softmax(self, dim=None, dtype=None):
     dim = _dim_explicit(x.shape, dim)
 
     if dtype is not None:
-        x = P.array_cast(x, _pt_dtype_to_my_dtype(dtype))
+        x = P.array_cast(x, dtype)
 
     maxes = torch.max(x, dim, keepdim=True)[0]
     lse_stable = torch.log(torch.sum(torch.exp(x - maxes), dim, keepdim=True))
@@ -342,7 +338,7 @@ def softmax(self, dim=None, dtype=None):
     dim = _dim_explicit(x.shape, dim)
 
     if dtype is not None:
-        x = P.array_cast(x, _pt_dtype_to_my_dtype(dtype))
+        x = P.array_cast(x, dtype)
 
     maxes = torch.max(x, dim, keepdim=True)[0]
     x_exp = torch.exp(x - maxes)
@@ -358,7 +354,7 @@ def _sum(self, dim=None, keepdim=False, *, dtype=None):
     dim = _dim_explicit(x.shape, dim)
 
     if dtype is not None:
-        x = P.array_cast(x, _pt_dtype_to_my_dtype(dtype))
+        x = P.array_cast(x, dtype)
 
     if dim is None:
         return P.array_reduce(P.scalar_add, x, ())
@@ -417,9 +413,7 @@ def transpose(a, dim0, dim1):
 @core
 def zeros(*shp, dtype=None):
     """Map of 'dim' pytorch method."""
-    if dtype is not None:
-        dtype = _pt_dtype_to_my_dtype(dtype)
-    else:
+    if dtype is None:
         dtype = f32
 
     if len(shp) == 1:

--- a/myia/operations/__init__.py
+++ b/myia/operations/__init__.py
@@ -293,6 +293,11 @@ dot = Operation(
     defaults='myia.operations.prim_dot'
 )
 
+dtype = Operation(
+    name='dtype',
+    defaults='myia.operations.macro_dtype'
+)
+
 embed = Operation(
     name='embed',
     defaults='myia.operations.macro_embed'

--- a/myia/operations/macro_dtype.py
+++ b/myia/operations/macro_dtype.py
@@ -1,0 +1,17 @@
+"""Implementation of the 'dtype' macro."""
+
+from ..lib import AbstractArray, Constant, macro
+
+
+@macro
+async def dtype(info, arr: AbstractArray):
+    """Macro implementation for 'dtype'."""
+    return Constant((await arr.get()).element)
+
+
+__operation_defaults__ = {
+    'name': 'dtype',
+    'registered_name': 'dtype',
+    'mapping': dtype,
+    'python_implementation': None,
+}

--- a/myia/operations/macro_isinstance.py
+++ b/myia/operations/macro_isinstance.py
@@ -14,13 +14,11 @@ async def isinstance_(info, r_data, r_type):
     if not isinstance(ts, tuple):
         ts = (ts,)
     for t in ts:
-        if not isinstance(t, type):
-            if not (isinstance(t, lib.AbstractClassBase)
-                    and t.user_defined_version() is t):
-                raise MyiaTypeError(
-                    'isinstance expects a Python type'
-                    ' or a tuple of Python types'
-                )
+        if not isinstance(t, lib.AbstractValue):
+            raise MyiaTypeError(
+                'isinstance expects a Python type'
+                ' or a tuple of Python types'
+            )
     hastypes = [info.graph.apply(P.hastype, r_data.node,
                                  Constant(type_to_abstract(t)))
                 for t in ts]

--- a/myia/operations/prim_array_cast.py
+++ b/myia/operations/prim_array_cast.py
@@ -1,7 +1,12 @@
 """Definitions for the primitive `array_cast`."""
 
 from .. import lib, operations, xtype
-from ..lib import bprop_to_grad_transform, standard_prim, type_to_abstract
+from ..lib import (
+    MyiaTypeError,
+    bprop_to_grad_transform,
+    standard_prim,
+    type_to_abstract,
+)
 from . import primitives as P
 
 
@@ -21,7 +26,10 @@ async def infer_array_cast(self, engine,
                            a: lib.AbstractArray,
                            typ: lib.AbstractType):
     """Infer the return type of primitive `array_cast`."""
-    t = (type_to_abstract(typ.xvalue())).xtype()
+    scal = self.require_constant(typ, argnum=1)
+    if not isinstance(scal, lib.AbstractScalar):
+        raise MyiaTypeError('array_cast must cast to a scalar dtype')
+    t = scal.xtype()
     engine.check(xtype.Number, t)
     e_values = {**a.element.values, lib.TYPE: t}
     return lib.AbstractArray(lib.AbstractScalar(e_values), a.values)

--- a/myia/operations/prim_scalar_cast.py
+++ b/myia/operations/prim_scalar_cast.py
@@ -6,6 +6,7 @@ from .. import lib, xtype
 from ..lib import (
     TYPE,
     AbstractScalar,
+    MyiaTypeError,
     bprop_to_grad_transform,
     standard_prim,
     type_to_abstract,
@@ -29,7 +30,9 @@ async def infer_scalar_cast(self, engine,
                             scalar: xtype.Number,
                             typ: lib.AbstractType):
     """Infer the return type of primitive `scalar_cast`."""
-    a = lib.type_to_abstract(typ.xvalue())
+    a = self.require_constant(typ, argnum=1)
+    if not isinstance(a, AbstractScalar):
+        raise MyiaTypeError('scalar_cast must cast to a scalar type')
     t = a.xtype()
     engine.check(xtype.Number, t)
     values = {**scalar.values, TYPE: t}

--- a/myia/pipeline/resources.py
+++ b/myia/pipeline/resources.py
@@ -2,8 +2,10 @@
 
 from types import FunctionType
 
+import numpy as np
+
 from .. import parser, xtype
-from ..abstract import InferenceEngine
+from ..abstract import InferenceEngine, type_to_abstract
 from ..compile import load_backend
 from ..ir import Graph, clone
 from ..monomorphize import monomorphize
@@ -58,8 +60,18 @@ def default_convert(env, x: Operation):
 
 
 @overload  # noqa: F811
-def default_convert(env, x: (object, type, xtype.TypeMeta)):
+def default_convert(env, x: (object, type)):
     return x
+
+
+@overload  # noqa: F811
+def default_convert(env, x: xtype.TypeMeta):
+    return type_to_abstract(x)
+
+
+@overload  # noqa: F811
+def default_convert(env, x: np.dtype):
+    return default_convert(env, xtype.np_dtype_to_type(x))
 
 
 class _Unconverted:

--- a/myia/pipeline/resources.py
+++ b/myia/pipeline/resources.py
@@ -60,18 +60,21 @@ def default_convert(env, x: Operation):
 
 
 @overload  # noqa: F811
-def default_convert(env, x: (object, type)):
+def default_convert(env, x: object):
     return x
 
 
 @overload  # noqa: F811
-def default_convert(env, x: xtype.TypeMeta):
-    return type_to_abstract(x)
+def default_convert(env, x: type):
+    try:
+        return type_to_abstract(x)
+    except KeyError:
+        return x
 
 
 @overload  # noqa: F811
 def default_convert(env, x: np.dtype):
-    return default_convert(env, xtype.np_dtype_to_type(x))
+    return default_convert(env, xtype.np_dtype_to_type(x.name))
 
 
 class _Unconverted:

--- a/myia/pipeline/standard.py
+++ b/myia/pipeline/standard.py
@@ -213,6 +213,7 @@ standard_method_map = {
         'shape': property(operations.shape),
         'T': property(operations.t),
         'ndim': property(operations.ndim),
+        'dtype': property(operations.dtype),
     },
 }
 

--- a/myia/vm.py
+++ b/myia/vm.py
@@ -7,11 +7,12 @@ implementation.
 
 from typing import Any, Iterable, List, Mapping
 
+from .abstract import AbstractClassBase
 from .graph_utils import toposort
 from .ir import ANFNode, Apply, Constant, Graph, Parameter
 from .operations import Primitive
 from .operations.primitives import partial, return_
-from .utils import TypeMap, is_dataclass_type
+from .utils import TypeMap
 
 
 class VMFrame:
@@ -265,8 +266,8 @@ class VM:
             self._dispatch_call(node, frame, fn.fn, fn.args + tuple(args))
         elif isinstance(fn, (Graph, Closure)):
             self._call(fn, args)
-        elif is_dataclass_type(fn):
-            frame.values[node] = fn(*args)
+        elif isinstance(fn, AbstractClassBase):
+            frame.values[node] = fn.constructor(*args)
         else:
             raise AssertionError(f'Invalid fn to call: {fn}')
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -25,6 +25,7 @@ from myia.abstract import (
     empty,
     from_value,
     listof,
+    type_to_abstract,
 )
 from myia.classes import ADT
 from myia.ir import MultitypeGraph
@@ -109,6 +110,7 @@ def Shp(*vals):
 
 
 def Ty(t):
+    t = t if t is ANYTHING else type_to_abstract(t)
     return AbstractType(t)
 
 

--- a/tests/operations/test_macro_dtype.py
+++ b/tests/operations/test_macro_dtype.py
@@ -1,0 +1,23 @@
+
+from myia.lib import InferenceError
+from myia.operations import dtype, scalar_cast
+
+from ..common import MA, Ty, af32_of, f32, i64, to_abstract_test
+from ..multitest import infer, mt, run
+
+
+@mt(
+    infer(i64, result=InferenceError),
+    infer(af32_of(4, 5), result=Ty(to_abstract_test(f32))),
+)
+def test_dtype(arr):
+    return dtype(arr)
+
+
+@mt(
+    infer(af32_of(4, 5), i64, result=f32),
+
+    run(MA(2, 3), 7, result=7.0),
+)
+def test_cast(arr, x):
+    return scalar_cast(x, dtype(arr))

--- a/tests/operations/test_macro_dtype.py
+++ b/tests/operations/test_macro_dtype.py
@@ -3,7 +3,7 @@ from myia.lib import InferenceError
 from myia.operations import dtype, scalar_cast
 
 from ..common import MA, Ty, af32_of, f32, i64, to_abstract_test
-from ..multitest import infer, mt, run
+from ..multitest import infer, mt, run_no_relay
 
 
 @mt(
@@ -17,7 +17,7 @@ def test_dtype(arr):
 @mt(
     infer(af32_of(4, 5), i64, result=f32),
 
-    run(MA(2, 3), 7, result=7.0),
+    run_no_relay(MA(2, 3), 7, result=7.0),
 )
 def test_cast_to_dtype(arr, x):
     return scalar_cast(x, dtype(arr))

--- a/tests/operations/test_macro_dtype.py
+++ b/tests/operations/test_macro_dtype.py
@@ -19,5 +19,5 @@ def test_dtype(arr):
 
     run(MA(2, 3), 7, result=7.0),
 )
-def test_cast(arr, x):
+def test_cast_to_dtype(arr, x):
     return scalar_cast(x, dtype(arr))

--- a/tests/prim/test_py_implementations.py
+++ b/tests/prim/test_py_implementations.py
@@ -12,7 +12,7 @@ from math import (
 import numpy as np
 import pytest
 
-from myia.abstract import ANYTHING
+from myia.abstract import ANYTHING, type_to_abstract
 from myia.operations import (
     array_cast,
     array_getitem,
@@ -468,15 +468,19 @@ def test_broadcast_shape():
 
 
 def test_scalar_cast():
-    assert isinstance(scalar_cast(1.5, i64), np.int64)
-    assert isinstance(scalar_cast(1.5, f16), np.float16)
+    assert isinstance(scalar_cast(1.5, type_to_abstract(i64)), np.int64)
+    assert isinstance(scalar_cast(1.5, type_to_abstract(f16)), np.float16)
 
 
 def test_array_cast():
-    assert isinstance(array_cast(np.array([1.5, 1.7]), i64), np.ndarray)
-    assert (array_cast(np.array([1.5, 1.7]), i64)).dtype == np.dtype(np.int64)
-    assert isinstance(array_cast(np.array([1.5, 1.7]), f16), np.ndarray)
-    assert (array_cast(np.array([1.5, 1.]), f16)).dtype == np.dtype(np.float16)
+    assert isinstance(array_cast(np.array([1.5, 1.7]),
+                                 type_to_abstract(i64)), np.ndarray)
+    assert (array_cast(np.array([1.5, 1.7]),
+                       type_to_abstract(i64))).dtype == np.dtype(np.int64)
+    assert isinstance(array_cast(np.array([1.5, 1.7]),
+                                 type_to_abstract(f16)), np.ndarray)
+    assert (array_cast(np.array([1.5, 1.]),
+                       type_to_abstract(f16))).dtype == np.dtype(np.float16)
 
 
 def test_env():

--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -230,7 +230,7 @@ def test_repr():
     assert repr(kw1) == f'AbstractKeywordArgument(KW(bucket :: Int[64] = 1))'
 
     ty1 = Ty(f32)
-    assert repr(ty1) == 'AbstractType(Ty(Float[32]))'
+    assert repr(ty1) == 'AbstractType(Ty(AbstractScalar(Float[32])))'
 
     e1 = AbstractError(DEAD)
     assert repr(e1) == 'AbstractError(E(DEAD))'

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1683,16 +1683,32 @@ def test_closure_in_data(c, x):
 
 
 @mt(
-    infer_scalar(i64, Ty(to_abstract_test(i64)), result=i64),
-    infer_scalar(i64, Ty(to_abstract_test(i16)), result=i16),
-    infer_scalar(f64, Ty(to_abstract_test(i16)), result=i16),
-    infer_scalar(f16, Ty(to_abstract_test(f32)), result=f32),
+    infer_scalar(i64, Ty(i64), result=i64),
+    infer_scalar(i64, Ty(i16), result=i16),
+    infer_scalar(f64, Ty(i16), result=i16),
+    infer_scalar(f16, Ty(f32), result=f32),
+    infer_scalar(f16, Ty(np.float32), result=f32),
+    infer_scalar(f16, Ty(np.dtype('float32')), result=f32),
     infer_scalar(f16, Ty(ANYTHING), result=InferenceError),
-    infer_scalar(f16, Ty(to_abstract_test(B)), result=InferenceError),
-    infer_scalar(B, Ty(to_abstract_test(f32)), result=InferenceError),
+    infer_scalar(f16, Ty(Bot), result=InferenceError),
+    infer_scalar(f16, Ty(B), result=InferenceError),
+    infer_scalar(B, Ty(f32), result=InferenceError),
 )
 def test_scalar_cast(x, t):
     return scalar_cast(x, t)
+
+
+@infer_scalar(i64, result=f32)
+def test_scalar_cast_2(x):
+    return scalar_cast(x, np.float32)
+
+
+_npf32 = np.dtype('float32')
+
+
+@infer_scalar(i64, result=f32)
+def test_scalar_cast_3(x):
+    return scalar_cast(x, _npf32)
 
 
 @mt(
@@ -1705,6 +1721,8 @@ def test_scalar_cast(x, t):
     infer_scalar(af16_of(2, 3), Ty(to_abstract_test(f32)),
                  result=af32_of(2, 3)),
     infer_scalar(af16_of(2, 3), Ty(ANYTHING),
+                 result=InferenceError),
+    infer_scalar(af16_of(2, 3), Ty(Bot),
                  result=InferenceError),
     infer_scalar(af16_of(2, 3), Ty(to_abstract_test(B)),
                  result=InferenceError),


### PR DESCRIPTION
* Add the `dtype` macro which returns the element type of an array.
* Support `numpy.<dtype>` and `torch.<dtype>`.
* Improve the handling of dtypes through the pipeline (convert, to_abstract, etc.)
* Fixes to `scalar_cast` and `array_cast`.
