### PR TITLE
Split the manager into infer_manager and opt_manager

### DIFF
--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -280,10 +280,6 @@ class InferenceEngine:
             self.constructors[m] = MacroInferrer(m.macro)
         return self.constructors[m]
 
-    @get_inferrer_for.register
-    def get_inferrer_for(self, df: DummyFunction):
-        raise MyiaTypeError(f"Trying to call dummy")
-
     async def execute(self, fn, *args):
         r"""Infer the result of fn(\*args)."""
         infs = [self.get_inferrer_for(poss) for poss in await fn.get()]

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -137,9 +137,13 @@ class InferenceEngine:
 
     def ref(self, node, context):
         """Return a Reference to the node in the given context."""
+        if node.abstract is not None:
+            return Reference(self, node, CONTEXTLESS)
         if context is CONTEXTLESS:
             return Reference(self, node, CONTEXTLESS)
         if node.is_constant_graph():
+            if node.value.abstract is not None:
+                return Reference(self, node, CONTEXTLESS)
             graph = node.value.parent
         else:
             graph = node.graph

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -100,6 +100,7 @@ class InferenceEngine:
             keytransform=self.get_actual_ref,
         )
         self.reference_map = {}
+        self.new_reference_map = {}
         self.constructors = {}
 
     async def infer_function(self, fn, argspec, outspec=None):
@@ -198,7 +199,7 @@ class InferenceEngine:
             # This will link the old node's debug info to the new node, if
             # necessary.
             new.node.debug.about = About(orig.node.debug, "reroute")
-        self.reference_map[orig] = new
+        self.reference_map[orig] = self.new_reference_map[orig] = new
         return await self.get_inferred(new)
 
     def get_actual_ref(self, ref):
@@ -384,8 +385,10 @@ class InferenceEngine:
 
     def concretize_cache(self):
         """Complete the engine's caches with concretized contexts."""
-        concretize_cache(self.cache.cache)
-        concretize_cache(self.reference_map)
+        concretize_cache(self.cache.new, dest=self.cache.cache)
+        self.cache.new = {}
+        concretize_cache(self.new_reference_map, dest=self.reference_map)
+        self.new_reference_map = {}
 
 
 class LiveInferenceEngine(InferenceEngine):

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -56,6 +56,7 @@ from .to_abstract import to_abstract
 from .utils import (
     broaden as _broaden,
     concretize_abstract,
+    concretize_cache,
     sensitivity_transform,
 )
 
@@ -380,6 +381,11 @@ class InferenceEngine:
         immediately.
         """
         return await force_pending(self.check(predicate, *values))
+
+    def concretize_cache(self):
+        """Complete the engine's caches with concretized contexts."""
+        concretize_cache(self.cache.cache)
+        concretize_cache(self.reference_map)
 
 
 class LiveInferenceEngine(InferenceEngine):

--- a/myia/abstract/ref.py
+++ b/myia/abstract/ref.py
@@ -115,6 +115,8 @@ class Reference(ReferenceBase):
 
     def get_resolved(self):
         """Get the value if resolved. Error out if not."""
+        if self.node.abstract is not None:
+            return self.node.abstract
         c = self.engine.cache.cache
         if self in c:
             fut = c[self]

--- a/myia/abstract/ref.py
+++ b/myia/abstract/ref.py
@@ -175,6 +175,7 @@ class EvaluationCache:
     def __init__(self, loop, keycalc, keytransform):
         """Initialize an EvaluationCache."""
         self.cache = {}
+        self.new = {}
         self.loop = loop
         self.keytransform = keytransform
         self.keycalc = keycalc
@@ -184,7 +185,7 @@ class EvaluationCache:
         key = self.keytransform(key)
         if key not in self.cache:
             coro = self.keycalc(key)
-            self.cache[key] = self.loop.create_task(coro)
+            self.cache[key] = self.new[key] = self.loop.create_task(coro)
         return self.cache[key]
 
     def set_value(self, key, value):
@@ -194,7 +195,7 @@ class EvaluationCache:
         """
         fut = asyncio.Future(loop=self.loop)
         fut.set_result(value)
-        self.cache[key] = fut
+        self.cache[key] = self.new[key] = fut
 
 
 __consolidate__ = True

--- a/myia/api.py
+++ b/myia/api.py
@@ -174,6 +174,7 @@ def myia(
         alias_tracker: function to indicate aliases
             (see :func:`myia.abstract.find_aliases`)
         use_universe: Enable use of sequential code (experimental)
+        pipeline: Pipeline to use
 
     """
     return MyiaFunction(

--- a/myia/api.py
+++ b/myia/api.py
@@ -45,6 +45,7 @@ class MyiaFunction:
         alias_tracker=None,
         use_universe=False,
         tracer=ABSENT,
+        pipeline=standard_pipeline,
     ):
         """Initialize a MyiaFunction."""
         # Change this once relay becomes the default backend.
@@ -55,7 +56,7 @@ class MyiaFunction:
         self.fn = fn
         self.alias_tracker = alias_tracker
         self.specialize_values = set(specialize_values)
