### PR TITLE
Pytorch frontend op cross_entropy

### DIFF
--- a/myia/frontends/pytorch.py
+++ b/myia/frontends/pytorch.py
@@ -5,7 +5,6 @@ import types
 from collections import OrderedDict
 
 import torch
-import torch.nn.functional
 
 from .. import operations
 from ..abstract.data import (

--- a/myia/frontends/pytorch.py
+++ b/myia/frontends/pytorch.py
@@ -5,6 +5,7 @@ import types
 from collections import OrderedDict
 
 import torch
+import torch.nn.functional
 
 from .. import operations
 from ..abstract.data import (
@@ -36,6 +37,7 @@ from .pytorch_functions import (
     cat,
     chunk,
     conv2d,
+    cross_entropy,
     gather,
     item,
     linear,
@@ -98,6 +100,7 @@ standard_object_map.update({
     torch.var: var,
     # torch.zeros_like: C.zeros_like,  # currently only works with pt backend
     torch.nn.functional.conv2d: conv2d,
+    torch.nn.functional.cross_entropy: cross_entropy,
     torch.nn.functional.linear: linear,
     torch.nn.functional.max_pool2d: max_pool2d,
     torch.nn.functional.mse_loss: mse_loss,

--- a/myia/frontends/pytorch_functions.py
+++ b/myia/frontends/pytorch_functions.py
@@ -19,7 +19,6 @@ import operator
 from functools import reduce
 
 import torch
-import torch.nn.functional
 
 from .. import operations
 from ..abstract import myia_static
@@ -270,10 +269,10 @@ def conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1,
 
 
 @core
-def cross_entropy(input, target):
+def cross_entropy(input, target, reduction='mean'):
     """Map of method torch.nn.functional.cross_entropy."""
     a = torch.nn.functional.log_softmax(input, 1)
-    b = torch.nn.functional.nll_loss(a, target)
+    b = torch.nn.functional.nll_loss(a, target, reduction=reduction)
     return b
 
 

--- a/myia/frontends/pytorch_functions.py
+++ b/myia/frontends/pytorch_functions.py
@@ -19,6 +19,7 @@ import operator
 from functools import reduce
 
 import torch
+import torch.nn.functional
 
 from .. import operations
 from ..abstract import myia_static
@@ -266,6 +267,14 @@ def conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1,
     if bias is not None:
         ret = ret + bias.reshape((1, bias.shape[0], 1, 1))
     return ret
+
+
+@core
+def cross_entropy(input, target):
+    """Map of method torch.nn.functional.cross_entropy."""
+    a = torch.nn.functional.log_softmax(input, 1)
+    b = torch.nn.functional.nll_loss(a, target)
+    return b
 
 
 @core
@@ -646,6 +655,7 @@ def zeros(*shp, dtype=None):
 
 __all__ = [
     'conv2d',
+    'cross_entropy',
     'item',
     'linear',
     'relu',

--- a/tests/frontends/test_pytorch_ops.py
+++ b/tests/frontends/test_pytorch_ops.py
@@ -314,28 +314,20 @@ def test_torch_conv2d__group3(inp, w, b):
 @mt(
     fwd_and_bwd_no_relay(nn.Parameter(torch.Tensor(torch.randn(3, 5))),
                          nn.Parameter(torch.randint(5, (3,)),
-                                      requires_grad=False)),
-)
-def test_torch_cross_entropy_mean(inp, target):
-    return F.cross_entropy(inp, target, reduction='mean')
-
-
-@mt(
+                                      requires_grad=False),
+                         'mean'),
     fwd_and_bwd_no_relay(nn.Parameter(torch.Tensor(torch.randn(3, 5))),
                          nn.Parameter(torch.randint(5, (3,)),
-                                      requires_grad=False)),
-)
-def test_torch_cross_entropy_none(inp, target):
-    return F.cross_entropy(inp, target, reduction='none')
-
-
-@mt(
+                                      requires_grad=False),
+                         'none'),
     fwd_and_bwd_no_relay(nn.Parameter(torch.Tensor(torch.randn(3, 5))),
                          nn.Parameter(torch.randint(5, (3,)),
-                                      requires_grad=False)),
+                                      requires_grad=False),
+                         'sum'),
+    broad_specs=(True, True, False)
 )
