### PR TITLE
Improve debugging and profiling of Overload

### DIFF
--- a/myia/abstract/to_abstract.py
+++ b/myia/abstract/to_abstract.py
@@ -92,8 +92,8 @@ def from_value(v, broaden=False, **kwargs):
 ###############
 
 
-@overload.wrapper(bootstrap=True)
-def to_abstract(fn, self, v, **kwargs):
+@overload(bootstrap=True)
+def to_abstract(self, v: AbstractValue, **kwargs):
     """Translate the value to an abstract value.
 
     Arguments:
@@ -107,29 +107,6 @@ def to_abstract(fn, self, v, **kwargs):
             the variables they interact with.
 
     """
-    if fn is not None:
-        rval = fn(self, v, **kwargs)
-
-    elif is_dataclass(v):
-        assert not isinstance(v, Function)
-        new_args = {}
-        for name, value in dataclass_fields(v).items():
-            new_args[name] = self(value, **kwargs)
-        rval = AbstractClass(type(v), new_args)
-
-    elif isinstance(v, type):
-        try:
-            rval = AbstractType(type_to_abstract(v))
-        except KeyError:
-            return AbstractExternal({VALUE: v, TYPE: type(v)})
-    else:
-        rval = AbstractExternal({VALUE: v, TYPE: type(v)})
-
-    return rval
-
-
-@overload  # noqa: F811
-def to_abstract(self, v: AbstractValue, **kwargs):
     return AbstractType(v)
 
 
@@ -239,6 +216,26 @@ def to_abstract(self, v: ADT, **kwargs):
         new_args[name] = self(value, **kwargs)
     draft = AbstractADT(type(v), new_args)
     return normalize_adt(draft)
+
+
+@overload  # noqa: F811
+def to_abstract(self, v: object, **kwargs):
+    if is_dataclass(v):
+        assert not isinstance(v, Function)
+        new_args = {}
+        for name, value in dataclass_fields(v).items():
+            new_args[name] = self(value, **kwargs)
+        return AbstractClass(type(v), new_args)
+    else:
+        return AbstractExternal({VALUE: v, TYPE: type(v)})
+
+
+@overload  # noqa: F811
+def to_abstract(self, v: type, **kwargs):
+    try:
+        rval = AbstractType(type_to_abstract(v))
+    except KeyError:
+        return AbstractExternal({VALUE: v, TYPE: type(v)})
 
 
 ####################

--- a/myia/abstract/to_abstract.py
+++ b/myia/abstract/to_abstract.py
@@ -233,7 +233,7 @@ def to_abstract(self, v: object, **kwargs):
 @overload  # noqa: F811
 def to_abstract(self, v: type, **kwargs):
     try:
-        rval = AbstractType(type_to_abstract(v))
+        return AbstractType(type_to_abstract(v))
     except KeyError:
         return AbstractExternal({VALUE: v, TYPE: type(v)})
 

--- a/myia/abstract/to_abstract.py
+++ b/myia/abstract/to_abstract.py
@@ -234,7 +234,7 @@ def to_abstract(self, v: object, **kwargs):
 def to_abstract(self, v: type, **kwargs):
     try:
         return AbstractType(type_to_abstract(v))
-    except KeyError:
+    except TypeError:
         return AbstractExternal({VALUE: v, TYPE: type(v)})
 
 

--- a/myia/abstract/utils.py
+++ b/myia/abstract/utils.py
@@ -534,19 +534,22 @@ async def force_through(__call__, self, x, through):
         return await call
 
 
-@overload  # noqa: F811
-async def force_through(self, x: AbstractScalar, through):
-    return AbstractScalar(await self(x.values, through))
+# Uncomment and test the other implementations if/when needed:
 
 
-@overload  # noqa: F811
-async def force_through(self, x: AbstractFunction, through):
-    yield (yield AbstractFunction)(*(await self(x.get_sync(), through)))
+# @overload  # noqa: F811
+# async def force_through(self, x: AbstractScalar, through):
+#     return AbstractScalar(await self(x.values, through))
 
 
-@overload  # noqa: F811
-async def force_through(self, d: TrackDict, through):
-    return {k: await self(v, through) for k, v in d.items()}
+# @overload  # noqa: F811
+# async def force_through(self, x: AbstractFunction, through):
+#     yield (yield AbstractFunction)(*(await self(x.get_sync(), through)))
+
+
+# @overload  # noqa: F811
+# async def force_through(self, d: TrackDict, through):
+#     return {k: await self(v, through) for k, v in d.items()}
 
 
 @overload  # noqa: F811
