### PR TITLE
(wip)(do not merge) Run all tests on relay

### DIFF
--- a/myia/compile/backends/pytorch.py
+++ b/myia/compile/backends/pytorch.py
@@ -382,7 +382,7 @@ def pytorch_conv_transpose2d(op):
     """Implementation of conv_transpose2d."""
 
     def _impl(
-        input, weight, bias, stride, padding, output_padding, groups, dilation
+        input, weight, stride, padding, output_padding, groups, dilation
     ):
         stride = tuple(_x.item() for _x in stride)
         padding = tuple(_x.item() for _x in padding)
@@ -392,7 +392,7 @@ def pytorch_conv_transpose2d(op):
         return torch.conv_transpose2d(
             input,
             weight,
-            bias,
+            None,
             stride,
             padding,
             output_padding,

--- a/myia/compile/backends/pytorch.py
+++ b/myia/compile/backends/pytorch.py
@@ -381,9 +381,7 @@ def pytorch_conv2d(op):
 def pytorch_conv_transpose2d(op):
     """Implementation of conv_transpose2d."""
 
-    def _impl(
-        input, weight, stride, padding, output_padding, groups, dilation
-    ):
+    def _impl(input, weight, stride, padding, output_padding, groups, dilation):
         stride = tuple(_x.item() for _x in stride)
         padding = tuple(_x.item() for _x in padding)
         output_padding = tuple(_x.item() for _x in output_padding)

--- a/myia/compile/backends/relay.py
+++ b/myia/compile/backends/relay.py
@@ -394,6 +394,7 @@ def relay_conv_transpose2d(
     _, w_c, filter_h, filter_w = weight_shape
     _i = c.ref(input)
     _w = c.ref(weight)
+    output_channels = w_c * groups.value
     return relay.nn.conv2d_transpose(
         _i,
         _w,
@@ -403,7 +404,7 @@ def relay_conv_transpose2d(
         groups=groups.value,
         output_padding=output_padding.value,
         kernel_size=(filter_h, filter_w),
-        channels=in_channels,
+        channels=output_channels,
     )
 
 

--- a/myia/compile/backends/relay.py
+++ b/myia/compile/backends/relay.py
@@ -382,6 +382,12 @@ def relay_conv_transpose2d(
     assert dilation.is_constant(tuple)
     assert groups.is_constant(int)
 
+    # Only groups==1 and dilation==(1, 1) is supported, on both CPU and GPU.
+    if groups.value != 1:
+        raise RuntimeError(f"Only support groups=1, got {groups.value}")
+    if dilation.value != (1, 1):
+        raise RuntimeError(f"Only support dilation=(1, 1), got {dilation.value}")
+
     data_shape = input.abstract.xshape()
     weight_shape = weight.abstract.xshape()
     _, in_channels, _, _ = data_shape

--- a/myia/compile/backends/relay.py
+++ b/myia/compile/backends/relay.py
@@ -374,14 +374,8 @@ def relay_conv2d_weight_grad(c, data, wsize, dout, stride, pad, dil, groups):
 
 
 def relay_conv_transpose2d(
-    c, input, weight, bias, stride, padding, output_padding, groups, dilation
+    c, input, weight, stride, padding, output_padding, groups, dilation
 ):
-
-    if not bias.is_constant(type(None)):
-        raise NotImplementedError(
-            "conv_transpose2d: bias not yet supported " "in relay backend."
-        )
-
     assert stride.is_constant(tuple)
     assert padding.is_constant(tuple)
     assert output_padding.is_constant(tuple)

--- a/myia/compile/backends/relay.py
+++ b/myia/compile/backends/relay.py
@@ -386,7 +386,9 @@ def relay_conv_transpose2d(
     if groups.value != 1:
         raise RuntimeError(f"Only support groups=1, got {groups.value}")
     if dilation.value != (1, 1):
-        raise RuntimeError(f"Only support dilation=(1, 1), got {dilation.value}")
+        raise RuntimeError(
+            f"Only support dilation=(1, 1), got {dilation.value}"
+        )
 
     data_shape = input.abstract.xshape()
     weight_shape = weight.abstract.xshape()

--- a/myia/operations/macro_conv2d_grad_input.py
+++ b/myia/operations/macro_conv2d_grad_input.py
@@ -67,7 +67,6 @@ async def conv2d_grad_input(
         P.conv_transpose2d,
         r_grad_output.node,
         r_weight.node,
-        Constant(None),
         r_stride.node,
         r_padding.node,
         Constant(grad_input_padding),

--- a/myia/operations/prim_conv_transpose2d.py
+++ b/myia/operations/prim_conv_transpose2d.py
@@ -18,7 +18,6 @@ async def infer_conv_transpose2d(
     engine,
     input: AbstractArray,
     weight: AbstractArray,
-    bias,  # un-typed, because it may be either None or an abstract array.
     stride: AbstractTuple,
     padding: AbstractTuple,
     output_padding: AbstractTuple,

--- a/myia/public_api.py
+++ b/myia/public_api.py
@@ -313,7 +313,7 @@ def conv_transpose2d(
 ):
     """Map of Pytorch method torch.nn.functional.conv_transpose2d."""
     return P.conv_transpose2d(
-        input, weight, bias, stride, padding, output_padding, groups, dilation
+        input, weight, stride, padding, output_padding, groups, dilation
     )
 
 

--- a/tests/frontends/test_all_ops.py
+++ b/tests/frontends/test_all_ops.py
@@ -23,13 +23,7 @@ from myia.pipeline import standard_pipeline
 from myia.xtype import NDArray, np_dtype_to_type
 
 from ..common import MA, MB, to_abstract_test
-from ..multitest import (
-    Multiple,
-    backend_all,
-    eqtest,
-    mt,
-    myia_function_test,
-)
+from ..multitest import Multiple, backend_all, eqtest, mt, myia_function_test
 from ..test_grad import grad_wrap
 
 torch = pytest.importorskip("torch")
@@ -62,7 +56,7 @@ def eqtest(t1: torch.Tensor, t2, rtol=1e-5, atol=1e-8, **kwargs):
             v2 = x2[i].item()
             if abs(v1 - v2) > atol:
                 c += 1
-                print('diff', c, i + 1, v1, v2)
+                print("diff", c, i + 1, v1, v2)
     # End debug code
 
     np.testing.assert_allclose(
@@ -571,7 +565,7 @@ def test_conv2d__non_tuple_args(inp, w, b):
         nn.Parameter(torch.randn(3, 1, 3, 3, dtype=torch.float32)),
         nn.Parameter(torch.randn(3, dtype=torch.float32)),
     ),
-    backend=backend_no_relay
+    backend=backend_no_relay,
 )
 def test_torch_conv2d__group3(inp, w, b):
     value = torch.nn.functional.conv2d(inp, w, b, (2, 3), (3, 2), (3, 4), 1)
@@ -610,7 +604,7 @@ def test_conv2d__group3(inp, w, b):
         (5, 4),
     ),
     broad_specs=(True, True, False, False, False, False, False, False),
-    backend=backend_no_relay
+    backend=backend_no_relay,
 )
 def test_torch_conv_transpose2d(i, w, b, s, p, o_p, g, d):
     return torch.nn.functional.conv_transpose2d(i, w, b, s, p, o_p, g, d)

--- a/tests/frontends/test_all_ops.py
+++ b/tests/frontends/test_all_ops.py
@@ -674,6 +674,7 @@ def test_torch_functional_log_softmax(x, y):
     torch.randn(4, 4, dtype=torch.float32, requires_grad=True),
     torch.randn(4, 4, dtype=torch.float32, requires_grad=True),
     torch.randn(4, 4, dtype=torch.float32, requires_grad=True),
+    atol=1e-5,
     grad_atol=1e-5,
 )
 def test_lstm_cell(inp, hx, cx, w_ih, w_hh, b_ih, b_hh):

--- a/tests/frontends/test_all_ops.py
+++ b/tests/frontends/test_all_ops.py
@@ -521,7 +521,7 @@ def test_conv2d(inp, w, b):
     fwd_and_bwd(
         nn.Parameter(torch.randn(2, 6, 4, 5, dtype=torch.float32)),
         nn.Parameter(torch.randn(3, 2, 3, 3, dtype=torch.float32)),
-        None
+        None,
     ),
     fwd_and_bwd(
         nn.Parameter(torch.randn(2, 6, 4, 5, dtype=torch.float32)),
@@ -539,7 +539,7 @@ def test_torch_conv2d__non_tuple_args(inp, w, b):
     fwd_and_bwd(
         nn.Parameter(torch.randn(2, 6, 4, 5, dtype=torch.float32)),
         nn.Parameter(torch.randn(3, 6, 3, 3, dtype=torch.float32)),
-        None
+        None,
     ),
     fwd_and_bwd(
         nn.Parameter(torch.randn(2, 2, 4, 5, dtype=torch.float32)),
@@ -565,7 +565,7 @@ def test_torch_conv2d__group3(inp, w, b):
 @fwd_and_bwd(
     nn.Parameter(torch.randn(2, 1, 4, 5, dtype=torch.float32)),
     nn.Parameter(torch.randn(3, 1, 3, 3, dtype=torch.float32)),
-    None
+    None,
 )
 def test_conv2d__group3(inp, w, b):
     value = torch.nn.functional.conv2d(inp, w, b, (2, 3), (3, 2), (1, 1), 1)

--- a/tests/frontends/test_all_ops.py
+++ b/tests/frontends/test_all_ops.py
@@ -476,7 +476,7 @@ def test_conv2d_no_dil_stride(inp, w):
     ),
 )
 def test_torch_conv2d(inp, w, b):
-    value = torch.nn.functional.conv2d(inp, w, b, (2, 3), (3, 2), (3, 4), 3)
+    value = torch.nn.functional.conv2d(inp, w, b, (2, 3), (3, 2), (1, 1), 1)
     return torch.sum(value)
 
 

--- a/tests/frontends/test_all_ops.py
+++ b/tests/frontends/test_all_ops.py
@@ -26,7 +26,6 @@ from ..common import MA, MB, to_abstract_test
 from ..multitest import (
     Multiple,
     backend_all,
-    backend_no_relay,
     eqtest,
     mt,
     myia_function_test,
@@ -226,7 +225,6 @@ fwd_and_bwd = _fwd_and_bwd.configure(backend=backend_all)
 fwd_and_bwd_no_numpy_compat = _fwd_and_bwd.configure(
     backend=backend_all, numpy_compat=False
 )
-fwd_and_bwd_no_relay = _fwd_and_bwd.configure(backend=backend_no_relay)
 
 
 @myia_function_test(marks=[pytest.mark.run], id="run")
@@ -476,7 +474,6 @@ def test_conv2d_no_dil_stride(inp, w):
         nn.Parameter(torch.randn(3, 2, 3, 3, dtype=torch.float32)),
         None,
     ),
-    backend=backend_no_relay,
 )
 def test_torch_conv2d(inp, w, b):
     value = torch.nn.functional.conv2d(inp, w, b, (2, 3), (3, 2), (3, 4), 3)
@@ -494,14 +491,13 @@ def test_torch_conv2d(inp, w, b):
         nn.Parameter(torch.randn(3, 2, 3, 3, dtype=torch.float32)),
         None,
     ),
-    backend=backend_no_relay,
 )
 def test_torch_conv2d__non_tuple_args(inp, w, b):
     value = torch.nn.functional.conv2d(inp, w, b, 2, 3, 4, 3)
     return torch.sum(value)
 
 
