### PR TITLE
Less GPU tests

### DIFF
--- a/tests/compile/test_backend.py
+++ b/tests/compile/test_backend.py
@@ -6,10 +6,16 @@ from myia.compile.backends import (
     load_backend,
     parse_default,
 )
-from myia.operations import array_reduce, reshape, scalar_add, scalar_to_array
+from myia.operations import (
+    array_reduce,
+    array_to_scalar,
+    reshape,
+    scalar_add,
+    scalar_to_array,
+)
 
 from ..common import AN, MA
-from ..multitest import mt, run
+from ..multitest import mt, run, run_gpu
 
 
 def test_default_backend():
@@ -75,6 +81,11 @@ def test_array_reduce2(x):
     return array_reduce(scalar_add, x, (3,))
 
 
+@run_gpu(MA(1, 1))
+def test_array_to_scalar(x):
+    return array_to_scalar(reshape(x, ()))
+
+
 @mt(
     run(2, 3),
     run(2.0, 3.0),
@@ -83,7 +94,7 @@ def test_truediv(x, y):
     return x / y
 
 
-@run(2)
+@run_gpu(2)
 def test_to_array(x):
     return scalar_to_array(x, AN)
 

--- a/tests/frontends/test_pytorch.py
+++ b/tests/frontends/test_pytorch.py
@@ -713,7 +713,8 @@ def test_optim_setitem():
         return _cost, update(model, dmodel, update_sgd)
     loss, model_new = step(model, inp, target)
 
-    assert loss.item() == 161.05856323242188
+    expected_loss = torch.Tensor([161.05856323242188])
+    assert torch.allclose(loss, expected_loss)
 
     expected_param = torch.Tensor([[-0.21953332, -0.31154382, -0.29184943],
                                    [-0.47497076, -0.39380032, -0.32451797],

--- a/tests/multitest.py
+++ b/tests/multitest.py
@@ -280,7 +280,7 @@ def _run(self, fn, args, result=None, abstract=None, broad_specs=None,
     self.check(out, args, result)
 
 
-backend_all = Multiple(
+backend_gpu = Multiple(
     pytest.param(('relay', {'target': 'cpu', 'device_id': 0}),
                  id='relay-cpu',
                  marks=pytest.mark.relay),
@@ -294,15 +294,21 @@ backend_all = Multiple(
                  id='pytorch-cuda',
                  marks=[pytest.mark.pytorch, pytest.mark.gpu])
 )
+backend_all = Multiple(
+    pytest.param(('relay', {'target': 'cpu', 'device_id': 0}),
+                 id='relay-cpu',
+                 marks=pytest.mark.relay),
+    pytest.param(('pytorch', {'device': 'cpu'}),
+                 id='pytorch-cpu',
+                 marks=pytest.mark.pytorch),
+)
 backend_no_relay = Multiple(
     pytest.param(('pytorch', {'device': 'cpu'}),
                  id='pytorch-cpu',
                  marks=pytest.mark.pytorch),
-    pytest.param(('pytorch', {'device': 'cuda'}),
-                 id='pytorch-cuda',
-                 marks=[pytest.mark.pytorch, pytest.mark.gpu])
 )
 run = _run.configure(backend=backend_all)
+run_gpu = _run.configure(backend=backend_gpu)
 run_no_relay = _run.configure(backend=backend_no_relay)
 run_debug = run.configure(pipeline=standard_debug_pipeline, validate=False,
                           backend=False)


### PR DESCRIPTION
We don't need to test every backend operation on the CPU and GPU.

This PR significantly cuts down on the number of things that we run on the GPU and makes the test suite faster.