@@ -613,6 +616,11 @@ async def force_through(self, x: TaggedPossibilities, through):
 @overload  # noqa: F811
 async def force_through(self, x: Pending, through):
     return await self(await x, through)
+
+
+@overload  # noqa: F811
+async def force_through(self, x: object, through):
+    raise NotImplementedError(type(x))
 
 
 ################################

--- a/myia/abstract/utils.py
+++ b/myia/abstract/utils.py
@@ -534,22 +534,19 @@ async def force_through(__call__, self, x, through):
         return await call
 
 
-# Uncomment and test the other implementations if/when needed:
+@overload  # noqa: F811
+async def force_through(self, x: AbstractScalar, through):
+    return AbstractScalar(await self(x.values, through))
 
 
-# @overload  # noqa: F811
-# async def force_through(self, x: AbstractScalar, through):
-#     return AbstractScalar(await self(x.values, through))
+@overload  # noqa: F811
+async def force_through(self, x: AbstractFunction, through):
+    yield (yield AbstractFunction)(*(await self(x.get_sync(), through)))
 
 
-# @overload  # noqa: F811
-# async def force_through(self, x: AbstractFunction, through):
-#     yield (yield AbstractFunction)(*(await self(x.get_sync(), through)))
-
-
-# @overload  # noqa: F811
-# async def force_through(self, d: TrackDict, through):
-#     return {k: await self(v, through) for k, v in d.items()}
+@overload  # noqa: F811
+async def force_through(self, d: TrackDict, through):
+    return {k: await self(v, through) for k, v in d.items()}
 
 
 @overload  # noqa: F811

--- a/myia/monomorphize.py
+++ b/myia/monomorphize.py
@@ -90,8 +90,9 @@ def _chk(
     initial_state=lambda: CloneState(cache={}, prop="_fixed", check=_chk)
 )
 def _fix_type(self, a: GraphFunction, finder, monomorphizer):