-@fwd_and_bwd_no_relay(
+@fwd_and_bwd(
     nn.Parameter(torch.randn(2, 1, 4, 5, dtype=torch.float32)),
     nn.Parameter(torch.randn(3, 1, 3, 3, dtype=torch.float32)),
     nn.Parameter(torch.randn(3, dtype=torch.float32)),
@@ -512,7 +508,7 @@ def test_torch_conv2d__group3(inp, w, b):
 
 
 @mt(
-    run_no_relay(
+    run(
         torch.randn(1, 2, 4, 4),
         torch.randn(2, 3, 2, 2),
         torch.randn(6),
@@ -522,7 +518,7 @@ def test_torch_conv2d__group3(inp, w, b):
         2,
         (1, 1),
     ),
-    run_no_relay(
+    run(
         torch.randn(1, 2, 5, 4),
         torch.randn(2, 4, 1, 3),
         None,
@@ -532,7 +528,7 @@ def test_torch_conv2d__group3(inp, w, b):
         2,
         (5, 4),
     ),
-    run_no_relay(
+    run(
         torch.randn(5, 2, 5, 6),
         torch.randn(2, 2, 4, 4),
         None,
@@ -542,7 +538,7 @@ def test_torch_conv2d__group3(inp, w, b):
         1,
         (1, 1),
     ),
-    run_no_relay(
+    run(
         torch.randn(1, 1, 4, 4),
         torch.randn(1, 3, 2, 2),
         None,
@@ -559,17 +555,17 @@ def test_torch_conv_transpose2d(i, w, b, s, p, o_p, g, d):
 
 
 @mt(
-    fwd_and_bwd_no_relay(
+    fwd_and_bwd(
         nn.Parameter(torch.Tensor(torch.randn(3, 5))),
         nn.Parameter(torch.randint(5, (3,)), requires_grad=False),
         "mean",
     ),
-    fwd_and_bwd_no_relay(
+    fwd_and_bwd(
         nn.Parameter(torch.Tensor(torch.randn(3, 5))),
         nn.Parameter(torch.randint(5, (3,)), requires_grad=False),
         "none",
     ),
-    fwd_and_bwd_no_relay(
+    fwd_and_bwd(
         nn.Parameter(torch.Tensor(torch.randn(3, 5))),
         nn.Parameter(torch.randint(5, (3,)), requires_grad=False),
         "sum",
@@ -608,7 +604,7 @@ def test_torch_detach(x):
     return r
 
 
-@fwd_and_bwd_no_relay(
+@fwd_and_bwd(
     nn.Parameter(torch.Tensor(MA(3, 4))),
     torch.tensor([[0, 1, 2, 0], [0, 0, 0, 1]]),
 )
@@ -640,12 +636,12 @@ def test_torch_norm(inp, p, dim):
     return torch.norm(inp, p, dim)
 
 
-@fwd_and_bwd_no_relay(nn.Parameter(torch.randn(2, 4, 3)))
+@fwd_and_bwd(nn.Parameter(torch.randn(2, 4, 3)))
 def test_torch_tensor_get(x):
     return x[:, -3:-1:2, -2]
 
 
-@fwd_and_bwd_no_relay(nn.Parameter(torch.randn(2, 4, 3)))
+@fwd_and_bwd(nn.Parameter(torch.randn(2, 4, 3)))
 def test_torch_tensor_get2(x):
     return x[1, 2]
 
@@ -655,7 +651,6 @@ def test_torch_tensor_get2(x):
     fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))), 1),
     fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))), -1),
     broad_specs=(True, False),
-    backend=backend_no_relay,
 )
 def test_torch_log_softmax(x, y):
     return torch.log_softmax(x, y)
@@ -666,7 +661,6 @@ def test_torch_log_softmax(x, y):
     fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))), 1),
     fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))), -1),
     broad_specs=(True, False),
-    backend=backend_no_relay,
 )
 def test_torch_functional_log_softmax(x, y):
     return torch.nn.functional.log_softmax(x, y)
@@ -686,15 +680,15 @@ def test_lstm_cell(inp, hx, cx, w_ih, w_hh, b_ih, b_hh):
     return torch.lstm_cell(inp, (hx, cx), w_ih, w_hh, b_ih, b_hh)
 
 
-@fwd_and_bwd_no_relay(nn.Parameter(torch.randn(2, 4, 3)))
+@fwd_and_bwd(nn.Parameter(torch.randn(2, 4, 3)))
 def test_torch_tensor_max_1_arg(x):
     return torch.max(x)
 
 
 @mt(
-    fwd_and_bwd_no_relay(nn.Parameter(torch.randn(2, 4, 3)), -1, True),
-    fwd_and_bwd_no_relay(nn.Parameter(torch.randn(2, 4, 3)), 1, True),
-    fwd_and_bwd_no_relay(nn.Parameter(torch.randn(4)), 0, True),
+    fwd_and_bwd(nn.Parameter(torch.randn(2, 4, 3)), -1, True),
+    fwd_and_bwd(nn.Parameter(torch.randn(2, 4, 3)), 1, True),
+    fwd_and_bwd(nn.Parameter(torch.randn(4)), 0, True),
     run(nn.Parameter(torch.randn(2, 4, 3)), -1, True),
     broad_specs=(True, False, False),
 )
@@ -739,7 +733,7 @@ def test_torch_mse_loss(x, y):
     return torch.nn.functional.mse_loss(x, y)
 
 
-@fwd_and_bwd_no_relay(
+@fwd_and_bwd(
     nn.Parameter(torch.Tensor(MA(2, 3))), torch.tensor([1, 2])
 )
 def test_torch_nll_loss(x, y):
@@ -757,13 +751,12 @@ def test_torch_nll_loss(x, y):
         nn.Parameter(torch.Tensor(MA(2, 3))), torch.tensor([1, 2]), "mean"
     ),
     broad_specs=(True, True, False),
-    backend=backend_no_relay,
 )
 def test_torch_nll_loss_reduce_options(x, y, z):
     return torch.nn.functional.nll_loss(x, y, reduction=z)
 
 