-def test_torch_cross_entropy_sum(inp, target):
-    return F.cross_entropy(inp, target, reduction='sum')
+def test_torch_cross_entropy(inp, target, reduction):
+    return F.cross_entropy(inp, target, reduction=reduction)
 
 
 @fwd_and_bwd_no_relay(nn.Parameter(torch.Tensor(MA(3, 4))),

--- a/tests/frontends/test_pytorch_ops.py
+++ b/tests/frontends/test_pytorch_ops.py
@@ -311,6 +311,17 @@ def test_torch_conv2d__group3(inp, w, b):
     return torch.sum(value)
 
 
+@mt(
+    fwd_and_bwd(nn.Parameter(torch.Tensor(torch.randn(3, 5))),
+                nn.Parameter(torch.randint(5, (3,)),
+                             requires_grad=False)),
+    run(torch.randn(3, 5), torch.randint(5, (3,))),
+    backend=backend_no_relay
+)
+def test_torch_cross_entropy(inp, target):
+    return F.cross_entropy(inp, target)
+
+
 @fwd_and_bwd_no_relay(nn.Parameter(torch.Tensor(MA(3, 4))),
                       torch.tensor([[0, 1, 2, 0], [0, 0, 0, 1]]))
 def test_torch_gather(x, index):

--- a/tests/frontends/test_pytorch_ops.py
+++ b/tests/frontends/test_pytorch_ops.py
@@ -317,7 +317,7 @@ def test_torch_conv2d__group3(inp, w, b):
                                       requires_grad=False)),
 )
 def test_torch_cross_entropy_mean(inp, target):
-    return F.cross_entropy(inp, target, reduction='none')
+    return F.cross_entropy(inp, target, reduction='mean')
 
 
 @mt(

--- a/tests/frontends/test_pytorch_ops.py
+++ b/tests/frontends/test_pytorch_ops.py
@@ -312,14 +312,30 @@ def test_torch_conv2d__group3(inp, w, b):
 
 
 @mt(
-    fwd_and_bwd(nn.Parameter(torch.Tensor(torch.randn(3, 5))),
-                nn.Parameter(torch.randint(5, (3,)),
-                             requires_grad=False)),
-    run(torch.randn(3, 5), torch.randint(5, (3,))),
-    backend=backend_no_relay
+    fwd_and_bwd_no_relay(nn.Parameter(torch.Tensor(torch.randn(3, 5))),
+                         nn.Parameter(torch.randint(5, (3,)),
+                                      requires_grad=False)),
 )
-def test_torch_cross_entropy(inp, target):
-    return F.cross_entropy(inp, target)
+def test_torch_cross_entropy_mean(inp, target):
+    return F.cross_entropy(inp, target, reduction='none')
+
+
+@mt(
+    fwd_and_bwd_no_relay(nn.Parameter(torch.Tensor(torch.randn(3, 5))),
+                         nn.Parameter(torch.randint(5, (3,)),
+                                      requires_grad=False)),
+)
+def test_torch_cross_entropy_none(inp, target):
+    return F.cross_entropy(inp, target, reduction='none')
+
+
+@mt(
+    fwd_and_bwd_no_relay(nn.Parameter(torch.Tensor(torch.randn(3, 5))),
+                         nn.Parameter(torch.randint(5, (3,)),
+                                      requires_grad=False)),
+)
+def test_torch_cross_entropy_sum(inp, target):
+    return F.cross_entropy(inp, target, reduction='sum')
 
 
 @fwd_and_bwd_no_relay(nn.Parameter(torch.Tensor(MA(3, 4))),


### PR DESCRIPTION
Hi @breuleux @abergeron @ethancaballero 

This is a PR to implement pytorch frontend operation `cross_entropy`.

@ethancaballero I did not yet try to implement all cross entropy function parameters (weight, size_average, ignore_index, reduce and reduction), I just implemented input and target parameters. Could you check if I modified right files in right places ? Should I implement all parameters ?

Thanks!