### PR TITLE
[wip] Add operations np.full and np.prod

### DIFF
--- a/myia/abstract/data.py
+++ b/myia/abstract/data.py
@@ -860,17 +860,6 @@ def listof(t):
 def u64tup_typecheck(engine, tup):
     """Verify that tup is a tuple of uint64."""
     tup_t = engine.check(AbstractTuple, tup)
-    # If tup is a constant tuple of positive integers,
-    # then consider it as a tuple of uint64.
-    try:
-        if all(isinstance(el, AbstractScalar)
-               and issubclass(el.xtype(), xtype.Integral)
-               and el.xvalue() >= 0
-               for el in tup_t.elements):
-            return tup_t
-    except TypeError:
-        pass
-    # Otherwise, check merged type.
     for elem_t in tup_t.elements:
         engine.abstract_merge(xtype.UInt[64], elem_t.xtype())
     return tup_t

--- a/myia/abstract/data.py
+++ b/myia/abstract/data.py
@@ -860,6 +860,17 @@ def listof(t):
 def u64tup_typecheck(engine, tup):
     """Verify that tup is a tuple of uint64."""
     tup_t = engine.check(AbstractTuple, tup)
+    # If tup is a constant tuple of positive integers,
+    # then consider it as a tuple of uint64.
+    try:
+        if all(isinstance(el, AbstractScalar)
+               and issubclass(el.xtype(), xtype.Integral)
+               and el.xvalue() >= 0
+               for el in tup_t.elements):
+            return tup_t
+    except TypeError:
+        pass
+    # Otherwise, check merged type.
     for elem_t in tup_t.elements:
         engine.abstract_merge(xtype.UInt[64], elem_t.xtype())
     return tup_t

--- a/myia/compile/backends/pytorch.py
+++ b/myia/compile/backends/pytorch.py
@@ -182,11 +182,9 @@ def _pytorch_array_reduce_mul(tshp):
 
         if len(tshp) in (0, len(ashp)):
             res = torch.prod(array)
-        elif len(tshp) == 1:
-            res = torch.prod(array, tshp[0], keepdim=True)
         else:
             raise NotImplementedError(
-                'Pytorch product reduction only accepts 1 dim nor no dim.')
+                'We currently only support full product on an array.')
         return (res,)
 
     return _impl