-@fwd_and_bwd_no_relay(
+@fwd_and_bwd(
     nn.Parameter(torch.randn(2, 3, dtype=torch.float64)), torch.tensor([1, 2])
 )
 def test_torch_nll_loss_reduce_cast(x, y):
@@ -792,7 +785,7 @@ def test_torch_tensor_reshape(x, y):
     return torch.reshape(x, y)
 
 
-@fwd_and_bwd_no_relay(
+@fwd_and_bwd(
     nn.Parameter(torch.Tensor(MA(3, 4))),
     torch.tensor([[0, 1, 2, 0], [0, 0, 0, 1]]),
     nn.Parameter(torch.Tensor(MA(2, 4))),
@@ -801,7 +794,7 @@ def test_torch_scatter(x, index, src):
     return torch.scatter(x, 0, index, src)
 
 
-@fwd_and_bwd_no_relay(
+@fwd_and_bwd(
     nn.Parameter(torch.Tensor(MA(3, 4))),
     torch.tensor([[0, 1, 2, 0], [0, 0, 0, 1]]),
     nn.Parameter(torch.Tensor(MA(2, 4))),
@@ -810,7 +803,7 @@ def test_torch_scatter_add(x, index, src):
     return torch.scatter_add(x, 0, index, src)
 
 
-@fwd_and_bwd_no_relay(
+@fwd_and_bwd(
     nn.Parameter(torch.Tensor(MA(3, 4))),
     torch.tensor([[0, 1, 2, 0], [0, 0, 0, 1]]),
     nn.Parameter(torch.Tensor([2.1]).reshape(())),
@@ -819,7 +812,7 @@ def test_torch_scatter_broadcast_source(x, index, src):
     return torch.scatter(x, 0, index, src)
 
 
-@fwd_and_bwd_no_relay(
+@fwd_and_bwd(
     nn.Parameter(torch.randn(3, 4, dtype=torch.float64)),
     torch.tensor([[0, 1, 2, 0], [0, 0, 0, 1]]),
     1.23,
@@ -855,7 +848,6 @@ def test_torch_smooth_l1_loss(x, y):
     fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))), 1),
     fwd_and_bwd(nn.Parameter(torch.Tensor(MA(2, 3))), -1),
     broad_specs=(True, False),
-    backend=backend_no_relay,
 )
 def test_torch_softmax(x, y):
     return torch.softmax(x, y)

--- a/tests/frontends/test_all_ops.py
+++ b/tests/frontends/test_all_ops.py
@@ -476,7 +476,7 @@ def test_conv2d_no_dil_stride(inp, w):
     ),
 )
 def test_torch_conv2d(inp, w, b):
-    value = torch.nn.functional.conv2d(inp, w, b, (2, 3), (3, 2), (1, 1), 1)
+    value = torch.nn.functional.conv2d(inp, w, b, (2, 3), (3, 2), (3, 4), 3)
     return torch.sum(value)
 
 

--- a/tests/frontends/test_pytorch.py
+++ b/tests/frontends/test_pytorch.py
@@ -54,8 +54,8 @@ class Args:
     def __init__(self):
         # device used
         self.dev = "cpu"
-        # backend used
-        self.backend = "pytorch"
+        # backend used (set 'relay' by default)
+        self.backend = "relay"
         # numerical precision
         self.dtype = "float32"
 
@@ -78,8 +78,8 @@ def test_module_matmul_fwd(model, inp):
     return model(inp)
 
 
-def test_module_matmul_bwd():
-    backend = "pytorch"
+def test_module_matmul_bwd(_backend_fixture):
+    backend = _backend_fixture
     backend_options = get_backend_options(args, backend)
 
     torch.manual_seed(123)
@@ -177,8 +177,8 @@ class MLP_2_Layers(nn.Module):
         return x
 
 
-def test_module_2_layer_mlp_fwd():
-    backend = "pytorch"
+def test_module_2_layer_mlp_fwd(_backend_fixture):
+    backend = _backend_fixture
     backend_options = get_backend_options(args, backend)
 
     torch.manual_seed(123)
@@ -202,8 +202,8 @@ def test_module_2_layer_mlp_fwd():
     assert torch.allclose(output, output_expected)
 
 
-def test_module_2_layer_mlp_bwd():
-    backend = "pytorch"
+def test_module_2_layer_mlp_bwd(_backend_fixture):
+    backend = _backend_fixture
     backend_options = get_backend_options(args, backend)
 
     torch.manual_seed(123)
@@ -252,8 +252,8 @@ def test_module_2_layer_mlp_bwd():
         assert torch.allclose(g, eg)
 
 
-def test_module_2_layer_mlp_update():
-    backend = "pytorch"
+def test_module_2_layer_mlp_update(_backend_fixture):
+    backend = _backend_fixture
     backend_options = get_backend_options(args, backend)
 
     torch.manual_seed(123)
@@ -418,8 +418,8 @@ class Linear_Seq(nn.Module):
         return x
 
 
-def test_module_2_layer_mlp_seq_fwd():
-    backend = "pytorch"
+def test_module_2_layer_mlp_seq_fwd(_backend_fixture):
+    backend = _backend_fixture
     backend_options = get_backend_options(args, backend)
 
     torch.manual_seed(123)
@@ -443,8 +443,8 @@ def test_module_2_layer_mlp_seq_fwd():
     assert torch.allclose(output, output_expected)
 
 
-def test_module_linear_seq_bwd():
-    backend = "pytorch"
+def test_module_linear_seq_bwd(_backend_fixture):
+    backend = _backend_fixture
     backend_options = get_backend_options(args, backend)
 
     torch.manual_seed(123)
@@ -509,8 +509,8 @@ class Linear_List(nn.Module):
         return x
 
 
-def test_alias_list_error():
-    backend = "pytorch"
+def test_alias_list_error(_backend_fixture):
+    backend = _backend_fixture
     backend_options = get_backend_options(args, backend)
 
     torch.manual_seed(123)
@@ -540,8 +540,8 @@ def test_alias_list_error():
         print(f([a, b, c, a], e))
 
 
-def test_nn_max_pool2d_fwd():
-    backend = "pytorch"
+def test_nn_max_pool2d_fwd(_backend_fixture):
+    backend = _backend_fixture
     backend_options = get_backend_options(args, backend)
 
     torch.manual_seed(123)
@@ -573,8 +573,8 @@ def test_nn_max_pool2d_fwd():
     assert torch.allclose(my_out, pt_out)
 
 
-def test_nn_max_pool2d_update():
-    backend = "pytorch"
+def test_nn_max_pool2d_update(_backend_fixture):
+    backend = _backend_fixture
     backend_options = get_backend_options(args, backend)
 
     torch.manual_seed(123)
@@ -615,8 +615,8 @@ def test_nn_max_pool2d_update():
 
 # TODO: Should this eventually be in a different test file?
 #       It's currently here because it needs to have 'torch' imported.
-def test_shp_explicit_errors():
-    backend = "pytorch"
+def test_shp_explicit_errors(_backend_fixture):
+    backend = _backend_fixture
     backend_options = get_backend_options(args, backend)
 
     input = torch.ones(2, 3)
@@ -654,8 +654,8 @@ def test_shp_explicit_errors():
 
 # TODO: Should this eventually be in a different test file?
 #       It's currently here because it needs to have 'torch' imported.
-def test_sum_keepdim_error():
-    backend = "pytorch"
+def test_sum_keepdim_error(_backend_fixture):
+    backend = _backend_fixture
     backend_options = get_backend_options(args, backend)
 
     input = torch.ones(2, 3)
@@ -671,8 +671,11 @@ def test_sum_keepdim_error():
         ret1 = step1(input, True)  # noqa: F841
 
 
-def test_switch_input_types():
-    @myia
+def test_switch_input_types(_backend_fixture):
+    backend = _backend_fixture
+    backend_options = get_backend_options(args, backend)
+
+    @myia(backend=backend, backend_options=backend_options)
     def f(x):
         return x * x
 
@@ -681,7 +684,7 @@ def test_switch_input_types():
 
 
 # This is mostly here to cover inst_tuple_setitem method in myia.compile.vm
-def test_optim_setitem():
+def test_optim_setitem(_backend_fixture):
     from myia.abstract import macro
     from myia.operations import primitives as P
     from myia.ir import sexp_to_node
@@ -711,7 +714,7 @@ def test_optim_setitem():
 
         return new_model
 
-    backend = "pytorch"
+    backend = _backend_fixture
     backend_options = get_backend_options(args, backend)
 
     torch.manual_seed(123)

--- a/tests/multitest.py
+++ b/tests/multitest.py
@@ -343,7 +343,6 @@ run_relay_debug = _run.configure(
     )
 )
 run_gpu = _run.configure(backend=backend_gpu)
-run_no_relay = _run.configure(backend=backend_no_relay)
 run_debug = run.configure(
     pipeline=standard_debug_pipeline, validate=False, backend=False
 )

--- a/tests/multitest.py
+++ b/tests/multitest.py
@@ -91,7 +91,7 @@ class MyiaFunctionTest:
         """Configure this test with new kwargs."""
         return MyiaFunctionTest(self.runtest, spec={**self.spec, **spec})
 
-    def check(self, run, args, expected):
+    def check(self, run, args, expected, **kwargs):
         """Check the result of run() against expected.
 
         Expected can be either:
@@ -118,7 +118,7 @@ class MyiaFunctionTest:
                 if not expected(args, res):
                     raise Exception(f"Failed the result check function")
 
-            elif not eqtest(res, expected):
+            elif not eqtest(res, expected, **kwargs):
                 raise Exception(f"Mismatch: expected {expected}, got {res}")
 
     def generate_params(self):
@@ -238,6 +238,7 @@ def _run(
     validate=True,
     pipeline=standard_pipeline,
     backend=None,
+    **kwargs,
 ):
     """Test a Myia function.
 
@@ -287,7 +288,7 @@ def _run(
     if result is None:
         result = fn(*args)
 
-    self.check(out, args, result)
+    self.check(out, args, result, **kwargs)
 
 
 backend_gpu = Multiple(
@@ -324,6 +325,13 @@ backend_all = Multiple(
         marks=pytest.mark.pytorch,
     ),
 )
+backend_no_relay = Multiple(
+    pytest.param(
+        ("pytorch", {"device": "cpu"}),
+        id="pytorch-cpu",
+        marks=pytest.mark.pytorch,
+    )
+)
 run = _run.configure(backend=backend_all)
 run_relay_debug = _run.configure(
     backend=Multiple(
@@ -335,6 +343,7 @@ run_relay_debug = _run.configure(
     )
 )
 run_gpu = _run.configure(backend=backend_gpu)
+run_no_relay = _run.configure(backend=backend_no_relay)
 run_debug = run.configure(
     pipeline=standard_debug_pipeline, validate=False, backend=False
 )

--- a/tests/multitest.py
+++ b/tests/multitest.py
@@ -324,13 +324,6 @@ backend_all = Multiple(
         marks=pytest.mark.pytorch,
     ),
 )
-backend_no_relay = Multiple(
-    pytest.param(
-        ("pytorch", {"device": "cpu"}),
-        id="pytorch-cpu",
-        marks=pytest.mark.pytorch,
-    )
-)
 run = _run.configure(backend=backend_all)
 run_relay_debug = _run.configure(
     backend=Multiple(
@@ -342,7 +335,6 @@ run_relay_debug = _run.configure(
     )
 )
 run_gpu = _run.configure(backend=backend_gpu)
-run_no_relay = _run.configure(backend=backend_no_relay)
 run_debug = run.configure(
     pipeline=standard_debug_pipeline, validate=False, backend=False
 )

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -11,7 +11,7 @@ from myia.operations import (
 from myia.pipeline import standard_pipeline
 
 from .common import MA, MB, Point
-from .multitest import mt, run, run_no_relay, run_relay_debug
+from .multitest import mt, run, run_relay_debug
 
 run_no_opt = run.configure(
     pipeline=standard_pipeline.configure({"opt.phases.main": []})
@@ -182,6 +182,6 @@ def test_array_getitem(x):
     return array_getitem(x, (0, 1), (3, 5), (2, 3))
 
 
-@run_no_relay(MA(4, 5), MB(2, 2))
+@run(MA(4, 5), MB(2, 2))
 def test_array_setitem(x, v):
     return array_setitem(x, (0, 1), (3, 5), (2, 3), v)

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -43,8 +43,8 @@ from .multitest import backend_all, mt, myia_function_test
 
 
 @pytest.fixture(params=[
-    pytest.param('pytorch'),
-    pytest.param('relay'),
+    pytest.param("pytorch"),
+    pytest.param("relay"),
 ])
 def _backend_fixture(request):
     return request.param

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -49,6 +49,7 @@ from .multitest import backend_all, mt, myia_function_test
 def _backend_fixture(request):
     return request.param
 
+
 @dataclass
 class Point:
     x: f64

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -42,6 +42,13 @@ from .common import AA, MA, MB, Point3D, U, f64, to_abstract_test, u64
 from .multitest import backend_all, mt, myia_function_test
 
 
+@pytest.fixture(params=[
+    pytest.param('pytorch'),
+    pytest.param('relay'),
+])
+def _backend_fixture(request):
+    return request.param
+
 @dataclass
 class Point:
     x: f64
@@ -694,13 +701,14 @@ def test_aliasing():
     _chk(res3, (3 * o, 2 * o, (2 * o, 3 * o)))
 
 
-def test_aliasing_list():
+def test_aliasing_list(_backend_fixture):
+    backend = _backend_fixture
     from myia.compile.backends import LoadingError, load_backend
 
     try:
-        load_backend("pytorch")
+        load_backend(backend)
     except LoadingError:
-        pytest.skip("PyTorch not available")
+        pytest.skip("%s not available" % backend)
 
     def g(xs, y):
         res = 0
@@ -708,7 +716,7 @@ def test_aliasing_list():
             res = res + x
         return sum(res)
 
-    @myia(backend="pytorch", alias_tracker=ndarray_aliasable)
+    @myia(backend=backend, alias_tracker=ndarray_aliasable)
     def f(xs, y):
         return grad(g)(xs, y)
 

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -42,10 +42,7 @@ from .common import AA, MA, MB, Point3D, U, f64, to_abstract_test, u64
 from .multitest import backend_all, mt, myia_function_test
 
 
-@pytest.fixture(params=[
-    pytest.param("pytorch"),
-    pytest.param("relay"),
-])
+@pytest.fixture(params=[pytest.param("pytorch"), pytest.param("relay")])
 def _backend_fixture(request):
     return request.param
 

--- a/tmp/conv2d_transpose.py
+++ b/tmp/conv2d_transpose.py
@@ -1,0 +1,304 @@
+"""
+Python implementation of conv2d_transpose based on Theano implementation.
+
+Reference (2020/04/07):
+https://github.com/Theano/Theano/blob/master/theano/tensor/nnet/abstract_conv.py#L2927
+
+"""
+import warnings
+
+import numpy as np
+from scipy.signal.signaltools import _bvalfromboundary, _valfrommode
+from scipy.signal.sigtools import _convolve2d
+from six import integer_types
+
+
+# Main function to call.
+def conv2d_transpose(
+    input: np.ndarray,
+    filters: np.ndarray,
+    output_padding=(0, 0),
+    padding=(0, 0),
+    strides=(1, 1),
+    dilation=(1, 1),
+    groups=1,
+):
+    grad_input_op = Conv2DTranspose(
+        output_padding=output_padding,
+        padding=padding,
+        strides=strides,
+        dilation=dilation,
+        groups=groups,
+    )
+    return grad_input_op.run(filters, input)
+
+
+class Conv2DTranspose:
+
+    __slots__ = (
+        "convdim",
+        "output_padding",
+        "padding",
+        "strides",
+        "dilation",
+        "groups",
+    )
+
+    def __init__(
+        self,
+        output_padding=(0, 0),
+        padding=(0, 0),
+        strides=(1, 1),
+        dilation=(1, 1),
+        groups=1,
+    ):
+        self.convdim = 2
+        self.output_padding = tuple(output_padding)
+        self.padding = tuple(padding)
+        self.strides = tuple(strides)
+        self.dilation = tuple(dilation)
+        self.groups = groups
+
+    def run(self, kern: np.ndarray, topgrad: np.ndarray):
+        new_shape = (topgrad.shape[0], topgrad.shape[1]) + tuple(
+            (topgrad.shape[-self.convdim + i] - 1) * self.strides[i]
+            + self.output_padding[i]
+            + 1
+            for i in range(self.convdim)
+        )
+        new_topgrad = np.zeros((new_shape), dtype=topgrad.dtype)
+        new_topgrad[
+            (slice(None), slice(None))
+            + tuple(
+                slice(None, None, self.strides[i]) for i in range(self.convdim)
+            )
+        ] = topgrad
+        topgrad = new_topgrad
+
+        kern = self.correct_for_groups(kern)
+
+        # "fill" padding
+        conv_padding = tuple(
+            (kern.shape[-self.convdim + i] - 1) * self.dilation[i]
+            for i in range(self.convdim)
+        )
+
+        img = conv(
+            topgrad,
+            kern,
+            padding=conv_padding,
+            dilation=self.dilation,
+            groups=self.groups,
+            conv_mode="full",
+        )
+
+        if any(p != 0 for p in self.padding):
+            img = img[
+                (slice(None), slice(None))
+                + tuple(
+                    slice(self.padding[i], img.shape[i + 2] - self.padding[i])
+                    for i in range(self.convdim)
+                )
+            ]
+
+        return img
+
+    def correct_for_groups(self, mat):
+        mshp0 = mat.shape[0] // self.groups
+        mshp1 = mat.shape[-self.convdim - 1] * self.groups
+        mat = mat.reshape((self.groups, mshp0) + mat.shape[1:])
+        mat = mat.transpose((1, 0, 2) + tuple(range(3, 3 + self.convdim)))
+        mat = mat.reshape((mshp0, mshp1) + mat.shape[-self.convdim :])
+        mat = mat.transpose((1, 0) + tuple(range(2, 2 + self.convdim)))
+        return mat
+
+
+def conv(
+    img, kern, padding=(0, 0), dilation=(1, 1), groups=1, conv_mode="valid"
+):
+    """Basic slow Python 2D convolution for DebugMode"""
+    convdim = 2
+    if isinstance(dilation, integer_types):
+        dilation = (dilation,) * convdim
+    if len(dilation) != convdim:
+        raise ValueError(
+            "invalid dilation {}, expected {} values".format(dilation, convdim)
+        )
+
+    out_shape = get_conv_output_shape(
+        img.shape, kern.shape, padding, [1] * convdim, dilation
+    )
+
+    dil_kern_shp = kern.shape[:-convdim] + tuple(
+        (kern.shape[-convdim + i] - 1) * dilation[i] + 1 for i in range(convdim)
+    )
+    dilated_kern = np.zeros(dil_kern_shp, dtype=kern.dtype)
+    dilated_kern[
+        (slice(None),) * (dilated_kern.ndim - convdim)
+        + tuple(slice(None, None, dilation[i]) for i in range(convdim))
+    ] = kern
+    out = np.zeros(out_shape, dtype=img.dtype)
+
+    if img.shape[1] % groups != 0:
+        raise ValueError(
+            "number of input channels must be divible by num_groups"
+        )
+    if kern.shape[0] % groups != 0:
+        raise ValueError("number of filters must be divisible by num_groups")
+    if img.shape[1] // groups != kern.shape[1]:
+        raise ValueError(
+            "the number of input channels in the kernel should "
+            "specify the number of channels of 1 group"
+        )
+    input_channel_offset = img.shape[1] // groups
+    output_channel_offset = kern.shape[0] // groups
+
+    val = _valfrommode(conv_mode)
+    bval = _bvalfromboundary("fill")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", np.ComplexWarning)
+        for b in range(img.shape[0]):
+            for g in range(groups):
+                for n in range(output_channel_offset):
+                    for im0 in range(input_channel_offset):
+                        # some cast generates a warning here
+                        out[
+                            b, g * output_channel_offset + n, ...
+                        ] += _convolve2d(
+                            img[b, g * input_channel_offset + im0, ...],
+                            dilated_kern[
+                                g * output_channel_offset + n, im0, ...
+                            ],
+                            1,
+                            val,
+                            bval,
+                            0,
+                        )
+
+    return out
+
+
+def get_conv_output_shape(
+    image_shape, kernel_shape, border_mode, subsample, filter_dilation=None
+):
+    """
+    This function compute the output shape of convolution operation.
+
+    Parameters
+    ----------
+    image_shape: tuple of int (symbolic or numeric) corresponding to the input
+        image shape. Its four (or five) element must correspond respectively
+        to: batch size, number of input channels, height and width (and
+        possibly depth) of the image. None where undefined.
+    kernel_shape: tuple of int (symbolic or numeric) corresponding to the
+        kernel shape. For a normal convolution, its four (for 2D convolution)
+        or five (for 3D convolution) elements must correspond respectively to :
+        number of output channels, number of input channels, height and width
+        (and possibly depth) of the kernel.
+        None where undefined.
+    border_mode: string, int (symbolic or numeric) or tuple of int (symbolic
+        or numeric) or pairs of ints. If it is a string, it must be 'valid',
+        'half' or 'full'. If it is a tuple, its two (or three) elements respectively
+        correspond to the padding on height and width (and possibly depth)
+        axis. For asymmetric padding, provide a pair of ints for each dimension.
+    subsample: tuple of int (symbolic or numeric). Its two or three elements
+        espectively correspond to the subsampling on height and width (and
+        possibly depth) axis.
+    filter_dilation: tuple of int (symbolic or numeric). Its two or three
+        elements correspond respectively to the dilation on height and width axis.
+    Note - The shape of the convolution output does not depend on  the 'num_groups' parameters.
+
+    Returns
+    -------
+    output_shape: tuple of int corresponding to the output image shape. Its
+        four element must correspond respectively to: batch size, number of
+        output channels, height and width of the image. None where undefined.
+
+    """
+    bsize, imshp = image_shape[0], image_shape[2:]
+
+    convdim = len(image_shape) - 2
+    nkern, kshp = kernel_shape[0], kernel_shape[-convdim:]
+
+    if filter_dilation is None:
+        filter_dilation = np.ones(len(subsample), dtype="int")
+
+    if isinstance(border_mode, tuple):
+        out_shp = tuple(
+            get_conv_shape_1axis(
+                imshp[i],
+                kshp[i],
+                border_mode[i],
+                subsample[i],
+                filter_dilation[i],
+            )
+            for i in range(len(subsample))
+        )
+    else:
+        out_shp = tuple(
+            get_conv_shape_1axis(
+                imshp[i], kshp[i], border_mode, subsample[i], filter_dilation[i]
+            )
+            for i in range(len(subsample))
+        )
+    return (bsize, nkern) + out_shp
+
+
+def get_conv_shape_1axis(
+    image_shape, kernel_shape, border_mode, subsample, dilation=1
+):
+    """
+    This function compute the output shape of convolution operation.
+
+    Parameters
+    ----------
+    image_shape: int or None. Corresponds to the input image shape on a
+        given axis. None if undefined.
+    kernel_shape: int or None. Corresponds to the kernel shape on a given
+        axis. None if undefined.
+    border_mode: string, int or tuple of 2 ints. If it is a string, it must be
+        'valid', 'half' or 'full'. If it is an integer, it must correspond to
+        the padding on the considered axis. If it is a tuple, its two elements
+        must correspond to the asymmetric padding (e.g., left and right) on
+        the considered axis.
+    subsample: int. It must correspond to the subsampling on the
+        considered axis.
+    dilation: int. It must correspond to the dilation on the
+        considered axis.
+
+    Returns
+    -------
+    out_shp: int corresponding to the output image shape on the
+        considered axis. None if undefined.
+
+    """
+    if None in [image_shape, kernel_shape, border_mode, subsample, dilation]:
+        return None
+    # Implicit dilated kernel shape
+    dil_kernel_shape = (kernel_shape - 1) * dilation + 1
+    if border_mode == "half":
+        pad_l = pad_r = dil_kernel_shape // 2
+    elif border_mode == "full":
+        pad_l = pad_r = dil_kernel_shape - 1
+    elif border_mode == "valid":
+        pad_l = pad_r = 0
+    else:
+        if isinstance(border_mode, tuple):
+            pad_l, pad_r = border_mode
+        else:
+            pad_l = pad_r = border_mode
+        if pad_l < 0 or pad_r < 0:
+            raise ValueError("border_mode must be >= 0")
+
+    # In case of symbolic shape, we want to build the smallest graph
+    # (image_shape + 2 * pad - dil_kernel_shape) // subsample + 1
+    out_shp = image_shape - dil_kernel_shape
+    if pad_l != 0:
+        out_shp += pad_l
+    if pad_r != 0:
+        out_shp += pad_r
+    if subsample != 1:
+        out_shp = out_shp // subsample
+    out_shp = out_shp + 1
+
+    return out_shp

--- a/tmp/shape_conv.py
+++ b/tmp/shape_conv.py
@@ -1,0 +1,669 @@
+import argparse
+
+import numpy as np
+import torch
+import torch.nn.functional
+import tvm
+from tvm import relay
+
+import conv2d_transpose as theano
+
+CHECK_THEANO = False
+CHECK_RELAY = False
+CHECK_RELAY_GRAPH = False
+
+
+def compile_relay_function(inputs, output):
+    f = relay.Function(list(inputs), output)
+    m = tvm.IRModule({})
+    fn = relay.GlobalVar("f")
+    m[fn] = f
+    e = relay.create_executor(mod=m)
+    c = e.evaluate(m[fn])
+    return c
+
+
+def ensure_couple(v):
+    """
+    If v is an integer, return (v, v)
+    Else, check if va is a tuple or list of 2 integers
+    """
+    if isinstance(v, int):
+        return v, v
+    if isinstance(v, (tuple, list)):
+        assert len(v) == 2
+        assert all(isinstance(e, int) for e in v)
+        return v
+    raise ValueError("Expected a int or a couple of int, got %s" % v)
+
+
+def assert_allclose(t1: np.ndarray, t2: np.ndarray, rtol=1e-5, atol=1e-8):
+
+    # Quick debug code to display mismatching values
+    shape = t1.shape
+    if len(shape) > 1:
+        x1 = t1.flatten()
+        x2 = t2.flatten()
+        s = x1.shape[0]
+        c = 0
+        for i in range(s):
+            v1 = x1[i].item()
+            v2 = x2[i].item()
+            if abs(v1 - v2) > atol:
+                c += 1
+                print("diff\t%s\t%s\t%s\t%s" % (c, i + 1, v1, v2))
+    # End debug code
+
+    np.testing.assert_allclose(t1, t2, rtol=rtol, atol=atol, verbose=True)
+    return True
+
+
+class Conv2D:
+    """
+    Class to compute and check a conv2d output shape.
+    """
+
+    def __init__(
+        self,
+        n=0,
+        c_in=0,
+        h_in=0,
+        w_in=0,
+        kernel_size=0,
+        c_out=0,
+        strides=1,
+        padding=0,
+        dilation=1,
+        groups=1,
+    ):
+        self.n = n
+        self.c_in = c_in
+        self.h_in = h_in
+        self.w_in = w_in
+        self.c_out = c_out
+        self.strides = ensure_couple(strides)
+        self.padding = ensure_couple(padding)
+        self.dilation = ensure_couple(dilation)
+        self.kernel_size = ensure_couple(kernel_size)
+        self.groups = groups
+        assert isinstance(self.n, int)
+        assert isinstance(self.c_in, int)
+        assert isinstance(self.h_in, int)
+        assert isinstance(self.w_in, int)
+        assert isinstance(self.c_out, int)
+        assert isinstance(self.groups, int)
+        assert self.c_out > 0
+        assert self.groups > 0
+        assert self.c_in % self.groups == 0
+        assert self.c_out % self.groups == 0
+
+    def debug_output(self):
+        print(
+            "%s %s filter=%s strides=%s, padding=%s, dilation=%s, groups=%s"
+            % (
+                type(self).__name__,
+                self.get_input_shape(),
+                self.get_filter_shape(),
+                self.strides,
+                self.padding,
+                self.dilation,
+                self.groups,
+            )
+        )
+        output_shape = self.get_output_shape()
+        # Use torch to check if output shape is computed correctly.
+        torch_output = self.compute_torch()
+        torch_output_shape = tuple(torch_output.shape)
+        assert output_shape == torch_output_shape, (
+            "%s: mismatch, expected %s, got %s"
+            % (type(self).__name__, output_shape, torch_output_shape),
+        )
+        print(type(self).__name__, "OK", output_shape)
+        print()
+
+    def get_input_shape(self):
+        return self.n, self.c_in, self.h_in, self.w_in
+
+    def get_filter_shape(self):
+        return (self.c_out, self.c_in // self.groups) + self.kernel_size
+
+    def get_output_shape(self):
+        n = self.n
+        c_out = self.c_out
+        h_out = int(
+            (
+                self.h_in
+                + 2 * self.padding[0]
+                - self.dilation[0] * (self.kernel_size[0] - 1)
+                - 1
+            )
+            / self.strides[0]
+            + 1
+        )
+        w_out = int(
+            (
+                self.w_in
+                + 2 * self.padding[1]
+                - self.dilation[1] * (self.kernel_size[1] - 1)
+                - 1
+            )
+            / self.strides[1]
+            + 1
+        )
+        return n, c_out, h_out, w_out
+
+    def compute_torch(self):
+        i = torch.randn(*self.get_input_shape())
+        w = torch.randn(*self.get_filter_shape())
+        return torch.nn.functional.conv2d(
+            i,
+            w,
+            stride=self.strides,
+            padding=self.padding,
+            dilation=self.dilation,
+            groups=self.groups,
+        )
+
+    def grad_input(self):
+        """
+        Infer and return parameters for conv2d input grad.
+        """
+        input_size = self.get_input_shape()
+        weight_shape = self.get_filter_shape()
+        grad_output_shape = self.get_output_shape()
+        input_size = input_size[2:]
+        min_sizes = [
+            (grad_output_shape[i + 2] - 1) * self.strides[i]
+            - 2 * self.padding[i]
+            + (self.kernel_size[i] - 1) * self.dilation[i]
+            + 1
+            for i in range(2)
+        ]
+        grad_input_padding = [input_size[i] - min_sizes[i] for i in range(2)]
+        return ConvTranspose2D(
+            n=grad_output_shape[0],
+            c_in=grad_output_shape[1],
+            h_in=grad_output_shape[2],
+            w_in=grad_output_shape[3],
+            c_out=weight_shape[1] * self.groups,
+            strides=self.strides,
+            padding=self.padding,
+            dilation=self.dilation,
+            kernel_size=self.kernel_size,
+            groups=self.groups,
+            output_padding=grad_input_padding,
+        )
+
+
+class ConvTranspose2D:
+    def __init__(
+        self,
+        n=0,
+        c_in=0,
+        h_in=0,
+        w_in=0,
+        kernel_size=0,
+        c_out=0,
+        strides=1,
+        padding=0,
+        dilation=1,
+        groups=1,
+        output_padding=0,
+    ):
+        self.n = n
+        self.c_in = c_in
+        self.h_in = h_in
+        self.w_in = w_in
+        self.c_out = c_out
+        self.strides = ensure_couple(strides)
+        self.padding = ensure_couple(padding)
+        self.dilation = ensure_couple(dilation)
+        self.kernel_size = ensure_couple(kernel_size)
+        self.output_padding = ensure_couple(output_padding)
+        self.groups = groups
+        assert isinstance(self.n, int)
+        assert isinstance(self.c_in, int)
+        assert isinstance(self.h_in, int)
+        assert isinstance(self.w_in, int)
+        assert isinstance(self.c_out, int)
+        assert isinstance(self.groups, int)
+        assert self.c_out > 0
+        assert self.groups > 0
+        assert self.c_in % self.groups == 0
+        assert self.c_out % self.groups == 0
+
+    def debug_output(self):
+        print(
+            "%s %s filter=%s strides=%s, padding=%s, dilation=%s, groups=%s, output_padding=%s"
+            % (
+                type(self).__name__,
+                self.get_input_shape(),
+                self.get_filter_shape(),
+                self.strides,
+                self.padding,
+                self.dilation,
+                self.groups,
+                self.output_padding,
+            )
+        )
+
+        output_shape = self.get_output_shape()
+        i, w = self._inputs()
+        # Use torch to check if output shape is computed correctly.
+        # Torch output will be also used to check other implementations below.
+        torch_output = self.compute_torch(i, w)
+        torch_output_shape = tuple(torch_output.shape)
+        assert output_shape == torch_output_shape, (
+            "%s: mismatch, expected %s, got %s"
+            % (type(self).__name__, output_shape, torch_output_shape),
+        )
+        print(type(self).__name__, "OK", output_shape)
+
+        if CHECK_THEANO:
+            # Check theano implementation.
+            self._debug_theano(i, w, torch_output)
+
+        if CHECK_RELAY:
+            # Check relay function conv2d_transpose.
+            self._debug_relay(i, w, torch_output)
+
+        if CHECK_RELAY_GRAPH:
+            # Check relay graph implementation.
+            self._debug_relay_graph(i, w, torch_output)
+
+        print()
+
+    def _debug_theano(self, i, w, expected):
+        output_shape = tuple(expected.shape)
+        theano_output = self.compute_theano(i, w)
+        theano_output_shape = tuple(theano_output.shape)
+        assert output_shape == theano_output_shape, (
+            "Theano %s: mismatch, expected %s, got %s"
+            % (type(self).__name__, output_shape, theano_output_shape),
+        )
+        assert_allclose(theano_output, expected, atol=1e-5)
+        print("Theano", type(self).__name__, "OK", output_shape)
+
+    def _debug_relay(self, i, w, expected):
+        output_shape = tuple(expected.shape)
+        relay_output = self.compute_relay(i, w)
+        relay_output_shape = tuple(relay_output.shape)
+        assert output_shape == relay_output_shape, (
+            "Relay %s: mismatch, expected %s, got %s"
+            % (type(self).__name__, output_shape, relay_output_shape),
+        )
+        assert_allclose(relay_output, expected, atol=1e-5)
+        print("Relay", type(self).__name__, "OK", output_shape)
+
+    def _debug_relay_graph(self, i, w, expected):
+        output_shape = tuple(expected.shape)
+        relay_graph_output = self.compute_relay_using_conv2d(i, w)
+        if any(p != 0 for p in self.padding):
+            # Small more step, will be integrated to relay graph later
+            # (once bugs will be fixed)
+            relay_graph_output = relay_graph_output[
+                :,
+                :,
+                self.padding[0] : -self.padding[0],
+                self.padding[1] : -self.padding[1],
+            ]
+        relay_graph_output_shape = tuple(relay_graph_output.shape)
+        assert output_shape == relay_graph_output_shape, (
+            "Relay Graph %s: mismatch, expected %s, got %s"
+            % (type(self).__name__, output_shape, relay_graph_output_shape),
+        )
+        assert_allclose(relay_graph_output, expected, atol=1e-5)
+        print("Relay Graph", type(self).__name__, "OK", output_shape)
+
+    def get_input_shape(self):
+        return self.n, self.c_in, self.h_in, self.w_in
+
+    def get_filter_shape(self):
+        return (self.c_in, self.c_out // self.groups) + self.kernel_size
+
+    def get_output_shape(self):
+        n = self.n
+        c_out = self.c_out
+        h_out = (
+            (self.h_in - 1) * self.strides[0]
+            - 2 * self.padding[0]
+            + self.dilation[0] * (self.kernel_size[0] - 1)
+            + self.output_padding[0]
+            + 1
+        )
+        w_out = (
+            (self.w_in - 1) * self.strides[1]
+            - 2 * self.padding[1]
+            + self.dilation[1] * (self.kernel_size[1] - 1)
+            + self.output_padding[1]
+            + 1
+        )
+        return n, c_out, h_out, w_out
+
+    def compute_torch(self, i, w):
+        i = torch.as_tensor(i)
+        w = torch.as_tensor(w)
+        return torch.nn.functional.conv_transpose2d(
+            i,
+            w,
+            stride=self.strides,
+            padding=self.padding,
+            output_padding=self.output_padding,
+            dilation=self.dilation,
+            groups=self.groups,
+        ).numpy()
+
+    def compute_theano(self, i, w):
+        return theano.conv2d_transpose(
+            i,
+            w,
+            self.output_padding,
+            padding=self.padding,
+            strides=self.strides,
+            dilation=self.dilation,
+            groups=self.groups,
+        )
+
+    def compute_relay(self, i, w):
+        if self.groups != 1 or self.dilation != (1, 1):
+            return None
+        if any(op > 1 for op in self.output_padding):
+            return None
+        data = relay.var("data", shape=self.get_input_shape())
+        weight = relay.var("weight", shape=self.get_filter_shape())
+        o = relay.nn.conv2d_transpose(
+            data,
+            weight,
+            strides=self.strides,
+            padding=self.padding,
+            dilation=self.dilation,
+            groups=self.groups,
+            channels=self.c_out,
+            output_padding=self.output_padding,
+        )
+        f = compile_relay_function([data, weight], o)
+        return f(i, w).asnumpy()
+
+    def compute_relay_using_conv2d(self, i, w):
+        """
+        Implementation of conv2d_transpose using relay conv2d function.
+        NB: Need operation relay.nn.dilate. I made a branch
+        to add it here (not yet submitted):
+        https://github.com/notoraptor/incubator-tvm/tree/relay-op-dilate
+        """
+
+        osh = self.get_output_shape()
+        topgrad_shape = self.get_input_shape()
+        kern_shape = self.get_filter_shape()
+
+        data = relay.var("data", shape=topgrad_shape)
+        weight = relay.var("weight", shape=kern_shape)
+        d1 = relay.nn.dilate(data, (1, 1) + self.strides)
+        work = relay.nn.pad(
+            d1,
+            (
+                (0, 0),
+                (0, 0),
+                (0, self.output_padding[0]),
+                (0, self.output_padding[1]),
+            ),
+        )
+        kern, kshp = self._relay_preprocess_kernel(weight, kern_shape)
+        conv_padding = tuple(
+            (kshp[-2 + i] - 1) * self.dilation[i] for i in range(2)
+        )
+        _work = relay.nn.pad(
+            work,
+            ((0, 0), (0, 0), (conv_padding[0],) * 2, (conv_padding[1],) * 2),
+        )
+        _kern = relay.nn.dilate(kern, (1, 1) + self.dilation)
+        img = relay.nn.conv2d(
+            _work, _kern, groups=self.groups, channels=osh[1],
+        )
+
+        # Temporarly deactivated.
+
+        # if any(p != 0 for p in self.p):
+        #     img = relay.op.transform.strided_slice(
+        #         data=img,
+        #         begin=[0, 0, self.p[0], self.p[1]],
+        #         end=[None, None, osh[2] + self.p[0], osh[3] + self.p[1]],
+        #     )
+
+        f = compile_relay_function([data, weight], img)
+        return f(i, w).asnumpy()
+
+    def _relay_preprocess_kernel(self, mat, mat_shape):
+        mshp0 = mat_shape[0] // self.groups
+        mshp1 = mat_shape[1] * self.groups
+        mat = relay.reshape(mat, (self.groups, mshp0) + mat_shape[1:])
+        # => (self.g, mshp0, m1, m2, m3)
+        mat = relay.op.transpose(mat, axes=(1, 0, 2, 3, 4))
+        # => (mshp0, self.g, m1, m2, m3)
+        mat = relay.reshape(mat, (mshp0, mshp1, mat_shape[-2], mat_shape[-1]))
+        # => (mshp0, mshp1, m2, m3)
+        mat = relay.op.transpose(mat, (1, 0, 2, 3))
+        # => (mshp1, mshp0, m2, m3)
+        # Kernel must be flipped
+        mat = relay.op.transform.reverse(mat, 2)
+        mat = relay.op.transform.reverse(mat, 3)
+        return mat, (mshp1, mshp0, mat_shape[2], mat_shape[3])
+
+    def _inputs(self):
+        i = np.random.rand(*self.get_input_shape()).astype("float32")
+        w = np.random.rand(*self.get_filter_shape()).astype("float32")
+        return i, w
+
+
+def tests():
+    # Check conv
+    c = Conv2D(
+        n=2,
+        c_in=6,
+        h_in=4,
+        w_in=5,
+        c_out=6,
+        strides=(2, 3),
+        padding=(3, 2),
+        dilation=(1, 1),
+        kernel_size=(3, 3),
+        groups=1,
+    )
+    c.debug_output()
+    # Check grad input
+    d1 = c.grad_input()
+    d1.debug_output()
+    # Get grad input, change some parameters, and check it
+    d2 = c.grad_input()
+    d2.output_padding = (2, 0)
+    d2.strides = (4, 3)
+    d2.debug_output()
+
+    # Check conv and grad input for each value
+    for conv in (
+        Conv2D(
+            n=3,
+            c_in=12,
+            h_in=60,
+            w_in=80,
+            c_out=3,
+            strides=(2, 3),
+            padding=(2, 2),
+            dilation=(1, 1),
+            kernel_size=(5, 5),
+            groups=3,
+        ),
+        Conv2D(
+            n=3,
+            c_in=12,
+            h_in=60,
+            w_in=80,
+            c_out=3,
+            strides=(2, 3),
+            padding=(2, 2),
+            dilation=(1, 2),
+            kernel_size=(5, 5),
+            groups=3,
+        ),
+        Conv2D(
+            n=3,
+            c_in=12,
+            h_in=60,
+            w_in=80,
+            c_out=3,
+            strides=(2, 3),
+            padding=0,
+            dilation=(1, 1),
+            kernel_size=(5, 5),
+            groups=3,
+        ),
+        Conv2D(
+            n=3,
+            c_in=12,
+            h_in=60,
+            w_in=80,
+            c_out=3,
+            strides=1,
+            padding=(2, 2),
+            dilation=(1, 2),
+            kernel_size=(5, 5),
+            groups=3,
+        ),
+        Conv2D(
+            n=3,
+            c_in=3,
+            h_in=60,
+            w_in=80,
+            c_out=1,
+            strides=(2, 3),
+            padding=(2, 2),
+            dilation=(1, 1),
+            kernel_size=(5, 5),
+            groups=1,
+        ),
+        Conv2D(
+            n=3,
+            c_in=3,
+            h_in=60,
+            w_in=80,
+            c_out=1,
+            strides=(2, 3),
+            padding=(2, 2),
+            dilation=(2, 1),
+            kernel_size=(5, 5),
+            groups=1,
+        ),
+        Conv2D(
+            n=3,
+            c_in=3,
+            h_in=60,
+            w_in=80,
+            c_out=1,
+            strides=(2, 3),
+            padding=0,
+            dilation=(1, 1),
+            kernel_size=(5, 5),
+            groups=1,
+        ),
+        Conv2D(
+            n=3,
+            c_in=3,
+            h_in=60,
+            w_in=80,
+            c_out=6,
+            strides=(2, 3),
+            padding=(2, 2),
+            dilation=(1, 1),
+            kernel_size=(5, 5),
+            groups=3,
+        ),
+        Conv2D(
+            n=3,
+            c_in=3,
+            h_in=60,
+            w_in=80,
+            c_out=6,
+            strides=(2, 3),
+            padding=(2, 2),
+            dilation=(2, 3),
+            kernel_size=(5, 5),
+            groups=3,
+        ),
+        Conv2D(
+            n=3,
+            c_in=3,
+            h_in=60,
+            w_in=80,
+            c_out=6,
+            strides=1,
+            padding=(2, 2),
+            dilation=(2, 3),
+            kernel_size=(5, 5),
+            groups=3,
+        ),
+    ):
+        conv.debug_output()
+        conv.grad_input().debug_output()
+
+    # Check conv transpose 2D directly
+    ConvTranspose2D(
+        n=2,
+        c_in=6,
+        h_in=4,
+        w_in=5,
+        c_out=2,
+        kernel_size=(3, 3),
+        strides=(2, 3),
+        padding=(3, 2),
+        dilation=(1, 1),
+        groups=1,
+    ).debug_output()
+    ConvTranspose2D(
+        n=2,
+        c_in=6,
+        h_in=4,
+        w_in=5,
+        c_out=2,
+        kernel_size=(3, 3),
+        strides=(2, 3),
+        padding=(3, 2),
+        dilation=(1, 1),
+        groups=1,
+    ).debug_output()
+
+
+def main():
+    global CHECK_THEANO, CHECK_RELAY, CHECK_RELAY_GRAPH
+    parser = argparse.ArgumentParser(
+        description="Check conv2d shapes and conv transpose 2d sahpes and implementations."
+    )
+    parser.add_argument(
+        "--theano",
+        "-t",
+        action="store_true",
+        default=False,
+        help="Check Theano-based implementation for conv transpose 2D (default False)",
+    )
+    parser.add_argument(
+        "--relay",
+        "-r",
+        action="store_true",
+        default=False,
+        help="Check Relay function conv2d_tranapose (default False)",
+    )
+    parser.add_argument(
+        "--relay-graph",
+        "-g",
+        action="store_true",
+        default=False,
+        help="Check Relay graph implementation for conv transpose 2D (default False)",
+    )
+    args = parser.parse_args()
+    CHECK_THEANO = args.theano
+    CHECK_RELAY = args.relay
+    CHECK_RELAY_GRAPH = args.relay_graph
+    tests()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Missing operations in relay backend to make all tests pass:
- array_setitem
- conv_transpose2d
- gather
- scatter
- scatter_add

I am currently working on `conv_transpose2d`. Issues:
- Seems limited to only `groups=1` and `dilation=(1, 1)`: https://github.com/apache/incubator-tvm/blob/master/python/tvm/relay/op/strategy/x86.py#L169
- Persistent error when running `pytest -xvvs tests/frontends/test_pytorch_ops.py::test_torch_conv2d` on this branch:

```log
(myia) notoraptor@notoraptor-linux:~/mila/dev/git/myia$ pytest -xvvs tests/frontends/test_pytorch_ops.py::test_torch_conv2d
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.7.6, pytest-5.4.1, py-1.8.1, pluggy-0.13.1 -- /home/notoraptor/anaconda3/envs/myia/bin/python
cachedir: .pytest_cache
rootdir: /media/win/Users/notoraptor/mila/dev/git/myia, inifile: pytest.ini
plugins: cov-2.8.1
collected 6 items                                                                                                                                                                                          

tests/frontends/test_pytorch_ops.py::test_torch_conv2d[relay-cpu-grad0] <- tests/multitest.py ANTLR runtime and generated code versions disagree: 4.8!=4.7.2
ANTLR runtime and generated code versions disagree: 4.8!=4.7.2
Cannot find config for target=llvm, workload=('conv2d_NCHWc.x86', ('TENSOR', (2, 6, 4, 5), 'float32'), ('TENSOR', (3, 6, 3, 3), 'float32'), (2, 3), (3, 2, 3, 2), (1, 1), 'NCHW', 'NCHW', 'float32'). A fallback configuration is used, which may bring great performance regression.
FAILED

================================================================================================= FAILURES =================================================================================================
____________________________________________________________________________________ test_torch_conv2d[relay-cpu-grad0] ____________________________________________________________________________________

test = <tests.multitest.MyiaFunctionTest object at 0x7f7570a72650>

    def runtest(test):
>       test.run(fn)

tests/multitest.py:66: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/multitest.py:166: in run
    return self.runtest(self, fn, **self.spec)
tests/frontends/test_pytorch_ops.py:147: in _fwd_and_bwd
    res = gpipeline.run(input=fn, argspec=[*argspec, sens_type])
myia/pipeline/pipeline.py:144: in run
    return self.make()(**args)
myia/pipeline/pipeline.py:201: in __call__
    return self[:](**args)
myia/pipeline/pipeline.py:245: in __call__
    raise results['error']
myia/pipeline/pipeline.py:229: in run_and_catch
    results = fn(**valid_args)
myia/pipeline/steps.py:402: in step_compile
    out = resources.backend.compile(graph, argspec, outspec)
myia/pipeline/resources.py:201: in compile
    return self.backend.compile(graph, argspec, outspec)
myia/compile/backends/__init__.py:277: in compile
    return self.proc.call_method('compile', graph, argspec, outspec)
myia/compile/channel/__init__.py:131: in call_method
    return self._read_msg()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <myia.compile.channel.RPCProcess object at 0x7f756e1fb5d0>

    def _read_msg(self):
        RemoteHandle.current_channel = self
        try:
            res = self.loader.get_data()
        finally:
            RemoteHandle.current_channel = None
        if isinstance(res, LoadedError):
>           raise res
E           myia.utils.serialize.LoadedError: Traceback (most recent call last):
E           
E             File "/media/win/Users/notoraptor/mila/dev/git/myia/myia/compile/channel/__main__.py", line 38, in _rpc_server
E               res = meth(*args, **kwargs)
E           
E             File "/media/win/Users/notoraptor/mila/dev/git/myia/myia/compile/backends/__init__.py", line 297, in compile
E               return handle(self.real.compile(graph, argspec, outspec))
E           
E             File "/media/win/Users/notoraptor/mila/dev/git/myia/myia/compile/backends/relay.py", line 884, in compile
E               self.exec_kind)
E           
E             File "/media/win/Users/notoraptor/mila/dev/git/myia/myia/compile/backends/relay.py", line 675, in run
E               add_functions(self.module, function_map, self.types)
E           
E             File "/media/win/Users/notoraptor/mila/dev/git/myia/myia/compile/backends/relay_helpers.py", line 275, in add_functions
E               mod[gv] = funcs[gv]
E           
E             File "/home/notoraptor/anaconda3/envs/myia/lib/python3.7/site-packages/tvm/ir/module.py", line 75, in __setitem__
E               return self._add(var, val)
E           
E             File "/home/notoraptor/anaconda3/envs/myia/lib/python3.7/site-packages/tvm/ir/module.py", line 84, in _add
E               _ffi_api.Module_Add(self, var, val, update)
E           
E             File "tvm/_ffi/_cython/./packed_func.pxi", line 308, in tvm._ffi._cy3.core.PackedFuncBase.__call__
E           
E             File "tvm/_ffi/_cython/./packed_func.pxi", line 253, in tvm._ffi._cy3.core.FuncCall
E           
E             File "tvm/_ffi/_cython/./base.pxi", line 159, in tvm._ffi._cy3.core.CALL
E           
E           tvm._ffi.base.TVMError: Traceback (most recent call last):
E             [bt] (8) /home/notoraptor/anaconda3/envs/myia/lib/libtvm.so(TVMFuncCall+0x65) [0x7f8ea4b23a25]
E             [bt] (7) /home/notoraptor/anaconda3/envs/myia/lib/libtvm.so(+0x539dc4) [0x7f8ea440fdc4]
E             [bt] (6) /home/notoraptor/anaconda3/envs/myia/lib/libtvm.so(+0x539a24) [0x7f8ea440fa24]
E             [bt] (5) /home/notoraptor/anaconda3/envs/myia/lib/libtvm.so(tvm::IRModuleNode::Add(tvm::GlobalVar const&, tvm::BaseFunc const&, bool)+0x425) [0x7f8ea440d875]
E             [bt] (4) /home/notoraptor/anaconda3/envs/myia/lib/libtvm.so(+0x5322d4) [0x7f8ea44082d4]
E             [bt] (3) /home/notoraptor/anaconda3/envs/myia/lib/libtvm.so(tvm::relay::InferType(tvm::relay::Function const&, tvm::IRModule const&, tvm::GlobalVar const&)+0x1db) [0x7f8ea49c545b]
E             [bt] (2) /home/notoraptor/anaconda3/envs/myia/lib/libtvm.so(+0xaeec28) [0x7f8ea49c4c28]
E             [bt] (1) /home/notoraptor/anaconda3/envs/myia/lib/libtvm.so(+0x5245fa) [0x7f8ea43fa5fa]
E             [bt] (0) /home/notoraptor/anaconda3/envs/myia/lib/libtvm.so(+0x423d01) [0x7f8ea42f9d01]
E             File "/home/user/conda-bld/tvm-libs_1584032126820/work/src/ir/error.cc", line 133
E           TVMError: 
E           Error(s) have occurred. The program has been annotated with them:
E           
E           In `main`: 
E           v0.0.4
E           fn (%v_parameter25: Tensor[(2, 6, 4, 5), float32], %v_parameter26: Tensor[(3, 6, 3, 3), float32], %v_parameter27: Tensor[(3), float32], %v_parameter28: float32) -> (Tensor[(2, 6, 4, 5), float32], Tensor[(3, 6, 3, 3), float32], Tensor[(3), float32]) {
E             let %seq.0 = (meta[relay.Constant][0],);
E             let %seq.1 = (meta[relay.Constant][1], meta[relay.Constant][2], meta[relay.Constant][3], meta[relay.Constant][4]);
E             let %seq.2 = (meta[relay.Constant][5], meta[relay.Constant][6], meta[relay.Constant][7], meta[relay.Constant][8]);
E             let %seq.3 = broadcast_to(%v_parameter28, meta[relay.attrs.InitOpAttrs][0]);
E             let %seq.4 = sum(%seq.3, axis=[0, 2, 3], keepdims=True);
E             let %seq.5 = reshape(%seq.4, newshape=[3]);
E             let %seq.6 = meta[relay.Constant][9];
E             let %seq.7 = (meta[relay.Constant][10], meta[relay.Constant][11]);
E             let %seq.8 = (meta[relay.Constant][12], meta[relay.Constant][13]);
E             let %seq.9 = (meta[relay.Constant][14], meta[relay.Constant][15]);
E             let %seq.10 = (meta[relay.Constant][16], meta[relay.Constant][17], meta[relay.Constant][18], meta[relay.Constant][19]);
E             %0 = reshape(%v_parameter25, newshape=[1, -1, 0, 0]);
E             %1 = tile(%seq.3, reps=[1, 6, 1, 1]);
E             %2 = reshape(%1, newshape=[-1, 1, 0, 0]);
E             %3 = nn.conv2d(%0, %2, padding=[3, 2, 3, 2], dilation=[2, 3], groups=12);
E             %4 = reshape(%3, newshape=[2, 6, 3, 4, 3]);
E             %5 = sum(%4, axis=[0]);
E             %6 = transpose(%5, axes=[1, 0, 2, 3]);
E             let %seq.11 = strided_slice(%6, begin=[0, 0, 0, 0], end=[None, None, 3, 3]);
E             let %seq.12 = (1, 0);
E             let %seq.13 = ();
E             let %seq.14 = nn.conv2d_transpose(%seq.3, %v_parameter26, channels=3, kernel_size=[3, 3], strides=[2, 3], output_padding=[1, 0], padding=[3, 2, 3, 2]) in particular dimension 1 conflicts 3 does not match 6; unable to unify: `Tensor[(3, 3, 3, 3), float32]` and `Tensor[(3, 6, 3, 3), float32]`; in particular dimension 1 conflicts 3 does not match 6; unable to unify: `Tensor[(2, 3, 4, 5), float32]` and `Tensor[(2, 6, 4, 5), float32]`; ;
E             let %seq.15 = (%seq.14, %seq.11, %seq.5);
E             %seq.15
E           }
E           // meta data omitted. you can use show_meta_data=True to include meta data

myia/compile/channel/__init__.py:148: LoadedError
========================================================================================= short test summary info ==========================================================================================
FAILED tests/frontends/test_pytorch_ops.py::test_torch_conv2d[relay-cpu-grad0] - myia.utils.serialize.LoadedError: Traceback (most recent call last):
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
============================================================================================ 1 failed in 17.73s ============================================================================================
```

The main error is in this line: `let %seq.14 = nn.conv2d_transpose(%seq.3, %v_parameter26, channels=3, kernel_size=[3, 3], strides=[2, 3], output_padding=[1, 0], padding=[3, 2, 3, 2]) in particular dimension 1 conflicts 3 does not match 6; unable to unify: `Tensor[(3, 3, 3, 3), float32]` and `Tensor[(3, 6, 3, 3), float32]`; in particular dimension 1 conflicts 3 does not match 6; unable to unify: `Tensor[(2, 3, 4, 5), float32]` and `Tensor[(2, 6, 4, 5), float32]`; ;`. I still don't know what causes this.