### PR TITLE
Add update_tag option to HyperMap

### DIFF
--- a/myia/abstract/to_abstract.py
+++ b/myia/abstract/to_abstract.py
@@ -15,6 +15,7 @@ from ..utils import (
     HandleInstance,
     MyiaTypeError,
     SymbolicKeyInstance,
+    Tag,
     UniverseInstance,
     dataclass_fields,
     is_dataclass_type,
@@ -310,6 +311,11 @@ def type_to_abstract(self, t: typing._GenericAlias):
         object if isinstance(arg, typing.TypeVar) else arg for arg in t.__args__
     )
     return pytype_to_abstract[t.__origin__](t, args)
+
+
+@overload  # noqa: F811
+def type_to_abstract(self, t: Tag):
+    return ANYTHING
 
 
 @overload  # noqa: F811

--- a/myia/utils/misc.py
+++ b/myia/utils/misc.py
@@ -472,6 +472,39 @@ def assert_scalar(*args):
             raise TypeError(f"Expected scalar, not {type(x)}")
 
 
+class Tag:
+    """A tag for dataclass fields."""
+
+    def __init__(self, name):
+        """Construct a Tag.
+
+        Arguments:
+            name: The name of this tag.
+
+        """
+        self.name = name
+
+    def __repr__(self):
+        """Return the object's name."""
+        return self.name
+
+
+class TagFactory:
+    """A factory for Tags."""
+
+    def __init__(self):
+        """Initialize a TagFactory."""
+        self.cache = {}
+
+    def __getattr__(self, attr):
+        if attr not in self.cache:
+            self.cache[attr] = Tag(attr)
+        return self.cache[attr]
+
+
+tags = TagFactory()
+
+
 __consolidate__ = True
 __all__ = [
     "ClosureNamespace",
@@ -486,6 +519,8 @@ __all__ = [
     "Named",
     "Namespace",
     "Registry",
+    "Tag",
+    "TagFactory",
     "TaggedValue",
     "UNKNOWN",
     "assert_scalar",
@@ -496,4 +531,5 @@ __all__ = [
     "list_str",
     "repr_",
     "resolve_from_path",
+    "tags",
 ]

--- a/tests/utils/test_misc.py
+++ b/tests/utils/test_misc.py
@@ -13,12 +13,18 @@ from myia.utils import (
     SymbolicKeyInstance,
     newenv,
     smap,
+    tags,
 )
 
 
 def test_named():
     named = Named("foo")
     assert repr(named) == "foo"
+
+
+def test_tags():
+    assert tags.Update is tags.Update
+    assert repr(tags.Update) == "Update"
 
 
 @smap.variant


### PR DESCRIPTION
This expands the interface to HyperMap to have a way to only process dataclass fields that are annotated with a specific tag. For example:

```python
from myia.utils import tags

@dataclass
class ConstYPoint:
    x: tags.Update
    y: object

add_update = HyperMap(fn_leaf=scalar_add, update_tag=tags.Update)

assert add_update(ConstYPoint(5, 10), 1) == ConstYPoint(6, 10)
```

Only the field marked with `tags.Update` will be updated. This works recursively and on all dataclasses, but only if the `update_tag` option is given to `HyperMap`.

Note that if you have nested dataclasses, updating fields in the nested dataclass requires tagging both that field and the dataclass with the update tag. In other words, if you want to update `x.y.z`, then both `x.y` and `x.y.z` must be annotated with `tags.Update`. If only `x.y.z` is marked, it won't work.