--- a/myia/compile/backends/relay.py
+++ b/myia/compile/backends/relay.py
@@ -84,7 +84,9 @@ SIMPLE_MAP = {
 def relay_distribute(c, array, shape):
     """Implementation of distribute for Relay."""
     assert shape.is_constant(tuple)
-    return relay.op.broadcast_to(c.ref(array), shape.value)
+    # Make sure shape is a tuple of builtin Python integers.
+    relay_shape = tuple(int(dim) for dim in shape.value)
+    return relay.op.broadcast_to(c.ref(array), relay_shape)
 
 
 def relay_transpose(c, a, ax):

--- a/myia/compile/backends/relay.py
+++ b/myia/compile/backends/relay.py
@@ -144,6 +144,14 @@ def relay_array_reduce(c, fn, array, shape):
             if rtshp == ():
                 res = relay.op.take(res, relay.const(0))
         return res
+    elif fn == P.scalar_mul:
+        ashp = ashape(array)
+        if len(tshp) in (0, len(ashp)):
+            res = relay.op.prod(ary)
+        else:
+            raise NotImplementedError(
+                'We currently support only full product on an array.')
+        return res
     else:
         raise NotImplementedError(f"reduce with {fn}")
 

--- a/myia/compile/backends/relay_helpers.py
+++ b/myia/compile/backends/relay_helpers.py
@@ -188,7 +188,9 @@ def to_relay_type(self, a: AbstractTuple):
 @overload  # noqa: F811
 def to_relay_type(self, a: AbstractArray):
     tp = a.element.xtype()
-    return relay.ty.TensorType(a.xshape(), type_to_np_dtype(tp))
+    # Make sure shape is a tuple of builtin Python integers.
+    relay_shape = tuple(int(dim) for dim in a.xshape())
+    return relay.ty.TensorType(relay_shape, type_to_np_dtype(tp))
 
 
 @overload  # noqa: F811

--- a/myia/compile/backends/relay_helpers.py
+++ b/myia/compile/backends/relay_helpers.py
@@ -188,9 +188,7 @@ def to_relay_type(self, a: AbstractTuple):
 @overload  # noqa: F811
 def to_relay_type(self, a: AbstractArray):
     tp = a.element.xtype()
-    # Make sure shape is a tuple of builtin Python integers.
-    relay_shape = tuple(int(dim) for dim in a.xshape())
-    return relay.ty.TensorType(relay_shape, type_to_np_dtype(tp))
+    return relay.ty.TensorType(a.xshape(), type_to_np_dtype(tp))
 
 
 @overload  # noqa: F811
@@ -226,7 +224,7 @@ def dead_value(t):
 
 def _placeholder_body(type):
     if isinstance(type, relay.TensorType):
-        sh = [int(sh) for sh in type.shape]
+        sh = [sh.value for sh in type.shape]
         return relay.const(np.array(np.random.rand(*sh)).astype(type.dtype),
                            dtype=type.dtype)
     elif isinstance(type, relay.TupleType):

--- a/myia/operations/__init__.py
+++ b/myia/operations/__init__.py
@@ -18,6 +18,11 @@ Jinv = Operation(
     defaults='myia.operations.prim_Jinv'
 )
 
+abstract_array = Operation(
+    name='abstract_array',
+    defaults='myia.operations.macro_abstract_array'
+)
+
 add = Operation(
     name='add',
     defaults='myia.operations.ops_dunder.add'
@@ -368,6 +373,11 @@ floordiv = Operation(
     defaults='myia.operations.ops_dunder.floordiv'
 )
 
+full = Operation(
+    name='full',
+    defaults='myia.operations.op_full'
+)
+
 gadd = Operation(
     name='gadd',
     defaults='myia.operations.op_gadd'
@@ -628,6 +638,11 @@ pow = Operation(
     defaults='myia.operations.ops_dunder.pow'
 )
 
+prod = Operation(
+    name='prod',
+    defaults='myia.operations.ops_array.prod'
+)
+
 raise_ = Operation(
     name='raise',
     defaults='myia.operations.prim_raise_'
@@ -886,6 +901,11 @@ t = Operation(
 tagged = Operation(
     name='tagged',
     defaults='myia.operations.prim_tagged'
+)
+
+to_scalar_type = Operation(
+    name='to_scalar_type',
+    defaults='myia.operations.macro_to_scalar_type'
 )
 
 transpose = Operation(

--- a/myia/operations/macro_abstract_array.py
+++ b/myia/operations/macro_abstract_array.py
@@ -1,0 +1,28 @@
+"""
+Implementation of the 'abstract_array' operation.
+
+Create an AbstractArray using given shape and AbstractScalar.
+Used in myia/operations/op_full.py
+"""
+
+from ..lib import SHAPE, TYPE, AbstractArray, Constant, macro
+from ..xtype import NDArray
+
+
+@macro
+async def abstract_array(info, shape, dtype):
+    """Return a constant with the type of the input."""
+    array_shape = await shape.get()
+    scalar_type = await dtype.get()
+    output_shape = tuple(
+        element.xvalue() for element in array_shape.children())
+    return Constant(
+        AbstractArray(scalar_type, {SHAPE: output_shape, TYPE: NDArray}))
+
+
+__operation_defaults__ = {
+    'name': 'abstract_array',
+    'registered_name': 'abstract_array',
+    'mapping': abstract_array,
+    'python_implementation': None,
+}

--- a/myia/operations/macro_abstract_array.py
+++ b/myia/operations/macro_abstract_array.py
@@ -15,7 +15,7 @@ async def abstract_array(info, shape, dtype):
     array_shape = await shape.get()
     scalar_type = await dtype.get()
     output_shape = tuple(
-        element.xvalue() for element in array_shape.children())
+        int(element.xvalue()) for element in array_shape.children())
     return Constant(
         AbstractArray(scalar_type, {SHAPE: output_shape, TYPE: NDArray}))
 

--- a/myia/operations/macro_to_scalar_type.py
+++ b/myia/operations/macro_to_scalar_type.py
@@ -23,14 +23,16 @@ from ..lib import (
 from ..xtype import Number, String, pytype_to_myiatype
 
 
-def convert_to_scalar_type(sync_data):
+@macro
+async def to_scalar_type(info, data):
     """
-    Main code to convert given data to abstract scalar.
+    Convert given data to abstract scalar.
 
-    :param sync_data: arbitrary data to convert
+    :param data: arbitrary data to convert
     :return: an abstract scalar object if data can be converted,
         otherwise raise an exception.
     """
+    sync_data = await data.get()
     if isinstance(sync_data, AbstractType):
         return Constant(sync_data.xvalue())
     elif isinstance(sync_data, AbstractScalar):
@@ -41,13 +43,6 @@ def convert_to_scalar_type(sync_data):
             myia_type = pytype_to_myiatype(np.dtype(sync_data.xvalue()).type)
             return Constant(AbstractScalar({VALUE: ANYTHING, TYPE: myia_type}))
     raise Exception('Unable to convert data to scalar type: %s' % sync_data)
-
-
-@macro
-async def to_scalar_type(info, data):
-    """Return a constant with the result of `data.xvalue()`."""
-    sync_data = await data.get()
-    return convert_to_scalar_type(sync_data)
 
 
 __operation_defaults__ = {

--- a/myia/operations/macro_to_scalar_type.py
+++ b/myia/operations/macro_to_scalar_type.py
@@ -1,0 +1,58 @@
+"""
+Implementation of 'to_scalar_type' operation.
+
+Convert given data into an appropriate abstract scalar.
+If data is already an abstract type, return the result of method xvalue().
+If data is already an abstract scalar with a number type, return it as is.
+If data is an abstract scalar with a string type, try to infer type
+from given string and return an abstract scalar with inferred type.
+Used in myia/operations/op_full.py
+"""
+
+import numpy as np
+
+from ..lib import (
+    ANYTHING,
+    TYPE,
+    VALUE,
+    AbstractScalar,
+    AbstractType,
+    Constant,
+    macro,
+)
+from ..xtype import Nil, Number, String, pytype_to_myiatype
+
+
+def convert_to_scalar_type(sync_data):
+    """
+    Main code to convert given data to abstract scalar.
+
+    :param sync_data: arbitrary data to convert
+    :return: an abstract scalar object if data can be converted,
+        otherwise raise an exception.
+    """
+    if isinstance(sync_data, AbstractType):
+        return Constant(sync_data.xvalue())
+    elif isinstance(sync_data, AbstractScalar):
+        xtype = sync_data.xtype()
+        if issubclass(xtype, Number):
+            return Constant(sync_data)
+        elif xtype is String:
+            myia_type = pytype_to_myiatype(np.dtype(sync_data.xvalue()).type)
+            return Constant(AbstractScalar({VALUE: ANYTHING, TYPE: myia_type}))
+    raise Exception('Unable to convert data to scalar type: %s' % sync_data)
+
+
+@macro
+async def to_scalar_type(info, data):
+    """Return a constant with the result of `data.xvalue()`."""
+    sync_data = await data.get()
+    return convert_to_scalar_type(sync_data)
+
+
+__operation_defaults__ = {
+    'name': 'to_scalar_type',
+    'registered_name': 'to_scalar_type',
+    'mapping': to_scalar_type,
+    'python_implementation': None,
+}

--- a/myia/operations/macro_to_scalar_type.py
+++ b/myia/operations/macro_to_scalar_type.py
@@ -20,7 +20,7 @@ from ..lib import (
     Constant,
     macro,
 )
-from ..xtype import Nil, Number, String, pytype_to_myiatype
+from ..xtype import Number, String, pytype_to_myiatype
 
 
 def convert_to_scalar_type(sync_data):

--- a/myia/operations/macro_to_scalar_type.py
+++ b/myia/operations/macro_to_scalar_type.py
@@ -58,7 +58,7 @@ async def to_scalar_type(info, data):
     sync_data = await data.get()
 
     # We expect either:
-    # - an abstract string containing an abstract scalar with scalar type
+    # - an abstract type containing an abstract scalar with scalar type
     # - an abstract scalar containing a string to be parsed to a scalar type
 
     if isinstance(sync_data, AbstractType):

--- a/myia/operations/macro_to_scalar_type.py
+++ b/myia/operations/macro_to_scalar_type.py
@@ -43,7 +43,7 @@ async def to_scalar_type(info, data):
             myia_type = pytype_to_myiatype(np.dtype(sync_data.xvalue()).type)
             return Constant(AbstractScalar({VALUE: ANYTHING, TYPE: myia_type}))
     else:
-        raise Exception(
+        raise TypeError(
             'Unable to convert data to scalar type: %s' % sync_data)
 
 

--- a/myia/operations/macro_to_scalar_type.py
+++ b/myia/operations/macro_to_scalar_type.py
@@ -34,15 +34,17 @@ async def to_scalar_type(info, data):
     """
     sync_data = await data.get()
     if isinstance(sync_data, AbstractType):
-        return Constant(sync_data.xvalue())
-    elif isinstance(sync_data, AbstractScalar):
+        sync_data = sync_data.xvalue()
+    if isinstance(sync_data, AbstractScalar):
         xtype = sync_data.xtype()
         if issubclass(xtype, Number):
             return Constant(sync_data)
         elif xtype is String:
             myia_type = pytype_to_myiatype(np.dtype(sync_data.xvalue()).type)
             return Constant(AbstractScalar({VALUE: ANYTHING, TYPE: myia_type}))
-    raise Exception('Unable to convert data to scalar type: %s' % sync_data)
+    else:
+        raise Exception(
+            'Unable to convert data to scalar type: %s' % sync_data)
 
 
 __operation_defaults__ = {

--- a/myia/operations/op_full.py
+++ b/myia/operations/op_full.py
@@ -1,0 +1,47 @@
+"""Implementation of operation for numpy.full."""
+
+import numpy as np
+
+from ..lib import (
+    abstract_array,
+    core,
+    distribute,
+    myia_to_array,
+    scalar_cast,
+    to_scalar_type,
+    typeof,
+)
+
+
+def pyimpl_full(shape, fill_value, dtype):
+    """Python implementation for operation full."""
+    return np.full(shape, fill_value, dtype)
+
+
+@core
+def full(shape, fill_value, dtype=None):
+    """
+    Main code for operation full.
+
+    :param shape: a tuple of integers
+    :param fill_value: a scalar value
+    :param dtype: either a string (e.g. 'int32')
+        or a numpy dtype (e.g. np.int32)
+    :return: an array
+    """
+    if dtype is None:
+        dtype = typeof(fill_value)
+    abstract_scalar_type = to_scalar_type(dtype)
+    scalar_value = scalar_cast(fill_value, abstract_scalar_type)
+    return distribute(
+        myia_to_array(scalar_value, abstract_array(shape, scalar_value)),
+        shape
+    )
+
+
+__operation_defaults__ = {
+    'name': 'full',
+    'registered_name': 'full',
+    'mapping': full,
+    'python_implementation': pyimpl_full,
+}

--- a/myia/operations/ops_array.py
+++ b/myia/operations/ops_array.py
@@ -5,7 +5,13 @@ from dataclasses import dataclass
 from .. import lib, operations
 from ..hypermap import HyperMap
 from ..lib import core, myia_static
-from ..operations import array_reduce, primitives as P, scalar_add, shape
+from ..operations import (
+    array_reduce,
+    primitives as P,
+    scalar_add,
+    scalar_mul,
+    shape,
+)
 from .utils import OperationDefinition, to_opdef
 
 
@@ -54,6 +60,13 @@ array_ge = elemwise('array_ge', operations.ge, infer_value=True)
 def sum(x):
     """Implementation of `sum`."""
     return array_reduce(scalar_add, x, ())
+
+
+@to_opdef
+@core
+def prod(x):
+    """Implementation of `np.prod`. Parameter `axis` is not yet supported."""
+    return array_reduce(scalar_mul, x, ())
 
 
 @to_opdef

--- a/myia/pipeline/standard.py
+++ b/myia/pipeline/standard.py
@@ -71,6 +71,7 @@ python_operation_map = {
     math.cos: operations.scalar_cos,
     math.tan: operations.scalar_tan,
     math.tanh: operations.scalar_tanh,
+    np.full: operations.full,
     np.abs: operations.array_abs,
     np.sign: operations.array_sign,
     np.floor: operations.array_floor,
@@ -88,6 +89,7 @@ python_operation_map = {
     np.tan: operations.array_tan,
     np.tanh: operations.array_tanh,
     np.sum: operations.sum,
+    np.prod: operations.prod,
 }
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -64,6 +64,10 @@ def ai16_of(*shp, value=ANYTHING):
     return arr_of(i16, shp, value)
 
 
+def au64_of(*shp, value=ANYTHING):
+    return arr_of(u64, shp, value)
+
+
 def af64_of(*shp, value=ANYTHING):
     return arr_of(f64, shp, value)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,4 +1,4 @@
-
+import inspect
 import typing
 from dataclasses import dataclass, is_dataclass
 
@@ -139,7 +139,7 @@ def to_abstract_test(self, x: (bool, int, float, str,
                                EnvInstance)):
     return AbstractScalar({
         VALUE: x,
-        TYPE: xtype.pytype_to_myiatype(type(x)),
+        TYPE: xtype.pytype_to_myiatype(x if inspect.isclass(x) else type(x)),
     })
 
 

--- a/tests/operations/test_operations.py
+++ b/tests/operations/test_operations.py
@@ -1,3 +1,6 @@
+import numpy as np
+
+from myia import myia
 from myia.xtype import i32, i64, u32
 
 from ..multitest import infer, mt, run, run_no_relay
@@ -51,3 +54,25 @@ def test_bitwise_lshift(a, b):
 )
 def test_bitwise_rshift(a, b):
     return a >> b
+
+
+def test_op_full():
+    @myia
+    def run_full(value):
+        return np.full((2, 7), value, 'float16')
+
+    expected = np.ones((2, 7), 'float16') * 4
+    output = run_full(4)
+    assert output.dtype == np.float16
+    assert np.allclose(expected, output)
+
+
+def test_op_prod():
+    @myia
+    def run_prod(val):
+        return np.prod(val)
+
+    values = np.arange(1, 6)
+    expected = np.prod(values)
+    output = run_prod(values)
+    assert expected == output == 120

--- a/tests/operations/test_operations.py
+++ b/tests/operations/test_operations.py
@@ -56,6 +56,14 @@ def test_bitwise_rshift(a, b):
     return a >> b
 
 
+@mt(
+    run(np.arange(10), result=np.prod(np.arange(10))),
+    run(np.asarray([-2, -1, 2, 11], dtype='float32'), result=np.float32(44)),
+)
+def test_prod(arr):
+    return np.prod(arr)
+
+
 def test_op_full():
     @myia
     def run_full(value):

--- a/tests/operations/test_operations.py
+++ b/tests/operations/test_operations.py
@@ -5,6 +5,11 @@ from myia.xtype import i32, i64, u32
 from ..multitest import infer, mt, run, run_no_relay
 
 
+def Shp(*values):
+    """Convert values to a tuple of numpy unsigned itnegers."""
+    return tuple(np.uint64(value) for value in values)
+
+
 @mt(
     infer(u32, u32, result=u32),
     infer(i32, i32, result=i32),
@@ -56,7 +61,7 @@ def test_bitwise_rshift(a, b):
 
 
 @mt(
-    run(np.arange(10), result=np.prod(np.arange(10))),
+    run(np.arange(1, 11), result=3628800),
     run(np.asarray([-2, -1, 2, 11], dtype='float32'), result=np.float32(44)),
 )
 def test_prod(arr):
@@ -64,10 +69,10 @@ def test_prod(arr):
 
 
 @mt(
-    run((2, 3), 0, None, result=np.zeros((2, 3), 'float32')),
-    run((8,), 1, 'float16', result=np.ones((8,), 'float16')),
-    run((1, 4), -2.5, None, result=(-2.5 * np.ones((1, 4), 'float32'))),
-    run((1, 4), -2.5, 'float64', result=(-2.5 * np.ones((1, 4), 'float64'))),
+    run(Shp(2, 3), 0, None, result=np.zeros((2, 3), 'float32')),
+    run(Shp(8,), 1, 'float16', result=np.ones((8,), 'float16')),
+    run(Shp(1, 4), -2.5, None, result=(-2.5 * np.ones((1, 4), 'float32'))),
+    run(Shp(1, 4), -2.5, 'double', result=(-2.5 * np.ones((1, 4), 'double'))),
     broad_specs=(False, False, False),
 )
 def test_full(shape, value, dtype):

--- a/tests/operations/test_operations.py
+++ b/tests/operations/test_operations.py
@@ -1,10 +1,10 @@
 import numpy as np
-import pytest
 
-from myia import myia
+from myia.utils.errors import MyiaTypeError
 from myia.xtype import f16, f32, f64, i16, i32, i64, u32
 
 from ..common import (
+    Ty,
     af16_of,
     af32_of,
     af64_of,
@@ -94,6 +94,10 @@ def test_full(shape, value, dtype):
 
 
 @mt(
+    # An error should be raised if wrong values are given as types.
+    infer(Shp(2, 3), i32, 'bad string', result=MyiaTypeError),
+    infer(Shp(2, 3), i32, 10, result=MyiaTypeError),
+    infer(Shp(2, 3), i32, (), result=MyiaTypeError),
     # If d-type is not specified, output type should be type of fill value.
     infer(Shp(2, 3), i16, None, result=ai16_of(2, 3)),
     infer(Shp(2, 3), i64, None, result=ai64_of(2, 3)),
@@ -107,33 +111,9 @@ def test_full(shape, value, dtype):
     infer(Shp(2, 3), f64, 'int32', result=ai32_of(2, 3)),
     infer(Shp(2, 3), f64, 'uint64', result=au64_of(2, 3)),
     # Numpy d-types should also be accepted as d-types.
-    infer(Shp(2, 3), i64, np.int16, result=ai16_of(2, 3)),
-    infer(Shp(2, 3), i64, np.float16, result=af16_of(2, 3)),
-    infer(Shp(2, 3), f64, np.uint64, result=au64_of(2, 3)),
+    infer(Shp(2, 3), i64, Ty(np.int16), result=ai16_of(2, 3)),
+    infer(Shp(2, 3), i64, Ty(np.float16), result=af16_of(2, 3)),
+    infer(Shp(2, 3), f64, Ty(np.uint64), result=au64_of(2, 3)),
 )
 def test_infer_full(shape, value, dtype):
     return np.full(shape, value, dtype)
-
-
-def test_full_bad_dtype():
-    """Test op full with wrong given d-types."""
-    for dtype, should_raise in (
-            ('float16', False),
-            (int, False),
-            (np.float16, False),
-            ('bad string', True),
-            # Bad value (integer, neither type not string)
-            (10, True),
-            # Bad value (a tuple)
-            ((), True),
-    ):
-        @myia
-        def test():
-            return np.full((2, 3), 0, dtype)
-
-        if should_raise:
-            with pytest.raises(TypeError):
-                test()
-        else:
-            result = test()
-            assert np.dtype(result.dtype).type is np.dtype(dtype).type

--- a/tests/operations/test_operations.py
+++ b/tests/operations/test_operations.py
@@ -104,6 +104,10 @@ def test_full(shape, value, dtype):
     infer(Shp(2, 3), f64, 'int16', result=ai16_of(2, 3)),
     infer(Shp(2, 3), f64, 'int32', result=ai32_of(2, 3)),
     infer(Shp(2, 3), f64, 'uint64', result=au64_of(2, 3)),
+    # Numpy d-types should also be accepted as d-types.
+    infer(Shp(2, 3), i64, np.int16, result=ai16_of(2, 3)),
+    infer(Shp(2, 3), i64, np.float16, result=af16_of(2, 3)),
+    infer(Shp(2, 3), f64, np.uint64, result=au64_of(2, 3)),
 )
 def test_infer_full(shape, value, dtype):
     return np.full(shape, value, dtype)

--- a/tests/operations/test_operations.py
+++ b/tests/operations/test_operations.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-from myia import myia
 from myia.xtype import i32, i64, u32
 
 from ..multitest import infer, mt, run, run_no_relay
@@ -64,23 +63,12 @@ def test_prod(arr):
     return np.prod(arr)
 
 
-def test_op_full():
-    @myia
-    def run_full(value):
-        return np.full((2, 7), value, 'float16')
-
-    expected = np.ones((2, 7), 'float16') * 4
-    output = run_full(4)
-    assert output.dtype == np.float16
-    assert np.allclose(expected, output)
-
-
-def test_op_prod():
-    @myia
-    def run_prod(val):
-        return np.prod(val)
-
-    values = np.arange(1, 6)
-    expected = np.prod(values)
-    output = run_prod(values)
-    assert expected == output == 120
+@mt(
+    run((2, 3), 0, None, result=np.zeros((2, 3), 'float32')),
+    run((8,), 1, 'float16', result=np.ones((8,), 'float16')),
+    run((1, 4), -2.5, None, result=(-2.5 * np.ones((1, 4), 'float32'))),
+    run((1, 4), -2.5, 'float64', result=(-2.5 * np.ones((1, 4), 'float64'))),
+    broad_specs=(False, False, False),
+)
+def test_full(shape, value, dtype):
+    return np.full(shape, value, dtype)

--- a/tests/prim/test_py_implementations.py
+++ b/tests/prim/test_py_implementations.py
@@ -30,6 +30,7 @@ from myia.operations import (
     env_add,
     env_getitem,
     env_setitem,
+    full,
     identity,
     partial as myia_partial,
     reshape,
@@ -399,6 +400,13 @@ def test_prim_dot():
     res = dot(a, b)
 
     assert (res == ref).all()
+
+
+def test_op_full():
+    ref = np.full((4, 9), -4, 'float16')
+    res = full((4, 9), -4, np.float16)
+    assert res.dtype == 'float16'
+    assert np.allclose(ref, res, rtol=0, atol=0)
 
 
 def test_prim_scalar_bit_lshift():


### PR DESCRIPTION
TODO:
- testing
- some issues for op full with relay backend
- some issues sometimes for op full when passing string as dtypes (e.g. `'int32'`)

@breuleux 