### PR TITLE
frontend_pytorch_v0_0_4: runs mnist example from pytorch examples with small changes

### DIFF
--- a/myia/compile/channel/__main__.py
+++ b/myia/compile/channel/__main__.py
@@ -30,11 +30,7 @@ def _rpc_server():
         return 1
 
     while loader.check_data():
-        try:
-            data = loader.get_data()
-        except Exception as e:
-            dumper.represent(e)
-            continue
+        data = loader.get_data()
         if isinstance(data, tuple):
             name, args, kwargs = data
             try:

--- a/myia/compile/channel/__main__.py
+++ b/myia/compile/channel/__main__.py
@@ -30,7 +30,11 @@ def _rpc_server():
         return 1
 
     while loader.check_data():
-        data = loader.get_data()
+        try:
+            data = loader.get_data()
+        except Exception as e:
+            dumper.represent(e)
+            continue
         if isinstance(data, tuple):
             name, args, kwargs = data
             try:

--- a/myia/compile/transform.py
+++ b/myia/compile/transform.py
@@ -257,10 +257,7 @@ class CompileGraph:
                         self.add_instr('tuple_getitem',
                                        self.ref(split.inputs[1]),
                                        self.ref(split.inputs[2]))
-                    elif fn.value == P.tuple_setitem:  # pragma: no cover
-                        raise RuntimeError(
-                            "Please report your testcase so that "
-                            "we can add it to the testsuite")
+                    elif fn.value == P.tuple_setitem:
                         self.add_instr('tuple_setitem',
                                        self.ref(split.inputs[1]),
                                        self.ref(split.inputs[2]),

--- a/myia/compile/vm.py
+++ b/myia/compile/vm.py
@@ -234,7 +234,7 @@ class FinalVM:
         idx = self.backend.to_scalar(self._ref(idx))
         self._push(a[idx])
 
-    def inst_tuple_setitem(self, t, idx, v):  # pragma: no cover
+    def inst_tuple_setitem(self, t, idx, v):
         """Set an item in a tuple.
 
         Arguments:
@@ -242,8 +242,6 @@ class FinalVM:
            idx: index
            v: value to set
         """
-        raise RuntimeError("Please report your test case so that "
-                           "we can add it to the test suite")
         t = self._ref(t)
         idx = self.backend.to_scalar(self._ref(idx))
         v = self._ref(v)

--- a/myia/frontends/pytorch.py
+++ b/myia/frontends/pytorch.py
@@ -43,14 +43,17 @@ from .pytorch_functions import (
     scatter,
     scatter_add,
     sigmoid,
+    size,
     softmax,
     squeeze,
     transpose,
+    view_as,
     zeros,
 )
 
 standard_object_map.update({
     torch.argmax: argmax,
+    torch.eq: operations.array_eq,
     torch.exp: operations.array_exp,
     torch.gather: gather,
     torch.log: operations.array_log,
@@ -84,6 +87,7 @@ standard_method_map[PyTorchTensor].update({
     'dim': operations.ndim,
     'dtype': property(operations.dtype),
     'argmax': argmax,
+    'eq': operations.array_eq,
     'exp': operations.array_exp,
     'gather': gather,
     'item': item,
@@ -97,13 +101,15 @@ standard_method_map[PyTorchTensor].update({
     'scatter_add': scatter_add,
     'sigmoid': sigmoid,
     'shape': property(operations.shape),
+    'size': size,
     'softmax': softmax,
     'squeeze': squeeze,
     'sum': _sum,
     't': operations.t,
     'transpose': transpose,
     'tanh': operations.array_tanh,
-    'view': P.reshape,  # contiguousness is ignored by us for now?
+    'view': reshape,  # contiguousness is ignored by us for now?
+    'view_as': view_as,  # contiguousness is ignored by us for now?
     'zeros_like': operations.zeros_like,  # hidden method used by bwd (I think)
 })
 

--- a/myia/frontends/pytorch_abstract_types.py
+++ b/myia/frontends/pytorch_abstract_types.py
@@ -10,7 +10,7 @@ from ..abstract.data import (
     AbstractScalar,
 )
 from ..utils import MyiaInputTypeError
-from ..xtype import Float, Int, Object, UInt
+from ..xtype import Bool, Float, Int, Object, UInt
 
 
 class PyTorchTensor(Object):
@@ -59,6 +59,7 @@ def pytorch_dtype_to_type(dtype):
         torch.float16: Float[16],
         torch.float32: Float[32],
         torch.float64: Float[64],
+        torch.bool: Bool,
     }
     if dtype not in _type_map:
         raise TypeError(f"Unsupported dtype {dtype}")
@@ -67,6 +68,12 @@ def pytorch_dtype_to_type(dtype):
 
 APT = AbstractArray(
     AbstractScalar({TYPE: ANYTHING, VALUE: ANYTHING}),
+    {SHAPE: ANYTHING, TYPE: PyTorchTensor}
+)
+
+
+APT_bool = AbstractArray(
+    AbstractScalar({TYPE: Bool, VALUE: ANYTHING}),
     {SHAPE: ANYTHING, TYPE: PyTorchTensor}
 )
 

--- a/myia/operations/op_gadd.py
+++ b/myia/operations/op_gadd.py
@@ -1,7 +1,7 @@
 """Implementation of the 'gadd' operation."""
 
 from ..lib import HyperMap, MultitypeGraph, core
-from ..xtype import EnvType, Nil, Number
+from ..xtype import Bool, EnvType, Nil, Number
 from .primitives import env_add, scalar_add
 
 _leaf_add = MultitypeGraph('gadd')
@@ -23,6 +23,13 @@ def _sm_add(x, y):
 @core
 def _nil_add(x, y):
     return None
+
+
+@_leaf_add.register(Bool, Bool)
+@core
+def _bool_add(x, y):
+    assert x is y
+    return y
 
 
 gadd = HyperMap(name='gadd', fn_leaf=_leaf_add,

--- a/myia/operations/op_gadd.py
+++ b/myia/operations/op_gadd.py
@@ -2,7 +2,7 @@
 
 from ..lib import HyperMap, MultitypeGraph, core
 from ..xtype import Bool, EnvType, Nil, Number
-from .primitives import env_add, scalar_add
+from .primitives import bool_or, env_add, scalar_add
 
 _leaf_add = MultitypeGraph('gadd')
 
@@ -28,8 +28,7 @@ def _nil_add(x, y):
 @_leaf_add.register(Bool, Bool)
 @core
 def _bool_add(x, y):
-    assert x is y
-    return y
+    return bool_or(x, y)
 
 
 gadd = HyperMap(name='gadd', fn_leaf=_leaf_add,

--- a/myia/simplify_types.py
+++ b/myia/simplify_types.py
@@ -332,7 +332,7 @@ def to_canonical(self, arg, orig_t: AbstractArray):
     et = orig_t.element
     assert isinstance(et, AbstractScalar)
     et = et.xtype()
-    assert issubclass(et, xtype.Number)
+    assert issubclass(et, (xtype.Number, xtype.Bool))
     arg = orig_t.xtype().to_numpy(arg)
     arg_dtype = xtype.np_dtype_to_type(str(arg.dtype))
     if arg_dtype != et:

--- a/tests/frontends/test_pytorch_ops.py
+++ b/tests/frontends/test_pytorch_ops.py
@@ -15,10 +15,13 @@ from myia.abstract.data import (
 )
 from myia.debug.finite_diff import NoTestGrad, clean_args
 from myia.frontends import activate_frontend  # noqa: E402
-from myia.frontends.pytorch_abstract_types import PyTorchTensor  # noqa: E402
+from myia.frontends.pytorch_abstract_types import (
+    PyTorchTensor,
+    pytorch_dtype_to_type,
+)
 from myia.pipeline import standard_pipeline
 
-from ..common import MA, f32, to_abstract_test
+from ..common import MA, to_abstract_test
 from ..multitest import eqtest, mt, myia_function_test, run, run_no_relay
 from ..test_grad import grad_wrap
 
@@ -89,10 +92,11 @@ def make_argspec(args, broad_specs):
 
 def _fwd_and_bwd(fn, args, broad_specs=None, pipeline=standard_pipeline):
 
-    def mksens(s):
+    def mksens(x):
         return AbstractArray(
-            AbstractScalar({TYPE: f32, VALUE: ANYTHING}),
-            {SHAPE: tuple(s), TYPE: PyTorchTensor}
+            AbstractScalar({TYPE: pytorch_dtype_to_type(x.dtype),
+                            VALUE: ANYTHING}),
+            {SHAPE: tuple(x.shape), TYPE: PyTorchTensor}
         )
 
     ref_result = fn(*map(copy, args))
@@ -105,13 +109,13 @@ def _fwd_and_bwd(fn, args, broad_specs=None, pipeline=standard_pipeline):
 
     if isinstance(myia_result, tuple):
         sens_type = AbstractTuple(
-            [mksens(res.shape) for res in myia_result]
+            [mksens(res) for res in myia_result]
         )
-        sens = tuple(torch.ones(res.shape) for res in myia_result)
-
+        sens = tuple(torch.ones(res.shape, dtype=res.dtype)
+                     for res in myia_result)
     else:
-        sens_type = mksens(myia_result.shape)
-        sens = torch.ones(myia_result.shape)
+        sens_type = mksens(myia_result)
+        sens = torch.ones(myia_result.shape, dtype=myia_result.dtype)
 
     pytorch_grads = pt_fn_grads(fn, *args)
 
@@ -185,6 +189,20 @@ def test_torch_tensor_argmax_1_arg(x):
 )
 def test_torch_tensor_argmax_3_arg(x, y, z):
     return torch.argmax(x, y, z)
+
+
+# uncomment this when bool array compare is merged in pytorch:
+"""
+http://forum.opennmt.net/t/runtimeerror-subtraction-the-operator-with-a-bool
+-tensor-is-not-supported-if-you-are-trying-to-invert-a-mask-use-the-or-bitwise
+-not-operator-instead/2994
+# """
+"""
+@run(nn.Parameter(torch.tensor([[0.74, 1., 2.], [0.3, 0.0, 0.6]])),
+     nn.Parameter(torch.tensor([[0.74, 1., 2.], [0.7, 0.0, -0.6]])))
+def test_torch_eq(x, y):
+    return torch.eq(x, y)
+# """
 
 
 @fwd_and_bwd(nn.Parameter(torch.Tensor(MA(3, 4))),
@@ -292,6 +310,12 @@ def test_torch_nll_loss_reduce_options(x, y, z):
     return torch.nn.functional.nll_loss(x, y, reduction=z)
 
 
+@fwd_and_bwd(nn.Parameter(torch.randn(2, 3, dtype=torch.float64)),
+             torch.tensor([1, 2]))
+def test_torch_nll_loss_reduce_cast(x, y):
+    return torch.nn.functional.nll_loss(x, y, reduction='mean')
+
+
 @fwd_and_bwd(nn.Parameter(torch.Tensor(torch.randn(2, 3, 4, 5))))
 def test_torch_tensor_permute(x):
     return x.permute((0, 3, 2, 1))
@@ -306,6 +330,7 @@ def test_torch_tensor_pow(x):
     fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))), (-1,)),
     fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))), (6,)),
     fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))), (2, 3)),
