### PR TITLE
Update relay backend for newer TVM

### DIFF
--- a/myia/compile/backends/relay.py
+++ b/myia/compile/backends/relay.py
@@ -27,7 +27,6 @@ from .relay_helpers import (
     get_myia_tag,
     get_union_ctr,
     handle_wrapper,
-    optimize,
     to_relay_type,
 )
 
@@ -590,8 +589,6 @@ class CompileGraph:
 
         self.types.finalize(self.module)
         add_functions(self.module, function_map)
-
-        self.module = optimize(self.module)
 
         vm = relay.create_executor(mod=self.module, ctx=context,
                                    target=target, kind='vm')

--- a/myia/compile/backends/relay.py
+++ b/myia/compile/backends/relay.py
@@ -31,7 +31,7 @@ from .relay_helpers import (
 )
 
 
-EXEC_KIND = 'vm'
+EXEC_KIND = 'debug'
 
 
 @wrap_result.register

--- a/myia/compile/backends/relay.py
+++ b/myia/compile/backends/relay.py
@@ -1,9 +1,7 @@
 """Transforms a graph into lower-level code."""
 
-from itertools import accumulate
 import os
-
-import numpy as np
+from itertools import accumulate
 
 import numpy as np
 import tvm
@@ -25,6 +23,7 @@ from .relay_helpers import (
     add_functions,
     dead_value,
     empty_env,
+    fill_reverse_tag_map,
     get_myia_tag,
     get_union_ctr,
     handle_wrapper,
@@ -598,6 +597,8 @@ class CompileGraph:
                                    target=target, kind='vm')
         res = vm.evaluate(self.module["main"])
 
+        fill_reverse_tag_map()
+
         res = handle_wrapper(res, handles_params)
 
         def f(*args):
@@ -762,7 +763,7 @@ class RelayOutputConverter(Converter):
 
     def convert_tagged(self, v, t):
         tag = get_myia_tag(v.tag)
-        conv_val = self(v.fields[0], t.options.get(tag))
+        conv_val = self(v[0], t.options.get(tag))
         return TaggedValue(tag, conv_val)
 
 

--- a/myia/compile/backends/relay.py
+++ b/myia/compile/backends/relay.py
@@ -38,7 +38,8 @@ def wrap_result(data: tvm.runtime.container.ADT):
     if data.tag == 0:
         return tuple(handle(d) for d in data)
     else:
-        return handle(data)
+        raise ValueError(  # pragma: no cover
+            "Returning non-tuple from top-level function.")
 
 
 def ashape(node):