-    assert a.graph.abstract is None
-    if a.tracking_id in monomorphizer.ctcache:
+    if a.graph.abstract is not None:
+        return self(a.graph.abstract.get_unique(), finder, monomorphizer)
+    elif a.tracking_id in monomorphizer.ctcache:
         ctx = monomorphizer.ctcache[a.tracking_id]
         g = monomorphizer.results[ctx]
         return VirtualFunction(

--- a/myia/monomorphize.py
+++ b/myia/monomorphize.py
@@ -56,7 +56,7 @@ from .ir import (
     succ_incoming,
 )
 from .operations import Primitive
-from .utils import InferenceError, MyiaTypeError, OrderedSet
+from .utils import InferenceError, MyiaTypeError, OrderedSet, overload
 
 
 class Unspecializable(Exception):
@@ -90,9 +90,8 @@ def _chk(
     initial_state=lambda: CloneState(cache={}, prop="_fixed", check=_chk)
 )
 def _fix_type(self, a: GraphFunction, finder, monomorphizer):
-    if a.graph.abstract is not None:
-        return self(a.graph.abstract.get_unique(), finder, monomorphizer)
-    elif a.tracking_id in monomorphizer.ctcache:
+    assert a.graph.abstract is None
+    if a.tracking_id in monomorphizer.ctcache:
         ctx = monomorphizer.ctcache[a.tracking_id]
         g = monomorphizer.results[ctx]
         return VirtualFunction(

--- a/myia/pipeline/resources.py
+++ b/myia/pipeline/resources.py
@@ -71,7 +71,7 @@ def default_convert(env, x: object):
 def default_convert(env, x: type):
     try:
         return type_to_abstract(x)
-    except KeyError:
+    except TypeError:
         return x
 
 

--- a/myia/utils/merge.py
+++ b/myia/utils/merge.py
@@ -102,13 +102,7 @@ def merge(__call__, a, b, mode=MergeMode.mode):
         mode = b.mode
         b = b.value
     assert not isinstance(a, MergeMode)
-    if __call__ is None:
-        if hasattr(a, "__merge__"):
-            return a.__merge__(b, mode)
-        else:
-            return cleanup(b)
-    else:
-        return __call__(a, b, mode)
+    return __call__(a, b, mode)
 
 
 @overload  # noqa: F811
@@ -164,6 +158,14 @@ def merge(xs: set, ys, mode):
         return xs | ys
     else:
         return ys
+
+
+@overload  # noqa: F811
+def merge(a: object, b, mode):
+    if hasattr(a, "__merge__"):
+        return a.__merge__(b, mode)
+    else:
+        return cleanup(b)
 
 
 __consolidate__ = True

--- a/myia/utils/overload.py
+++ b/myia/utils/overload.py
@@ -239,15 +239,12 @@ class Overload:
         try:
             method = self.map[type(main)]
         except KeyError:
-            method = None
+            raise TypeError(
+                f"No overloaded method in {self} for {type(main)}"
+            )
 
         if self._wrapper is None:
-            if method is None:
-                raise TypeError(
-                    f"No overloaded method in {self} for {type(main)}"
-                )
-            else:
-                return method(*args, **kwargs)
+            return method(*args, **kwargs)
         else:
             return self._wrapper(method, *args, **kwargs)
 

--- a/myia/utils/overload.py
+++ b/myia/utils/overload.py
@@ -232,18 +232,6 @@ class Overload:
             ov.register(fn)
             return ov
 
-    def variant_wrapper(self, wrapper=MISSING, *, initial_state=None):
-        """Decorator to create a variant of this Overload with a new wrapper.
-
-        New functions can be registered to the variant without affecting the
-        original.
-        """
-        ov = self.copy(wrapper=None, initial_state=initial_state)
-        if wrapper is MISSING:
-            return ov.wrapper
-        else:
-            return ov.wrapper(wrapper)
-
     def __get__(self, obj, cls):
         return self.ocls(
             map=self.map,
@@ -255,11 +243,8 @@ class Overload:
         )
 
     def __getitem__(self, t):
-        assert not self.bootstrap
-        if self.bind_to:
-            return self.map[t].__get__(self.bind_to)
-        else:
-            return self.map[t]
+        assert not self.bootstrap and self.bind_to is None
+        return self.map[t]
 
     def __call__(self, *args, **kwargs):
         """Compile the overloaded function and then call it."""

--- a/myia/utils/overload.py
+++ b/myia/utils/overload.py
@@ -42,6 +42,8 @@ class TypeMap(dict):
 
         if handler is not None:
             return handler
+        elif hasattr(self, "_key_error"):
+            raise self._key_error(obj_t)
         else:
             raise KeyError(obj_t)
 
@@ -156,6 +158,9 @@ class Overload:
             )
         else:
             cls.__call__ = cls.__real_call__
+        self.map._key_error = lambda key: TypeError(
+            f"No overloaded method in {self} for {key}"
+        )
 
     def wrapper(self, wrapper):
         """Set a wrapper function."""
@@ -292,11 +297,7 @@ class OverloadCall:
             args = (fself,) + args
 
         main = args[self.which]
-
-        try:
-            method = self.map[type(main)]
-        except KeyError:
-            raise TypeError(f"No overloaded method in {self} for {type(main)}")
+        method = self.map[type(main)]
 
         if self.wrapper is None:
             return method(*args, **kwargs)

--- a/myia/utils/overload.py
+++ b/myia/utils/overload.py
@@ -116,6 +116,9 @@ class Overload:
                 assert mixin.which == self.which
             _map.update(mixin._uncached_map)
         self.map = TypeMap(_map)
+        self.map._key_error = lambda key: TypeError(
+            f"No overloaded method in {self} for {key}"
+        )
         self._uncached_map = _map
         self.ocls = _fresh(OverloadCall)
 
@@ -163,7 +166,7 @@ class Overload:
                 )
 
             # Rename the mapped functions
