### PR TITLE
Use per-file-ignores in .flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,5 @@
 [flake8]
 ignore = W503,W504,E241,F722
+per-file-ignores =
+  __init__.py:F401,F403
+  myia/lib.py:F401,F403

--- a/myia/__init__.py
+++ b/myia/__init__.py
@@ -1,7 +1,7 @@
 """Myia."""
 
 
-from .api import myia  # noqa
-from .classes import ArithmeticData  # noqa
-from .hypermap import hyper_map  # noqa
-from .operations import grad, value_and_grad  # noqa
+from .api import myia
+from .classes import ArithmeticData
+from .hypermap import hyper_map
+from .operations import grad, value_and_grad

--- a/myia/abstract/__init__.py
+++ b/myia/abstract/__init__.py
@@ -1,11 +1,11 @@
 """Abstract data and type/shape inference."""
 
-from .aliasing import *  # noqa
-from .amerge import *  # noqa
-from .data import *  # noqa
-from .infer import *  # noqa
-from .loop import *  # noqa
-from .macro import *  # noqa
-from .ref import *  # noqa
-from .to_abstract import *  # noqa
-from .utils import *  # noqa
+from .aliasing import *
+from .amerge import *
+from .data import *
+from .infer import *
+from .loop import *
+from .macro import *
+from .ref import *
+from .to_abstract import *
+from .utils import *

--- a/myia/compile/__init__.py
+++ b/myia/compile/__init__.py
@@ -1,5 +1,5 @@
 """Compilation of graphs into optimized code."""
 
-from .backends import LoadingError, load_backend  # noqa
-from .cconv import closure_convert  # noqa
-from .utils import BackendValue  # noqa
+from .backends import LoadingError, load_backend
+from .cconv import closure_convert
+from .utils import BackendValue

--- a/myia/ir/__init__.py
+++ b/myia/ir/__init__.py
@@ -1,8 +1,8 @@
 """Main exports for ir submodule."""
 
-from .abstract import *  # noqa
-from .anf import *  # noqa
-from .clone import *  # noqa
-from .manager import *  # noqa
-from .metagraph import *  # noqa
-from .utils import *  # noqa
+from .abstract import *
+from .anf import *
+from .clone import *
+from .manager import *
+from .metagraph import *
+from .utils import *

--- a/myia/lib.py
+++ b/myia/lib.py
@@ -1,11 +1,11 @@
 """Consolidate all Myia functions in a single module."""
 
-from .abstract import *  # noqa
-from .classes import *  # noqa
-from .grad import *  # noqa
-from .hypermap import *  # noqa
-from .info import *  # noqa
-from .ir import *  # noqa
-from .operations import *  # noqa
-from .pipeline import *  # noqa
-from .utils import *  # noqa
+from .abstract import *
+from .classes import *
+from .grad import *
+from .hypermap import *
+from .info import *
+from .ir import *
+from .operations import *
+from .pipeline import *
+from .utils import *

--- a/myia/opt/__init__.py
+++ b/myia/opt/__init__.py
@@ -1,5 +1,5 @@
 """Optimization submodule."""
 
-from .cse import *  # noqa
-from .dde import *  # noqa
-from .opt import *  # noqa
+from .cse import *
+from .dde import *
+from .opt import *

--- a/myia/pipeline/__init__.py
+++ b/myia/pipeline/__init__.py
@@ -1,6 +1,6 @@
 """Contains Myia's pipeline definitions, steps, resources, etc."""
 
-from .pipeline import *  # noqa
-from .resources import *  # noqa
-from .standard import *  # noqa
-from .steps import *  # noqa
+from .pipeline import *
+from .resources import *
+from .standard import *
+from .steps import *

--- a/myia/utils/__init__.py
+++ b/myia/utils/__init__.py
@@ -1,15 +1,15 @@
 """General utilities."""
 
-from .env import *  # noqa
-from .errors import *  # noqa
-from .get_fields import *  # noqa
-from .intern import *  # noqa
-from .merge import *  # noqa
-from .misc import *  # noqa
-from .orderedset import *  # noqa
-from .overload import *  # noqa
-from .partial import *  # noqa
-from .serialize import *  # noqa
-from .trace import *  # noqa
-from .unify import *  # noqa
-from .universe import *  # noqa
+from .env import *
+from .errors import *
+from .get_fields import *
+from .intern import *
+from .merge import *
+from .misc import *
+from .orderedset import *
+from .overload import *
+from .partial import *
+from .serialize import *
+from .trace import *
+from .unify import *
+from .universe import *


### PR DESCRIPTION
flake8 can ignore certain errors on a per-file basis. We can use this to allow `import *` in `__init__.py` or `myia/lib.py` without allowing it elsewhere and without needing ugly `# noqa` comments.