--- a/myia/compile/backends/relay.py
+++ b/myia/compile/backends/relay.py
@@ -32,9 +32,12 @@ from .relay_helpers import (
 
 
 @wrap_result.register
-def wrap_result(data: interpreter.TupleValue):
+def wrap_result(data: tvm.container.ADT):
     """Wrap tuples from relay."""
-    return tuple(handle(d) for d in data)
+    if data.tag == 0:
+        return tuple(handle(d) for d in data)
+    else:
+        return handle(data)
 
 
 def ashape(node):

--- a/myia/compile/backends/relay.py
+++ b/myia/compile/backends/relay.py
@@ -514,7 +514,7 @@ class RelayConstantConverter(Converter):
 
     def convert_array(self, v, t):  # pragma: no cover
         """Make a TVM array from a numpy array."""
-        return relay.const(tvm.ndarray.array(v, self.context))
+        return relay.const(tvm.runtime.ndarray.array(v, self.context))
 
     def convert_scalar(self, v, t):
         """Convert the scalar to a TVM array."""
@@ -695,16 +695,16 @@ class RelayInputConverter(Converter):
 
     def convert_array(self, v, t):
         """Make a TVM array from a numpy array."""
-        return tvm.ndarray.array(v, self.context)
+        return tvm.runtime.ndarray.array(v, self.context)
 
     def convert_scalar(self, v, t):
         """Convert the scalar to a TVM array."""
-        return tvm.ndarray.array(getattr(np, type_to_np_dtype(t))(v),
-                                 self.context)
+        return tvm.runtime.ndarray.array(getattr(np, type_to_np_dtype(t))(v),
+                                         self.context)
 
     def convert_bool(self, v, t):
         """Convert the scalar to a TVM array."""
-        return tvm.ndarray.array(np.bool_(v), self.context)
+        return tvm.runtime.ndarray.array(np.bool_(v), self.context)
 
     def convert_nil(self, v, t):
         """Convert Nil to Relay."""
@@ -786,7 +786,7 @@ class RelayBackend(Backend):
     def __init__(self, target, device_id):
         """Create a Relay backend for the given device."""
         device_id = int(device_id)
-        self.context = tvm.ndarray.context(target, device_id)
+        self.context = tvm.runtime.ndarray.context(target, device_id)
         if target == 'cpu':
             target = 'llvm'
         self.target = target

--- a/myia/compile/backends/relay.py
+++ b/myia/compile/backends/relay.py
@@ -1,6 +1,5 @@
 """Transforms a graph into lower-level code."""
 
-import os
 from itertools import accumulate
 
 import numpy as np
@@ -29,7 +28,6 @@ from .relay_helpers import (
     handle_wrapper,
     to_relay_type,
 )
-
 
 EXEC_KIND = 'debug'
 

--- a/myia/compile/backends/relay.py
+++ b/myia/compile/backends/relay.py
@@ -35,7 +35,7 @@ EXEC_KIND = 'debug'
 
 
 @wrap_result.register
-def wrap_result(data: tvm.container.ADT):
+def wrap_result(data: tvm.runtime.container.ADT):
     """Wrap tuples from relay."""
     if data.tag == 0:
         return tuple(handle(d) for d in data)

--- a/myia/compile/backends/relay_helpers.py
+++ b/myia/compile/backends/relay_helpers.py
@@ -25,7 +25,7 @@ from ...xtype import Bool, EnvType, Nil, UniverseType, type_to_np_dtype
 
 union_type = relay.GlobalTypeVar('$_union_adt')
 empty_union = adt.Constructor("empty", [], union_type)
-tag_map = {}
+tag_map = {None: empty_union}
 rev_tag_map = {}
 
 

--- a/myia/compile/backends/relay_helpers.py
+++ b/myia/compile/backends/relay_helpers.py
@@ -5,7 +5,7 @@ Most of those should go away as Relay main development progresses.
 
 import numpy as np
 from tvm import relay
-from tvm.relay import adt, transform
+from tvm.relay import adt
 
 from ...abstract import (
     AbstractArray,

--- a/myia/compile/backends/relay_helpers.py
+++ b/myia/compile/backends/relay_helpers.py
@@ -310,30 +310,6 @@ def add_functions(mod, funcs):
         mod[gv] = funcs[gv]
 
 
-pass_set = transform.Sequential(
-    passes=[
-        transform.SimplifyInference(),
-        transform.CanonicalizeOps(),
-        transform.CanonicalizeCast(),
-        transform.FuseOps(3),
-        # transform.CombineParallelConv2d(),
-        transform.AlterOpLayout(),
-        # transform.RewriteAnnotatedOps(???),
-    ],
-    opt_level=0
-)
-
-
-def optimize(mod):
-    """Optimize all the functions in a module.
-
-    Modules are the only mutable piece of Relay.  We write an
-    optimization pass over the module which destructively updates each
-    function while optimizing.
-    """
-    return pass_set(mod)
-
-
 __all__ = [
     'TypeHelper',
     'add_functions',
@@ -342,6 +318,5 @@ __all__ = [
     'fill_reverse_tag_map',
     'get_myia_tag',
     'get_union_ctr',
-    'optimize',
     'to_relay_type',
 ]

--- a/myia/compile/backends/relay_helpers.py
+++ b/myia/compile/backends/relay_helpers.py
@@ -36,13 +36,26 @@ def get_union_ctr(tag, t):
         rt = to_relay_type(t)
         ctr = adt.Constructor(f"c{tag}", [rt], union_type)
         tag_map[tag] = ctr
-        rev_tag_map[ctr] = tag
     return tag_map[tag]
 
 
-def get_myia_tag(ctr):
-    """Return the myia tag for a constructor."""
-    return rev_tag_map[ctr]
+def fill_reverse_tag_map():
+    """Fill the back-conversion map.
+
+    Do this after a compilation step involving the constructors you
+    need since the tags are not set otherwise.
+    """
+    for tag, ctr in tag_map.items():
+        if ctr.tag != -1:
+            rev_tag_map[ctr.tag] = tag
+
+
+def get_myia_tag(rtag):
+    """Return the myia tag for a constructor.
+
+    This will fail if you haven't properly called fill_reverse_tag_map().
+    """
+    return rev_tag_map[rtag]
 
 
 env_val = relay.GlobalTypeVar('$_env_val')
@@ -326,6 +339,7 @@ __all__ = [
     'add_functions',
     'dead_value',
     'empty_env',
+    'fill_reverse_tag_map',
     'get_myia_tag',
     'get_union_ctr',
     'optimize',

--- a/requirements-cpu.conda
+++ b/requirements-cpu.conda
@@ -1,7 +1,7 @@
 python>=3.7,<3.8a0
 colorama
 numpy
-abergeron::tvm==0.6dev+3.*
+abergeron::tvm==0.7dev+0.*
 pytest
 pytest-cov
 yaml

--- a/requirements-gpu.conda
+++ b/requirements-gpu.conda
@@ -2,7 +2,7 @@ python>=3.7,<3.8a0
 colorama
 numpy
 abergeron/label/cuda::tvm-libs
-abergeron::tvm==0.6dev+3.*
+abergeron::tvm==0.7dev+0.*
 pytest
 pytest-cov
 yaml

--- a/tests/compile/test_backend.py
+++ b/tests/compile/test_backend.py
@@ -108,6 +108,11 @@ def test_bool_and_nil_args(x):
     return x
 
 
+@run(3)
+def test_return_tuple(x):
+    return (1, 2, x)
+
+
 @pytest.mark.xfail  # MyiaTypeError: AbstractTuple vs AbstractTaggedUnion
 @run(())
 def test_return_list():


### PR DESCRIPTION
This also restructures the I/O parts to be able to support the relay VM in the future (some cases are currently not working so it's still using the debug interpreter for now).