### PR TITLE
Add support for ruamel.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - TEST_SUITE=static
   - TEST_SUITE=unit
 script:
-  - if [[ $TEST_SUITE == "static" ]]; then flake8 && pydocstyle myia && isort -c -df; fi
+  - if [[ $TEST_SUITE == "static" ]]; then source activate test && flake8 && pydocstyle myia && isort -c -df; fi
   - if [[ $TEST_SUITE == "unit" ]]; then source activate test && pytest tests --cov=./ --cov-report term-missing; fi
 after_success:
   - if [[ $TEST_SUITE == "unit" ]]; then codecov; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ env:
   - TEST_SUITE=unit
 script:
   - if [[ $TEST_SUITE == "static" ]]; then flake8 && pydocstyle myia && isort -c -df; fi
-  - if [[ $TEST_SUITE == "unit" ]]; then pytest tests --cov=./ --cov-report term-missing; fi
+  - if [[ $TEST_SUITE == "unit" ]]; then source activate test && pytest tests --cov=./ --cov-report term-missing; fi
 after_success:
   - if [[ $TEST_SUITE == "unit" ]]; then codecov; fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,19 +7,20 @@ node ('gpu') {
   }
   try {
     stage ('Test') {
-      sh script: '$HOME/miniconda/bin/pytest --cov=./ --cov-report= --gpu --junit-xml test-report.xml'
+      sh script: 'source activate test && pytest --cov=./ --cov-report= --gpu --junit-xml test-report.xml'
     }
   } finally {
     junit 'test-report.xml'
   }
   stage ('Coverage') {
-    withEnv(['PATH+CONDA=/home/jenkins/miniconda/bin']) {
-      sh script: './cov.sh'
-      sh script: 'coverage xml'
-      sh script: 'pip install codecov'
-      withCredentials([string(credentialsId: 'myia_codecov', variable: 'CODECOV_TOKEN')]) {
-        sh script: 'codecov'
-      }
+    sh script: """
+source activate test &&
+./cov.sh &&
+coverage xml
+"""
+    sh script: '$HOME/miniconda/bin/pip install codecov'
+    withCredentials([string(credentialsId: 'myia_codecov', variable: 'CODECOV_TOKEN')]) {
+      sh script: '$HOME/miniconda/bin/codecov'
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,14 +7,14 @@ node ('gpu') {
   }
   try {
     stage ('Test') {
-      sh script: 'source activate test && pytest --cov=./ --cov-report= --gpu --junit-xml test-report.xml'
+      sh script: '. $HOME/miniconda/bin/activate test && pytest --cov=./ --cov-report= --gpu --junit-xml test-report.xml'
     }
   } finally {
     junit 'test-report.xml'
   }
   stage ('Coverage') {
     sh script: """
-source activate test &&
+. $HOME/miniconda/bin/activate test &&
 ./cov.sh &&
 coverage xml
 """

--- a/ci-install.sh
+++ b/ci-install.sh
@@ -24,6 +24,7 @@ hash -r
 conda config --set always_yes yes --set changeps1 no
 conda update -q conda
 conda create -y -n test python=3.7
+conda init
 source activate test
 conda install --file=requirements-$DEV.conda
 pip install -r requirements.txt

--- a/ci-install.sh
+++ b/ci-install.sh
@@ -23,6 +23,8 @@ export PATH="$HOME/miniconda/bin:$PATH"
 hash -r
 conda config --set always_yes yes --set changeps1 no
 conda update -q conda
+conda create -y -n test python=3.7
+source activate test
 conda install --file=requirements-$DEV.conda
 pip install -r requirements.txt
 pip install -e . --no-deps

--- a/myia/utils/serialize.py
+++ b/myia/utils/serialize.py
@@ -1,9 +1,34 @@
 """Serialization utilities for graphs and their properties."""
 
-try:
-    from yaml import CSafeLoader as SafeLoader, CSafeDumper as SafeDumper
-except ImportError:  # pragma: no cover
-    from yaml import SafeLoader, SafeDumper
+# This is a mess of imports
+
+# 1) We prefer ruamel.yaml since it has merged the large files fix.
+# 2) Conda has a different name for it since it doesn't like namespaces.
+# 3) We attempt to use pyyaml as a fallback
+try:  # pragma: no cover
+    try:
+        from ruamel.yaml import (
+            CSafeLoader as SafeLoader,
+            CSafeDumper as SafeDumper
+        )
+    except ImportError:
+        try:
+            from ruamel_yaml import (
+                CSafeLoader as SafeLoader,
+                CSafeDumper as SafeDumper
+            )
+        except ImportError:
+            from yaml import (
+                CSafeLoader as SafeLoader,
+                CSafeDumper as SafeDumper
+            )
+except ImportError as e:  # pragma: no cover
+    raise RuntimeError("""
+Couldn't find a C-backed version of yaml.
+
+Please install either ruamel.yaml or PyYAML with the C extension. The python
+ versions are just too slow to work properly.
+""") from e
 
 import codecs
 import os

--- a/requirements-cpu.conda
+++ b/requirements-cpu.conda
@@ -4,7 +4,7 @@ numpy
 abergeron::tvm==0.6dev+3.*
 pytest
 pytest-cov
-pyyaml
+ruamel_yaml
 flake8==3.7.7
 pytorch::pytorch==1.1.0
 pydocstyle==2.1.1

--- a/requirements-cpu.conda
+++ b/requirements-cpu.conda
@@ -4,7 +4,7 @@ numpy
 abergeron::tvm==0.6dev+3.*
 pytest
 pytest-cov
-ruamel_yaml
+yaml
 flake8==3.7.7
 pytorch::pytorch==1.1.0
 pydocstyle==2.1.1

--- a/requirements-cpu.conda
+++ b/requirements-cpu.conda
@@ -6,7 +6,7 @@ pytest
 pytest-cov
 yaml
 flake8==3.7.7
-pytorch::pytorch==1.1.0
+pytorch::pytorch-cpu==1.1.0
 pydocstyle==2.1.1
 isort==4.3.21
 docopt==0.6.2

--- a/requirements-gpu.conda
+++ b/requirements-gpu.conda
@@ -5,7 +5,7 @@ abergeron/label/cuda::tvm-libs
 abergeron::tvm==0.6dev+3.*
 pytest
 pytest-cov
-pyyaml
+ruamel_yaml
 flake8==3.7.7
 pytorch::pytorch==1.1.0
 pydocstyle==2.1.1

--- a/requirements-gpu.conda
+++ b/requirements-gpu.conda
@@ -5,7 +5,7 @@ abergeron/label/cuda::tvm-libs
 abergeron::tvm==0.6dev+3.*
 pytest
 pytest-cov
-ruamel_yaml
+yaml
 flake8==3.7.7
 pytorch::pytorch==1.1.0
 pydocstyle==2.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 asttokens
 codecov
 prettyprinter
+ruamel.yaml
+ruamel.yaml.clib>=0.2

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     ],
     packages=find_packages(exclude=['docs', 'tests']),
     install_requires=['asttokens', 'colorama', 'prettyprinter',
-                      'numpy', 'pyyaml'],
+                      'numpy', 'ruamel.yaml'],
     extras_require={
         'test': ['flake8', 'pytest', 'codecov', 'isort',
                  'pytest-cov', 'pydocstyle', 'docopt'],


### PR DESCRIPTION
Since ruamel.yaml merged the size_t fix after a couple of days (https://bitbucket.org/ruamel/yaml.clib/pull-requests/1/use-size_t-for-marks-in-cython-to-handle/diff) and PyYAML has apparently been "considering" a very similar fix for at least a month now: https://github.com/yaml/pyyaml/pull/310, I believe it is in our best interest to possibly switch to ruamel.yaml in order to have a "fixed" version as soon as possible.

Also @ethancaballero and I did some runs using the python version of PyYAML and it is so slow that I consider it unusable for our purposes and therefore removed support.