-            self.map = TypeMap(
+            self.map.update(
                 {
                     t: rename_function(fn, f"{name}[{t.__name__}]")
                     for t, fn in self.map.items()
@@ -171,10 +174,6 @@ class Overload:
             )
         else:
             cls.__call__ = cls.__real_call__
-
-        self.map._key_error = lambda key: TypeError(
-            f"No overloaded method in {self} for {key}"
-        )
 
     def wrapper(self, wrapper):
         """Set a wrapper function."""

--- a/myia/utils/overload.py
+++ b/myia/utils/overload.py
@@ -44,7 +44,7 @@ class TypeMap(dict):
             return handler
         elif hasattr(self, "_key_error"):
             raise self._key_error(obj_t)
-        else:
+        else:  # pragma: no cover
             raise KeyError(obj_t)
 
 
@@ -87,11 +87,9 @@ class Overload:
         postprocess=None,
         mixins=[],
         name=None,
-        _parent=None,
     ):
         """Initialize an Overload."""
         self.bind_to = bind_to
-        self._parent = _parent
         self._wrapper = wrapper
         self.state = None
         self.initial_state = initial_state
@@ -100,13 +98,6 @@ class Overload:
             bootstrap or self.initial_state or self.postprocess
         )
         self.name = name
-        if _parent:
-            assert _parent.which is not None
-            self.map = _parent.map
-            self._uncached_map = _parent._uncached_map
-            self.which = _parent.which
-            self._wrapper = _parent._wrapper
-            return
         _map = {}
         self.which = None
         for mixin in mixins:
@@ -185,8 +176,6 @@ class Overload:
 
     def register(self, fn):
         """Register a function."""
-        if self._parent:  # pragma: no cover
-            raise Exception("Cannot register a function on derived Overload")
         ann = fn.__annotations__
         if len(ann) != 1:
             raise Exception("Only one parameter may be annotated.")

--- a/tests/utils/test_overload.py
+++ b/tests/utils/test_overload.py
@@ -159,12 +159,6 @@ def test_Overload_variant_wrapper():
 
     assert g(1) == {2}
 
-    @f.variant_wrapper(initial_state=lambda: 10)
-    def h(fn, self, x):
-        return self.state * x
-
-    assert h(1) == 10
-
 
 def test_Overload_stateful():
 

--- a/tests/utils/test_overload.py
+++ b/tests/utils/test_overload.py
@@ -76,7 +76,7 @@ def test_Overload_mixins():
 
 def test_Overload_bootstrap():
 
-    f = Overload(bind_to=True)
+    f = Overload(bootstrap=True)
 
     @f.register
     def f(self, xs: list):

--- a/tests/utils/test_overload.py
+++ b/tests/utils/test_overload.py
@@ -143,23 +143,6 @@ def test_Overload_wrapper():
     assert f((1, 2, (3, 4))) == [([2], [3], [([4], [5])])]
 
 
-def test_Overload_variant_wrapper():
-
-    f = Overload()
-
-    @f.register
-    def f(x: int):
-        return x + 1
-
-    assert f(1) == 2
-
-    @f.variant_wrapper
-    def g(fn, x):
-        return {fn(x)}
-
-    assert g(1) == {2}
-
-
 def test_Overload_stateful():
 
     f = Overload(initial_state=lambda: -1)


### PR DESCRIPTION
This PR is based on #343

Each Overload now copies and renames all of the functions it needs, which improves debugging and profiling. For example, consider a call to `broaden`. On the left, what the stack trace currently looks like on master, on the right, what it looks like with this PR.

```
n/a               => broaden.entry
Overload.__call__ => broaden.dispatch
abstract_clone    => broaden.wrapper
abstract_clone    => broaden[AbstractTuple]
Overload.__call__ => broaden.dispatch
abstract_clone    => broaden.wrapper
abstract_clone    => broaden[AbstractScalar]
Overload.__call__ => broaden.dispatch
abstract_clone    => broaden.wrapper
broaden           => broaden[Pending]
```

* Each function contains the Overload's name, in this case `broaden`, even for those that are inherited from the parent, in this case `abstract_clone`.
* The type on which the function operates is also included in the name, between square brackets, which is valuable information.
* Source location information is fully preserved, only the name is changed.
* The function `<name>.entry` creates the initial state and does the postprocessing.
* The function `<name>.dispatch` finds the right function to call and calls the wrapper if there is one. It is much simpler than `Overload.__call__` used to be.
* The SVG produced by `--profile-svg` is now much, much cleaner because there is no longer a "super-node" named `Overload.__call__` with 500 arrows coming from and to it, and each Overload has its very own set of nodes.