+    fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))), (-1, 6)),
     fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 1))), (2,)),
     broad_specs=(True, False)
 )
@@ -334,14 +359,11 @@ def test_torch_scatter_broadcast_source(x, index, src):
     return torch.scatter(x, 0, index, src)
 
 
-# TODO: Need dtype attr for xtype.NDArray to support nonpytorch scalar src
-"""
-@fwd_and_bwd(nn.Parameter(torch.Tensor(MA(3, 4))),
-              torch.tensor([[0, 1, 2, 0], [0, 0, 0, 1]]),
-              1.23)
+@fwd_and_bwd(nn.Parameter(torch.randn(3, 4, dtype=torch.float64)),
+             torch.tensor([[0, 1, 2, 0], [0, 0, 0, 1]]),
+             1.23)
 def test_torch_scatter_broadcast_source_nonpytorch_scalar(x, index, src):
     return torch.scatter(x, 0, index, src)
-# """
 
 
 # TODO: NotImplementedError: <_ast.Subscript object at 0x*>
@@ -385,16 +407,17 @@ def test_torch_sum(x):
     return torch.sum(x)
 
 
-@run(nn.Parameter(torch.Tensor(MA(2, 3))))
-def test_torch_sum_dtype_fwd(x):
-    return torch.sum(x, dtype=torch.float64)
+# need pytorch-cpu=1.2.0 or higher to install to run this test
+"""
+@run(torch.BoolTensor([[True, False, False], [False, False, True]]))
+def test_torch_sum_bool(x):
+    return torch.sum(x)
+# """
 
 
-""" # TODO: implement bwd for array_cast
 @fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))))
 def test_torch_sum_dtype(x):
     return torch.sum(x, dtype=torch.float64)
-"""
 
 
 @fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))))