-        self.pip = standard_pipeline.configure(
+        self.pip = pipeline.configure(
             {
                 "resources.universal": use_universe,
                 "resources.backend.name": backend,
@@ -148,6 +149,7 @@ def myia(
     return_backend=False,
     alias_tracker=None,
     use_universe=False,
+    pipeline=standard_pipeline,
 ):
     """Create a function using Myia's runtime.
 
@@ -182,6 +184,7 @@ def myia(
         return_backend=return_backend,
         alias_tracker=alias_tracker,
         use_universe=use_universe,
+        pipeline=pipeline,
     )
 
 

--- a/myia/grad.py
+++ b/myia/grad.py
@@ -472,7 +472,7 @@ class SensRemapper(GradRemapper):
                 ng.add_parameter()
 
 
-def _grad(mng, root):
+def _grad(root):
     graphs = root.scope
 
     remappers = RemapperSet(
@@ -507,8 +507,7 @@ def Jimpl(prim: Primitive, resources, node):
 @overload  # noqa: F811
 def Jimpl(graph: Graph, resources, node):
     """Implement J on a Graph."""
-    manager = resources.manager
-    return _grad(manager, graph)
+    return _grad(graph)
 
 
 @overload  # noqa: F811

--- a/myia/ir/clone.py
+++ b/myia/ir/clone.py
@@ -461,11 +461,7 @@ class GraphCloner:
 
 
 def clone(
-    g,
-    total=True,
-    relation="copy",
-    clone_constants=False,
-    graph_relation=None,
+    g, total=True, relation="copy", clone_constants=False, graph_relation=None,
 ):
     """Return a clone of g."""
     return GraphCloner(

--- a/myia/ir/clone.py
+++ b/myia/ir/clone.py
@@ -17,13 +17,6 @@ from .manager import manage
 
 
 @dataclass
-class Quarantined:
-    """Wraps a node's value to block it from the manager."""
-
-    graph: Graph
-
-
-@dataclass
 class _ToLink:
     """Describes a node that we want to link in the link phase."""
 
@@ -254,7 +247,6 @@ class CloneRemapper(BasicRemapper):
         graph_repl,
         graph_relation,
         clone_constants,
-        quarantine=None,
         set_abstract=True,
     ):
         """Initialize the GraphCloner."""
@@ -268,7 +260,6 @@ class CloneRemapper(BasicRemapper):
         self.inlines = inlines
         self.clone_constants = clone_constants
         self.set_abstract = set_abstract
-        self.quarantine = quarantine
 
     def remap_node(self, key, graph, node, new_graph, new_node, link=None):
         """Remap the given node as normal and also copy the abstract."""
@@ -318,18 +309,11 @@ class CloneRemapper(BasicRemapper):
     def gen_constant_graph(self, graph, new_graph, constant):
         """Generate a constant for the cloned graph when applicable."""
         g = constant.value
-        if self.quarantine and self.quarantine(g):
+        if g not in self.inlines and g in self.graph_repl:
+            target_graph = self.get_graph(g)
             with About(constant.debug, self.relation):
-                new = Constant(Quarantined(g))
-                new.abstract = g.abstract
-                assert new.abstract
+                new = Constant(target_graph)
                 self.remap_node(constant, graph, constant, new_graph, new)
-        else:
-            if g not in self.inlines and g in self.graph_repl:
-                target_graph = self.get_graph(g)
-                with About(constant.debug, self.relation):
-                    new = Constant(target_graph)
-                    self.remap_node(constant, graph, constant, new_graph, new)
 
     def link_apply(self, link):
         """Fill a node's inputs."""
@@ -420,11 +404,9 @@ class GraphCloner:
         graph_relation=None,
         graph_repl=None,
         remapper_class=CloneRemapper,
-        quarantine=None,
     ):
         """Initialize a GraphCloner."""
         self.total = total
-        self.quarantine = quarantine
         self.clone_children = clone_children
         if isinstance(inline, tuple):
             inline = [inline]
@@ -439,7 +421,6 @@ class GraphCloner:
             graph_repl=graph_repl,
             graph_relation=graph_relation,
             clone_constants=clone_constants,
-            quarantine=quarantine,
         )
         self.remapper.run()
 
@@ -470,8 +451,6 @@ class GraphCloner:
                 msg += " Try setting the `total` option to False."
             raise Exception(msg)
         self.graphs.update(self.inlines)
-        if self.quarantine is not None:
-            self.graphs = {g for g in self.graphs if not self.quarantine(g)}
 
     def __getitem__(self, x):
         """Get the clone of the given graph or node."""
