### PR TITLE
Add tan to relay backend.

### DIFF
--- a/myia/compile/backends/relay.py
+++ b/myia/compile/backends/relay.py
@@ -61,6 +61,7 @@ SIMPLE_MAP = {
     P.scalar_tanh: relay.op.tanh,
     P.scalar_sin: relay.op.sin,
     P.scalar_cos: relay.op.cos,
+    P.scalar_tan: relay.op.tan,
     P.scalar_trunc: relay.op.trunc,
     P.scalar_sign: relay.sign,
     P.scalar_abs: relay.abs,

--- a/tests/operations/test_operations.py
+++ b/tests/operations/test_operations.py
@@ -114,6 +114,19 @@ def test_cos(a):
 
 
 @mt(
+    # seems to not accept integers
+    run(0., result=0),
+    run(np.float16(0), result=0),
+    run(np.float32(0), result=0),
+    run(np.float64(0), result=0),
+    run(math.pi / 4, result=1),
+    run(2 * math.pi / 3, result=math.tan(2 * math.pi / 3))
+)
+def test_tan(a):
+    return math.tan(a)
+
+
+@mt(
     run(-2.7, result=-2),
     run(7.8, result=7),
     run(np.float16(7.8), result=7),
@@ -140,6 +153,15 @@ def test_elemwise_sin(a):
 )
 def test_elemwise_cos(a):
     return np.cos(a)
+
+
+@mt(
+    # cos seems not supported for pytorch/CPU/float16
+    run(MA(3, 3, dtype='float32'), result=np.tan(MA(3, 3, dtype='float32'))),
+    run(MA(3, 3, dtype='float64'), result=np.tan(MA(3, 3, dtype='float64'))),
+)
+def test_elemwise_tan(a):
+    return np.tan(a)
 
 
 @mt(


### PR DESCRIPTION
@abergeron @breuleux 

This PR adds `tan` to relay backend.

**NB**:

TVM API changed again, and now it seems `tvm.relay.Module` does not exist anymore. So, I guess we would need to update whole relay backend again to support new TVM API before merging this pull request.

On my computer, I use this code to compile relay with current TVM code:

```python
import tvm
from tvm import relay
from tvm.contrib import graph_runtime


# Old way, does not work anymore currently.
def compile_function_old(inputs, output):
    f = relay.Function(list(inputs), output)
    m = relay.Module({})
    fn = relay.GlobalVar('f')
    m[fn] = f
    e = relay.create_executor(mod=m)
    c = e.evaluate(m[fn])
    return c


# New way. I don't know if another way exists, but this works now.
def compile_function(inputs, output):
    ir = relay.Function(list(inputs), output)
    mod = tvm.IRModule.from_expr(ir)
    target = tvm.target.create('llvm')
    graph, lib, params = relay.build(mod, target=target)
    ctx = tvm.cpu()
    module = graph_runtime.create(graph, lib, ctx)

    def fn(*args):
        for i in range(len(inputs)):
            module.set_input(i, args[i])
        module.set_input(**params)
        module.run()
        out = module.get_output(0)
        return out

    return fn
```