@@ -419,6 +442,12 @@ def test_torch_sum_multi_dim(x):
 @fwd_and_bwd(nn.Parameter(torch.Tensor(torch.randn(2, 4, 3, 5))))
 def test_torch_tensor_transpose(x):
     return x.transpose(3, 1)
+
+
+@fwd_and_bwd(nn.Parameter(torch.Tensor(torch.randn(2, 4, 3))),
+             nn.Parameter(torch.Tensor(torch.randn(4, 3, 2))))
+def test_torch_tensor_view_as(x, y):
+    return x.view_as(y)
 
 
 @run()

--- a/tests/frontends/test_pytorch_ops.py
+++ b/tests/frontends/test_pytorch_ops.py
@@ -191,7 +191,7 @@ def test_torch_tensor_argmax_3_arg(x, y, z):
     return torch.argmax(x, y, z)
 
 
-# uncomment this when bool array compare is merged in pytorch:
+# TODO: uncomment this when bool array compare is merged in pytorch:
 """
 http://forum.opennmt.net/t/runtimeerror-subtraction-the-operator-with-a-bool
 -tensor-is-not-supported-if-you-are-trying-to-invert-a-mask-use-the-or-bitwise
@@ -407,7 +407,7 @@ def test_torch_sum(x):
     return torch.sum(x)
 
 
-# need pytorch-cpu=1.2.0 or higher to install to run this test
+# TODO: need pytorch-cpu=1.2.0 or higher to install to run this test
 """
 @run(torch.BoolTensor([[True, False, False], [False, False, True]]))
 def test_torch_sum_bool(x):

--- a/tests/multitest.py
+++ b/tests/multitest.py
@@ -27,6 +27,14 @@ def eqtest(a1: (np.ndarray, int, float), a2,
 
 
 @overload  # noqa: F811
+def eqtest(x: type(None), y, **kwargs):
+    if y is None:
+        return True
+    else:
+        return y.sum().item() == 0
+
+
+@overload  # noqa: F811
 def eqtest(x: object, y, **kwargs):
     return x == y
 

--- a/tests/multitest.py
+++ b/tests/multitest.py
@@ -31,7 +31,7 @@ def eqtest(x: type(None), y, **kwargs):
     if y is None:
         return True
     else:
-        return y.sum().item() == 0
+        return (y == 0).all()
 
 
 @overload  # noqa: F811


### PR DESCRIPTION
- runs mnist example from pytorch examples with small changes
- also adds support for cast option of pytorch function that needed support for `.dtype` attribute