@@ -487,7 +466,6 @@ def clone(
     relation="copy",
     clone_constants=False,
     graph_relation=None,
-    quarantine=None,
 ):
     """Return a clone of g."""
     return GraphCloner(
@@ -496,7 +474,6 @@ def clone(
         relation=relation,
         clone_constants=clone_constants,
         graph_relation=graph_relation,
-        quarantine=quarantine,
     )[g]
 
 
@@ -524,7 +501,6 @@ __all__ = [
     "CloneRemapper",
     "GraphCloner",
     "GraphRemapper",
-    "Quarantined",
     "RemapperSet",
     "clone",
     "transformable_clone",

--- a/myia/ir/manager.py
+++ b/myia/ir/manager.py
@@ -560,6 +560,7 @@ class GraphManager(Partializable):
         if allow_changes is None:
             allow_changes = self.manage
         self.allow_changes = allow_changes
+        self.check_opaque = None
         self.reset()
 
     def clear(self):
@@ -612,6 +613,10 @@ class GraphManager(Partializable):
         for root in roots:
             self.add_graph(root, root=True)
 
+    def set_opaque_condition(self, fn):
+        """Set a condition on nodes that should not be included."""
+        self.check_opaque = fn
+
     def add_graph(self, graph, root=False):
         """Add a graph to this manager, optionally as a root graph."""
         if root:
@@ -647,7 +652,9 @@ class GraphManager(Partializable):
         """Ensure that the graph is managed by this manager."""
         if self.manage:
             if graph._manager and graph._manager is not self:
-                raise ManagerError("A graph can only have one manager.")
+                raise ManagerError(
+                    "A graph can only have one manager. " f"Graph: {graph}"
+                )
             graph._manager = self
         self.graphs.add(graph)
 
@@ -691,6 +698,8 @@ class GraphManager(Partializable):
                 * -1 if the edge is removed.
 
         """
+        if self.check_opaque and self.check_opaque(inp):
+            return
         if direction == -1:
             if (node, key) not in self.uses[inp]:
                 # It's possible that we already got here when we
@@ -730,9 +739,12 @@ class GraphManager(Partializable):
 
         acq = OrderedSet()
         for node in nodes:
-            new_nodes = OrderedSet(dfs(node, succ_deeper, limit))
-            self.all_nodes |= new_nodes
-            acq |= new_nodes
+            acq |= OrderedSet(dfs(node, succ_deeper, limit))
+
+        if self.check_opaque:
+            acq = [n for n in acq if not self.check_opaque(n)]
+
+        self.all_nodes |= acq
 
         for node in acq:
             g = node.graph

--- a/myia/ir/manager.py
+++ b/myia/ir/manager.py
@@ -563,14 +563,6 @@ class GraphManager(Partializable):
         self.check_opaque = None
         self.reset()
 
-    def clear(self):
-        """Clear the manager entirely."""
-        self.roots = []
-        if self.manage:
-            for graph in self.graphs:
-                graph._manager = None
-        self.reset()
-
     def reset(self):
         """Reset the manager's state.
 

--- a/myia/ir/manager.py
+++ b/myia/ir/manager.py
@@ -724,7 +724,9 @@ class GraphManager(Partializable):
         """Add newly connected nodes."""
 
         def limit(x):
-            if x in self.all_nodes:
+            if x in self.all_nodes or (
+                self.check_opaque and self.check_opaque(x)
+            ):
                 return EXCLUDE
             else:
                 return FOLLOW
@@ -732,9 +734,6 @@ class GraphManager(Partializable):
         acq = OrderedSet()
         for node in nodes:
             acq |= OrderedSet(dfs(node, succ_deeper, limit))
-
-        if self.check_opaque:
-            acq = [n for n in acq if not self.check_opaque(n)]
 
         self.all_nodes |= acq
 

--- a/myia/monomorphize.py
+++ b/myia/monomorphize.py
@@ -55,7 +55,6 @@ from .ir import (
     MetaGraph,
     succ_incoming,
 )
-from .ir.clone import Quarantined
 from .operations import Primitive
 from .utils import InferenceError, MyiaTypeError, OrderedSet, overload
 
@@ -710,7 +709,6 @@ class _MonoRemapper(CloneRemapper):
         engine,
         graph_repl,
         fv_function,
-        quarantine,
     ):
         """Initialize the _MonoRemapper."""
         super().__init__(
@@ -722,7 +720,6 @@ class _MonoRemapper(CloneRemapper):
             graph_relation=graph_relation,
             clone_constants=clone_constants,
             set_abstract=False,
-            quarantine=quarantine,
         )
         self.engine = engine
         self.fv_function = fv_function

--- a/myia/monomorphize.py
+++ b/myia/monomorphize.py
@@ -415,9 +415,9 @@ class Monomorphizer:
 
     """
 
-    def __init__(self, resources):
+    def __init__(self, resources, engine):
         """Initialize the monomorphizer."""
-        self.engine = resources.inferrer.engine
+        self.engine = engine
         self.manager = resources.manager
         self.specializations = {}
         self.replacements = defaultdict(dict)
@@ -793,15 +793,8 @@ class _MonoRemapper(CloneRemapper):
             self.remap_node((g, fv), g, fv, ng, new, link=False)
 
 
-def monomorphize(resources, root_context):
-    """Monomorphize all graphs starting with the given root context."""
-    mono = Monomorphizer(resources)
-    return mono.run(root_context)
-
-
 __all__ = [
     "Monomorphizer",
     "Unspecializable",
     "concretize_cache",
-    "monomorphize",
 ]

--- a/myia/monomorphize.py
+++ b/myia/monomorphize.py
@@ -416,9 +416,10 @@ class Monomorphizer:
 
     """
 
-    def __init__(self, engine, reuse_existing=True):
+    def __init__(self, resources, reuse_existing=True):
         """Initialize the monomorphizer."""
-        self.engine = engine
+        self.engine = resources.inferrer.engine
+        self.manager = resources.manager
         self.specializations = {}
         self.replacements = defaultdict(dict)
         self.results = {}
@@ -430,7 +431,6 @@ class Monomorphizer:
 
     def run(self, context):
         """Run monomorphization."""
-        self.manager = context.graph.manager
         concretize_cache(self.engine.cache.cache)
         concretize_cache(self.engine.reference_map)
         self.collect(context)
@@ -814,9 +814,9 @@ class _MonoRemapper(CloneRemapper):
             self.remap_node((g, fv), g, fv, ng, new, link=False)
 
 
-def monomorphize(engine, root_context, reuse_existing=True):
+def monomorphize(resources, root_context, reuse_existing=True):
     """Monomorphize all graphs starting with the given root context."""
-    mono = Monomorphizer(engine, reuse_existing=reuse_existing)
+    mono = Monomorphizer(resources, reuse_existing=reuse_existing)
     return mono.run(root_context)
 
 

--- a/myia/monomorphize.py
+++ b/myia/monomorphize.py
@@ -18,7 +18,6 @@ from .abstract import (
     AbstractFunction,
     AbstractJTagged,
     AbstractTuple,
-    AbstractValue,
     Context,
     DummyFunction,
     GraphFunction,
@@ -32,7 +31,6 @@ from .abstract import (
     TypedPrimitive,
     VirtualFunction,
     VirtualReference,
-    abstract_check,
     abstract_clone,
     amerge,
     broaden,
@@ -44,7 +42,6 @@ from .abstract import (
     refmap,
 )
 from .abstract.infer import VirtualInferrer
-from .abstract.utils import CheckState, CloneState
 from .graph_utils import dfs
 from .info import About
 from .ir import (
@@ -56,7 +53,7 @@ from .ir import (
     succ_incoming,
 )
 from .operations import Primitive
-from .utils import InferenceError, MyiaTypeError, OrderedSet, overload
+from .utils import InferenceError, MyiaTypeError, OrderedSet
 
 
 class Unspecializable(Exception):

--- a/myia/operations/macro_user_switch.py
+++ b/myia/operations/macro_user_switch.py
@@ -30,7 +30,6 @@ class _CastRemapper(CloneRemapper):
         graph_relation,
         clone_constants,
         graph_repl,
-        quarantine,
         fv_replacements,
     ):
         """Initialize the GraphCloner."""
@@ -42,7 +41,6 @@ class _CastRemapper(CloneRemapper):
             graph_repl=graph_repl,
             graph_relation=graph_relation,
             clone_constants=clone_constants,
-            quarantine=quarantine,
         )
         self.fv_replacements = fv_replacements
 

--- a/myia/operations/prim_Jinv.py
+++ b/myia/operations/prim_Jinv.py
@@ -1,76 +1,15 @@
 """Definitions for the primitive `Jinv`."""
 
-from ..lib import (
-    AbstractFunction,
-    AbstractJTagged,
-    Context,
-    DummyFunction,
-    Graph,
-    GraphFunction,
-    JTransformedFunction,
-    MyiaTypeError,
-    Primitive,
-    PrimitiveFunction,
-    VirtualFunction,
-    bprop_to_grad_transform,
-    standard_prim,
-)
+from ..abstract.infer import compute_jinv_type
+from ..lib import bprop_to_grad_transform, standard_prim
 from ..operations import J
-from ..utils.errors import untested_legacy
 from . import primitives as P
 
 
 @standard_prim(P.Jinv)
 async def infer_Jinv(self, engine, x):
     """Infer the return type of primitive `Jinv`."""
-    if isinstance(x, AbstractFunction):
-        v = await x.get()
-        results = []
-        for f in v:
-            if isinstance(f, JTransformedFunction):
-                res = f.fn
-            elif isinstance(f, GraphFunction):
-                g = f.graph
-                primal = g and g.transforms.get("primal", None)
-                if primal:
-                    if isinstance(primal, Graph):
-                        if primal.parent:
-                            # The primal for a closure can't be used
-                            # because it points to the original nodes
-                            # of its parent, whereas we would like to
-                            # point to the transformed nodes of the
-                            # parent. This is fixable, and will need
-                            # to be fixed to support a few edge cases.
-                            res = DummyFunction()
-                        else:
-                            with untested_legacy():
-                                # Not sure why this never happens anymore
-                                primal = engine.resources.convert(primal)
-                                res = GraphFunction(primal, Context.empty())
-                    else:
-                        with untested_legacy():
-                            # Not sure why this never happens either
-                            res = primal
-                            if isinstance(res, Primitive):
-                                tid = getattr(f, "tracking_id", None)
-                                res = PrimitiveFunction(res, tracking_id=tid)
-                else:
-                    raise MyiaTypeError(f"Bad input type for {self.prim}: {f}")
-            elif isinstance(f, VirtualFunction):
-                res = VirtualFunction(
-                    tuple(
-                        [await self._infer(self, engine, arg) for arg in f.args]
-                    ),
-                    await self._infer(self, engine, f.output.elements[0]),
-                )
-            else:
-                raise MyiaTypeError(f"Expected JTransformedFunction, not {f}")
-            results.append(res)
-        return AbstractFunction(*results)
-    if isinstance(x, AbstractJTagged):
-        return x.element
-    else:
-        raise MyiaTypeError("Expected JTagged")
+    return await compute_jinv_type(x)
 
 
 @bprop_to_grad_transform(P.Jinv)

--- a/myia/opt/cse.py
+++ b/myia/opt/cse.py
@@ -83,11 +83,14 @@ class CSE(Partializable):
     def __call__(self, root):
         """Apply CSE on root."""
         args = dict(
-            opt=self, node=None, manager=self.resources.manager, profile=False
+            opt=self,
+            node=None,
+            manager=self.resources.opt_manager,
+            profile=False,
         )
         with tracer("opt", **args) as tr:
             tr.set_results(success=False, **args)
-            chg = cse(root, self.resources.manager)
+            chg = cse(root, self.resources.opt_manager)
             if chg:
                 tracer().emit_success(**args, new_node=None)
             return chg and self.report_changes

--- a/myia/opt/dde.py
+++ b/myia/opt/dde.py
@@ -42,7 +42,7 @@ class ValuePropagator:
     def __init__(self, resources, root):
         """Initialize a ValuePropagator and run the algorithm."""
         self.resources = resources
-        self.manager = resources.manager
+        self.manager = resources.opt_manager
         # need :: node -> {paths}
         self.need = defaultdict(set)
         # flow :: node -> {node}

--- a/myia/opt/dde.py
+++ b/myia/opt/dde.py
@@ -474,7 +474,6 @@ class DeadDataElimination(Partializable):
         args = dict(opt=self, node=None, manager=root.manager, profile=False)
         with tracer("opt", **args) as tr:
             tr.set_results(success=False, **args)
-            root.manager.keep_roots(root)
             vprop = ValuePropagator(self.resources, root)
             present = {node for node, needs in vprop.need.items() if needs}
             missing = vprop.manager.all_nodes - present

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -1119,7 +1119,7 @@ def expand_J(resources, node, equiv):
             sig = newg.make_signature(argspec)
             newg = newg.generate_graph(sig)
         newg = clone(newg, quarantine=lambda g: g.abstract is not None)
-        resources.manager.add_graph(newg)
+        resources.infer_manager.add_graph(newg)
         empty = engine.context_class.empty()
         context = empty.add(newg, tuple(argspec))
         engine.run_coroutine(engine.infer_function(newg, argspec, outspec))
@@ -1167,8 +1167,8 @@ class JElim(Partializable):
 
     def __call__(self, root):
         """Apply JElim on root."""
-        mng = self.resources.manager
-        args = dict(opt=self, node=None, manager=self.resources.manager)
+        mng = self.resources.opt_manager
+        args = dict(opt=self, node=None, manager=mng)
         with tracer("opt", **args) as tr:
             tr.set_results(success=False, **args)
             mng.keep_roots(root)

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -16,7 +16,6 @@ from ..ir import (
     Constant,
     Graph,
     GraphCloner,
-    clone,
     transformable_clone,
 )
 from ..operations import Primitive, primitives as P

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -1124,6 +1124,7 @@ def expand_J(resources, node, equiv):
         context = empty.add(newg, tuple(argspec))
         engine.run_coroutine(engine.infer_function(newg, argspec, outspec))
         newg2 = resources.monomorphizer(context)
+        resources.opt_manager.keep_roots(newg2)
 
         newg = newg2
         for node in mono.manager.all_nodes:

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -1087,7 +1087,6 @@ def expand_J(resources, node, equiv):
     from ..grad import Jimpl
 
     arg = equiv[C].value
-    assert getattr(arg, "parent", None) is None
 
     if not hasattr(resources, "grad_cache"):
         resources.grad_cache = {}

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -1146,7 +1146,6 @@ class JElim(Partializable):
         args = dict(opt=self, node=None, manager=mng)
         with tracer("opt", **args) as tr:
             tr.set_results(success=False, **args)
-            mng.keep_roots(root)
             nodes = []
             typesubs = []
             for node in mng.all_nodes:

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -16,7 +16,6 @@ from ..ir import (
     Constant,
     Graph,
     GraphCloner,
-    Quarantined,
     clone,
     transformable_clone,
 )

--- a/myia/opt/opt.py
+++ b/myia/opt/opt.py
@@ -176,7 +176,7 @@ class LocalPassOptimizer:
         due to optimizations.
         """
         if self.resources is not None:
-            mng = self.resources.manager
+            mng = self.resources.opt_manager
             mng.add_graph(graph)
         else:
             mng = manage(graph)

--- a/myia/opt/opt.py
+++ b/myia/opt/opt.py
@@ -232,8 +232,8 @@ class LocalPassOptimizer:
                         mng.replace(n, new)
                         tracer().emit_success(**args, new_node=new)
                         tr.set_results(success=True, **args)
-                        if self.resources and self.resources.inferrer:
-                            self.resources.inferrer.infer_incremental()
+                        if self.resources and self.resources.live_inferrer:
+                            self.resources.live_inferrer()
                         n = new
                         loop = True
                         changes = True

--- a/myia/pipeline/pipeline.py
+++ b/myia/pipeline/pipeline.py
@@ -130,7 +130,13 @@ class PipelineDefinition:
         The names don't have to be in the same order as the original
         definition, so pipeline steps can be reordered this way.
         """
-        return PipelineDefinition(**{name: self.steps[name] for name in names})
+        new_steps = {}
+        for name in names:
+            if isinstance(name, str):
+                new_steps[name] = self.steps[name]
+            else:
+                new_steps.update(name)
+        return PipelineDefinition(**new_steps)
 
     def make(self):
         """Create a Pipeline from this definition."""

--- a/myia/pipeline/resources.py
+++ b/myia/pipeline/resources.py
@@ -342,10 +342,6 @@ class Resources(Partializable):
         """Run the Resources as a pipeline step."""
         return {"resources": self}
 
-    def copy(self):
-        """Copy the resources object."""
-        return Resources(**self._members)
-
 
 __consolidate__ = True
 __all__ = [

--- a/myia/pipeline/resources.py
+++ b/myia/pipeline/resources.py
@@ -200,7 +200,7 @@ class InferenceResource(Partializable):
     def monomorphize(self, context):
         """Perform monomorphization."""
         with tracer("monomorphize", engine=self.engine, context=context) as tr:
-            rval = monomorphize(self.engine, context, reuse_existing=True)
+            rval = monomorphize(self.resources, context, reuse_existing=True)
             tr.set_results(output=rval)
             return rval
 

--- a/myia/pipeline/resources.py
+++ b/myia/pipeline/resources.py
@@ -236,7 +236,6 @@ class Incorporator(Partializable):
     def __init__(self, resources):
         """Initialize an Incorporator."""
         self.infer_manager = resources.infer_manager
-        self.opt_manager = resources.opt_manager
         self.engine = resources.inferrer.engine
         self.mono = resources.monomorphizer
 
@@ -260,9 +259,7 @@ class Incorporator(Partializable):
         self.engine.run_coroutine(
             self.engine.infer_function(graph, argspec, outspec)
         )
-        mgraph = self.mono(context)
-        # self.opt_manager.add_graph(mgraph)
-        return mgraph
+        return self.mono(context)
 
 
 class NumpyChecker:

--- a/myia/pipeline/resources.py
+++ b/myia/pipeline/resources.py
@@ -200,7 +200,7 @@ class InferenceResource(Partializable):
     def monomorphize(self, context):
         """Perform monomorphization."""
         with tracer("monomorphize", engine=self.engine, context=context) as tr:
-            rval = monomorphize(self.resources, context, reuse_existing=True)
+            rval = monomorphize(self.resources, context)
             tr.set_results(output=rval)
             return rval
 

--- a/myia/pipeline/standard.py
+++ b/myia/pipeline/standard.py
@@ -297,7 +297,6 @@ standard_resources = Resources.partial(
 standard_pipeline = PipelineDefinition(
     resources=standard_resources,
     parse=steps.step_parse,
-    resolve=steps.step_resolve,
     infer=steps.step_infer,
     specialize=steps.step_specialize,
     simplify_types=steps.step_simplify_types,
@@ -317,7 +316,6 @@ scalar_pipeline = standard_pipeline.configure(
 standard_debug_pipeline = PipelineDefinition(
     resources=standard_resources,
     parse=steps.step_parse,
-    resolve=steps.step_resolve,
     infer=steps.step_infer,
     specialize=steps.step_specialize,
     simplify_types=steps.step_simplify_types,
@@ -345,12 +343,12 @@ standard_parse = standard_pipeline.select(
 
 
 scalar_parse = scalar_pipeline.select(
-    "resources", "parse", "resolve"
+    "resources", "parse", {"resolve": steps.step_resolve}
 ).make_transformer("input", "graph")
 
 
 scalar_debug_compile = scalar_debug_pipeline.select(
-    "resources", "parse", "resolve", "export"
+    "resources", "parse", {"resolve": steps.step_resolve}, "export"
 ).make_transformer("input", "output")
 
 

--- a/myia/pipeline/standard.py
+++ b/myia/pipeline/standard.py
@@ -20,6 +20,7 @@ from .resources import (
     BackendResource,
     ConverterResource,
     DebugVMResource,
+    Incorporator,
     InferenceResource,
     LiveInferenceResource,
     MonomorphizationResource,
@@ -285,6 +286,7 @@ standard_resources = Resources.partial(
             # CallValidator,
         ]
     ),
+    incorporate=Incorporator.partial(),
     return_backend=False,
     universal=False,
 )

--- a/myia/pipeline/standard.py
+++ b/myia/pipeline/standard.py
@@ -264,7 +264,8 @@ standard_method_map = {
 
 
 standard_resources = Resources.partial(
-    manager=GraphManager.partial(),
+    infer_manager=GraphManager.partial(),
+    opt_manager=GraphManager.partial(),
     py_implementations=py_registry,
     grad_implementations=grad_registry,
     method_map=standard_method_map,

--- a/myia/pipeline/standard.py
+++ b/myia/pipeline/standard.py
@@ -21,6 +21,8 @@ from .resources import (
     ConverterResource,
     DebugVMResource,
     InferenceResource,
+    LiveInferenceResource,
+    MonomorphizationResource,
     Resources,
     Tracker,
 )
@@ -270,6 +272,8 @@ standard_resources = Resources.partial(
     inferrer=InferenceResource.partial(
         constructors=inferrer_registry, max_stack_depth=50
     ),
+    monomorphizer=MonomorphizationResource.partial(),
+    live_inferrer=LiveInferenceResource.partial(constructors=inferrer_registry),
     tracker=Tracker.partial(),
     backend=BackendResource.partial(),
     debug_vm=DebugVMResource.partial(implementations=vm_registry),

--- a/myia/pipeline/standard.py
+++ b/myia/pipeline/standard.py
@@ -13,6 +13,7 @@ from ..operations import primitives as P
 from ..operations.gen import lop, reverse_binop, rop
 from ..public_api import item
 from ..utils import Registry
+from ..validate import AbstractValidator, MultiValidator, OperatorValidator
 from . import steps
 from .pipeline import PipelineDefinition
 from .resources import (
@@ -272,6 +273,13 @@ standard_resources = Resources.partial(
     tracker=Tracker.partial(),
     backend=BackendResource.partial(),
     debug_vm=DebugVMResource.partial(implementations=vm_registry),
+    validator=MultiValidator.partial(
+        validators=[
+            OperatorValidator,
+            AbstractValidator,
+            # CallValidator,
+        ]
+    ),
     return_backend=False,
     universal=False,
 )

--- a/myia/pipeline/steps.py
+++ b/myia/pipeline/steps.py
@@ -148,7 +148,7 @@ def step_infer(resources, graph, argspec):
     orig_argspec = argspec
     if resources.universal:
         argspec = (type_to_abstract(UniverseType), *argspec)
-    outspec, context = resources.inferrer.infer(graph, argspec)
+    outspec, context = resources.inferrer(graph, argspec)
     if not nobottom(outspec):
         raise InferenceError(
             "There is no condition in which the program succeeds"
@@ -180,7 +180,7 @@ def step_specialize(resources, graph, inference_context):
     Outputs:
         graph: The specialized graph.
     """
-    new_graph = resources.inferrer.monomorphize(inference_context)
+    new_graph = resources.monomorphizer(inference_context)
     return {"graph": new_graph}
 
 
@@ -205,7 +205,7 @@ def step_simplify_types(resources, graph, argspec, outspec):
     simplify_types(graph, mng)
     mng.keep_roots(graph)
     new_argspec = tuple(p.abstract for p in graph.parameters)
-    resources.inferrer.infer_incremental()
+    resources.live_inferrer()
     new_outspec = graph.output.abstract
     return {
         "graph": graph,

--- a/myia/pipeline/steps.py
+++ b/myia/pipeline/steps.py
@@ -85,8 +85,6 @@ class Optimizer(Partializable):
                             changes = True
                 if run_only_once:
                     break
-        with tracer("keep_roots"):
-            resources.opt_manager.keep_roots(graph)
         res = {"graph": graph}
         return res
 
@@ -217,7 +215,6 @@ def step_simplify_types(resources, graph, argspec, outspec):
     resources.tracker.activate()
     mng = resources.opt_manager
     simplify_types(graph, mng)
-    mng.keep_roots(graph)
     new_argspec = tuple(p.abstract for p in graph.parameters)
     resources.live_inferrer()
     new_outspec = graph.output.abstract

--- a/myia/pipeline/steps.py
+++ b/myia/pipeline/steps.py
@@ -24,7 +24,7 @@ from ..utils import (
     new_universe,
     tracer,
 )
-from ..validate import ValidationError, validate
+from ..validate import ValidationError
 from ..xtype import UniverseType
 
 #############
@@ -378,7 +378,7 @@ def step_validate(resources, graph, outspec=None):
         raise ValidationError(
             "The output type of the graph changed during optimization."
         )
-    validate(graph)
+    resources.validator(graph)
     return {"graph": graph}
 
 

--- a/myia/pipeline/steps.py
+++ b/myia/pipeline/steps.py
@@ -194,6 +194,7 @@ def step_specialize(resources, graph, inference_context):
         graph: The specialized graph.
     """
     new_graph = resources.monomorphizer(inference_context)
+    resources.opt_manager.keep_roots(new_graph)
     return {"graph": new_graph}
 
 

--- a/myia/utils/errors.py
+++ b/myia/utils/errors.py
@@ -120,4 +120,5 @@ __all__ = [
     "check_nargs",
     "infer_trace",
     "type_error_nargs",
+    "untested_legacy",
 ]

--- a/myia/validate.py
+++ b/myia/validate.py
@@ -4,8 +4,10 @@ from types import SimpleNamespace
 
 from . import xtype
 from .abstract import (
+    ANYTHING,
     DEAD,
     POLY,
+    AbstractArray,
     AbstractClass,
     AbstractError,
     AbstractExternal,
@@ -51,6 +53,16 @@ def validate_abstract(self, a: AbstractError, uses):
 
 
 @overload  # noqa: F811
+def validate_abstract(self, a: AbstractArray, uses):
+    at = a.xtype()
+    if at is not ANYTHING and not issubclass(at, xtype.NDArray):
+        raise ValidationError(
+            f"Illegal array type in the graph: {a.xtype()}", type=a.xtype()
+        )
+    return True
+
+
+@overload  # noqa: F811
 def validate_abstract(self, a: AbstractScalar, uses):
     if not issubclass(
         a.xtype(),
@@ -89,6 +101,7 @@ def validate_abstract(self, a: AbstractFunction, uses):
         raise ValidationError(
             f"All function types should be VirtualFunction, not {fn}"
         )
+    return self(a.values, uses)
 
 
 class NodeValidator:

--- a/myia/validate.py
+++ b/myia/validate.py
@@ -96,7 +96,7 @@ class NodeValidator:
 
     def __init__(self, resources, errors=None):
         self.errors = errors or ErrorPool(exc_class=ValidationError)
-        self.manager = resources.manager
+        self.manager = resources.opt_manager
 
     def _test(self, node):
         try:
@@ -206,7 +206,7 @@ def validate(root):
             AbstractValidator,
             # CallValidator,
         ],
-        resources=SimpleNamespace(manager=root.manager),
+        resources=SimpleNamespace(opt_manager=root.manager),
     )
     mv(root)
 

--- a/myia/validate.py
+++ b/myia/validate.py
@@ -108,6 +108,7 @@ class NodeValidator:
     """Validate each node in a graph."""
 
     def __init__(self, resources, errors=None):
+        """Initialize a NodeValidator."""
         self.errors = errors or ErrorPool(exc_class=ValidationError)
         self.manager = resources.opt_manager
 

--- a/tests/compile/test_cconv.py
+++ b/tests/compile/test_cconv.py
@@ -2,7 +2,7 @@ from pytest import mark
 
 from myia.compile import closure_convert
 from myia.ir import manage
-from myia.pipeline import scalar_debug_pipeline
+from myia.pipeline import scalar_debug_pipeline, steps
 
 
 def step_cconv(graph):
@@ -11,7 +11,7 @@ def step_cconv(graph):
 
 
 cconv_pipeline = scalar_debug_pipeline.select(
-    "resources", "parse", "resolve", "export"
+    "resources", "parse", {"resolve": steps.step_resolve}, "export"
 ).insert_after("resolve", cconv=step_cconv)
 
 

--- a/tests/opt/test_opt.py
+++ b/tests/opt/test_opt.py
@@ -10,7 +10,7 @@ from myia.opt import (
     cse,
     pattern_replacer,
 )
-from myia.pipeline import scalar_pipeline
+from myia.pipeline import scalar_pipeline, steps
 from myia.utils import InferenceError, Merge
 from myia.utils.unify import Var, var
 from myia.validate import ValidationError
@@ -33,7 +33,7 @@ parse = (
             )
         }
     )
-    .select("resources", "parse", "resolve")
+    .select("resources", "parse", {"resolve": steps.step_resolve})
     .make_transformer("input", "graph")
 )
 
@@ -44,7 +44,9 @@ specialize = scalar_pipeline.configure(
             {operations.getitem: prim.tuple_getitem}
         )
     }
-).select("resources", "parse", "resolve", "infer", "specialize")
+).select(
+    "resources", "parse", {"resolve": steps.step_resolve}, "infer", "specialize"
+)
 
 
 # We will optimize patterns of these fake primitives

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -8,8 +8,11 @@ import pytest
 from myia import myia
 from myia.lib import core
 from myia.operations import array_map
+from myia.pipeline import standard_pipeline, steps
 
 from .multitest import eqtest
+
+pipeline2 = standard_pipeline.insert_after("parse", resolve=steps.step_resolve)
 
 
 def test_static_inline_array_map():
@@ -34,7 +37,7 @@ def test_call_opdef():
     with pytest.raises(TypeError):
         f(1, 2)
 
-    @myia
+    @myia(pipeline=pipeline2)
     def g(x, y):
         return f(x, y)
 

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -499,7 +499,6 @@ def _runwith(f, *args):
     return res["output"](*args)
 
 
-@pytest.mark.xfail(reason="Grad not supported on graphs with freevars")
 def test_freevar_outside_grad():
     def f(x, y):
         a = x * x
@@ -513,7 +512,6 @@ def test_freevar_outside_grad():
     assert _runwith(f, 5.0, 8.0) == 25.0
 
 
-@pytest.mark.xfail(reason="Grad not supported on graphs with freevars")
 def test_freegraph_outside_grad():
     def f(x, y):
         def sqx():

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -63,7 +63,6 @@ def grad_wrap(graph, argspec):
 grad_pipeline = PipelineDefinition(
     resources=standard_resources,
     parse=steps.step_parse,
-    resolve=steps.step_resolve,
     infer=steps.step_infer,
     specialize=steps.step_specialize,
     opt=steps.step_debug_opt,

--- a/tests/test_lang.py
+++ b/tests/test_lang.py
@@ -1,12 +1,12 @@
 from pytest import mark
 
-from myia.pipeline import scalar_debug_pipeline
+from myia.pipeline import scalar_debug_pipeline, steps
 
 from .common import Point, mysum
 from .multitest import mt, run, run_debug
 
 lang_pipeline = scalar_debug_pipeline.select(
-    "resources", "parse", "resolve", "export"
+    "resources", "parse", {"resolve": steps.step_resolve}, "export"
 )
 
 

--- a/tests/test_universal.py
+++ b/tests/test_universal.py
@@ -4,11 +4,15 @@ from myia import myia
 from myia.compile.backends import load_backend
 from myia.lib import Empty, HandleInstance, core
 from myia.operations import handle, handle_get, handle_set
+from myia.pipeline import standard_pipeline, steps
 
 try:
     load_backend("relay")
 except Exception:
     pytestmark = pytest.mark.skip("Requires relay")
+
+
+upipeline = standard_pipeline.insert_after("parse", resolve=steps.step_resolve)
 
 
 def add_one(x):
@@ -26,6 +30,7 @@ def test_increment():
         use_universe=True,
         backend="relay",
         backend_options={"exec_kind": "debug"},
+        pipeline=upipeline,
     )
     def plus4(x):
         h = handle(x)
@@ -44,6 +49,7 @@ def test_increment_interleave():
         use_universe=True,
         backend="relay",
         backend_options={"exec_kind": "debug"},
+        pipeline=upipeline,
     )
     def plus2(x, y):
         h1 = handle(x)
@@ -63,6 +69,7 @@ def test_increment_loop():
         use_universe=True,
         backend="relay",
         backend_options={"exec_kind": "debug"},
+        pipeline=upipeline,
     )
     def plus(x, y):
         h = handle(x)
@@ -81,6 +88,7 @@ def test_increment_recursion():
         use_universe=True,
         backend="relay",
         backend_options={"exec_kind": "debug"},
+        pipeline=upipeline,
     )
     def length(h, xs):
         if not isinstance(xs, Empty):
@@ -98,6 +106,7 @@ def test_give_handle():
         use_universe=True,
         backend="relay",
         backend_options={"exec_kind": "debug"},
+        pipeline=upipeline,
     )
     def plus(h, y):
         i = y
@@ -123,6 +132,7 @@ def test_return_handle():
         use_universe=True,
         backend="relay",
         backend_options={"exec_kind": "debug"},
+        pipeline=upipeline,
     )
     def plus2(h):
         increment(h)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,6 +1,13 @@
 import pytest
 
-from myia.abstract import AbstractFunction, VirtualFunction
+from myia.abstract import (
+    SHAPE,
+    TYPE,
+    AbstractArray,
+    AbstractFunction,
+    VirtualFunction,
+)
+from myia.frontends.pytorch_abstract_types import PyTorchTensor
 from myia.operations import partial, primitives as P
 from myia.pipeline import scalar_parse, scalar_pipeline
 from myia.validate import ValidationError, validate, validate_abstract
@@ -132,6 +139,19 @@ def test_validate_abstract():
     fn = AbstractFunction(
         VirtualFunction((), to_abstract_test(i64)),
         VirtualFunction((), to_abstract_test(f64)),
+    )
+    with pytest.raises(ValidationError):
+        validate_abstract(fn, {})
+
+
+def test_validate_abstract_2():
+    fn = AbstractFunction(
+        VirtualFunction(
+            (),
+            AbstractArray(
+                to_abstract_test(f64), {SHAPE: (1, 2), TYPE: PyTorchTensor}
+            ),
+        ),
     )
     with pytest.raises(ValidationError):
         validate_abstract(fn, {})


### PR DESCRIPTION
This splits the single manager used in the pipeline up to now into two managers, `infer_manager` and `opt_manager`, the former for the parse/inference part of the pipeline, the latter for optimization. Monomorphize takes the graphs that are in the `infer_manager` and creates monomorphized versions to handle with `opt_manager`.

This separation makes it possible to reuse the pipeline's managers to perform the gradient expansion, since the graphs added during inference won't interfere with the ones in the `opt_manager`. This, in turn, means that we can reuse cached graphs that are used in multiple grad expansions, like `zeros_like`.

Here is a further list of changes:

* The monomorphizer will no longer change any graphs in place, because of the manager split (the reuse_existing option is removed).
* The monomorphizer can now work incrementally: it can accept new graphs.
* The manager gains a `set_opaque_condition` method. Using this method, the manager can be told to ignore certain nodes. This is used when we need to perform inference on new graphs that refer to graphs that are in `opt_manager`, because we don't want the `infer_manager` to see them.
* The "quarantine" hack in `clone` is no longer necessary and is removed.
* `test_grad::test_free[var/graph]_outside_grad` are no longer xfail.
* There is now a `validator` resource, which can easily be called elsewhere in the pipeline for debugging purposes.
* The `inferrer` resource is split into three resources, `inferrer`, `live_inferrer` and `monomorphizer`, because they don't really need to be together anymore.
* The `resolve` step is removed from the standard inferrer because it is not compatible with the new manager structure, but since some tests require it, it is added to the pipelines for these specific tests that don't perform inference.

**Performance improvements**: not sure on the whole test suite, but on examples/rnn, the time spent in gradient expansion goes down from 4.2s to 3.2s on my machine, and there are similar gains on other tests. The maximal number of nodes in the manager goes down from a peak of 2,500 before these changes to about 1,700, because more graphs can be reused.
