### PR TITLE
Add relay implementation to fully support conv2d_transpose in relay backend

### DIFF
--- a/myia/compile/backends/pytorch.py
+++ b/myia/compile/backends/pytorch.py
@@ -381,9 +381,7 @@ def pytorch_conv2d(op):
 def pytorch_conv_transpose2d(op):
     """Implementation of conv_transpose2d."""
 
-    def _impl(
-        input, weight, bias, stride, padding, output_padding, groups, dilation
-    ):
+    def _impl(input, weight, stride, padding, output_padding, groups, dilation):
         stride = tuple(_x.item() for _x in stride)
         padding = tuple(_x.item() for _x in padding)
         output_padding = tuple(_x.item() for _x in output_padding)
@@ -392,7 +390,7 @@ def pytorch_conv_transpose2d(op):
         return torch.conv_transpose2d(
             input,
             weight,
-            bias,
+            None,
             stride,
             padding,
             output_padding,

--- a/myia/compile/backends/relay.py
+++ b/myia/compile/backends/relay.py
@@ -374,13 +374,17 @@ def relay_conv2d_weight_grad(c, data, wsize, dout, stride, pad, dil, groups):
 
 
 def relay_conv_transpose2d(
-    c, input, weight, bias, stride, padding, output_padding, groups, dilation
+    c, input, weight, stride, padding, output_padding, groups, dilation
 ):
+    """Implement conv2d_transpose using 10 relay calls including conv2d.
 
-    if not bias.is_constant(type(None)):
-        raise NotImplementedError(
-            "conv_transpose2d: bias not yet supported " "in relay backend."
-        )
+    Support all values for groups, dilation, strides, padding and
+    output padding.
+    Based on Theano implementation (2020/04/14):
+    https://github.com/Theano/Theano/blob/master/theano/tensor/nnet/abstract_conv.py#L2927
+    Need implementation of operation relay.nn.dilate
+    in TVM relay backend
+    """
 
     assert stride.is_constant(tuple)
     assert padding.is_constant(tuple)
@@ -389,22 +393,72 @@ def relay_conv_transpose2d(
     assert groups.is_constant(int)
 
     data_shape = input.abstract.xshape()
-    weight_shape = weight.abstract.xshape()
-    _, in_channels, _, _ = data_shape
-    _, w_c, filter_h, filter_w = weight_shape
-    _i = c.ref(input)
-    _w = c.ref(weight)
-    return relay.nn.conv2d_transpose(
-        _i,
-        _w,
-        strides=stride.value,
-        padding=padding.value,
-        dilation=dilation.value,
-        groups=groups.value,
-        output_padding=output_padding.value,
-        kernel_size=(filter_h, filter_w),
-        channels=in_channels,
+    kern_shape = weight.abstract.xshape()
+    h_in, w_in = data_shape[2:]
+    filter_h, filter_w = kern_shape[2:]
+    strides = stride.value
+    padding = padding.value
+    dilation = dilation.value
+    output_padding = output_padding.value
+    groups = groups.value
+    data = c.ref(input)
+    weight = c.ref(weight)
+
+    h_out = (
+        (h_in - 1) * strides[0]
+        - 2 * padding[0]
+        + dilation[0] * (filter_h - 1)
+        + output_padding[0]
+        + 1
     )
+    w_out = (
+        (w_in - 1) * strides[1]
+        - 2 * padding[1]
+        + dilation[1] * (filter_w - 1)
+        + output_padding[1]
+        + 1
+    )
+
+    data_dilated = relay.nn.dilate(data, (1, 1) + strides)
+    data_padded = relay.nn.pad(
+        data_dilated,
+        ((0, 0), (0, 0), (0, output_padding[0]), (0, output_padding[1]),),
+    )
+
+    # Pre-process kernel,
+    # from (m0, m1, m2, m3) to (m1 * g, m0 // g, m2, m3).
+    mshp0 = kern_shape[0] // groups
+    c_out = kern_shape[1] * groups
+    kern = relay.reshape(weight, (groups, mshp0) + kern_shape[1:])
+    # => (g, m0 // g, m1, m2, m3)
+    kern = relay.op.transpose(kern, axes=(1, 0, 2, 3, 4))
+    # => (m0 // g, g, m1, m2, m3)
+    kern = relay.reshape(kern, (mshp0, c_out, kern_shape[-2], kern_shape[-1]))
+    # => (m0 // g, m1 * g, m2, m3)
+    kern = relay.op.transpose(kern, (1, 0, 2, 3))
+    # => (m1 * g, m0 // g, m2, m3)
+    # Kernel 2 latest dimensions must be flipped
+    kern = relay.op.transform.reverse(kern, 2)
+    kern = relay.op.transform.reverse(kern, 3)
+    # End pre-processing kernel.
+
+    img = relay.nn.conv2d(
+        data_padded,
+        kern,
+        groups=groups,
+        channels=c_out,
+        padding=[(kern_shape[2 + i] - 1) * dilation[i] for i in range(2)],
+        dilation=dilation,
+    )
+
+    if any(p != 0 for p in padding):
+        img = relay.op.transform.strided_slice(
+            data=img,
+            begin=[0, 0, padding[0], padding[1]],
+            end=[None, None, h_out + padding[0], w_out + padding[1]],
+        )
+
+    return img
 
 
 def relay_concat(c, x, dim):

--- a/myia/compile/backends/relay.py
+++ b/myia/compile/backends/relay.py
@@ -361,7 +361,7 @@ def relay_conv2d_weight_grad(c, data, wsize, dout, stride, pad, dil, groups):
     conv_sh1 = grad_sh0 * grad_sh1 * (in_channel // groups.value)
     d = relay.reshape(
         d,
-        [batch, conv_sh1 // batch, padded_weight_grad_h, padded_weight_grad_w,],
+        [batch, conv_sh1 // batch, padded_weight_grad_h, padded_weight_grad_w],
     )
     d = relay.sum(d, axis=0)
 

--- a/myia/operations/macro_conv2d_grad_input.py
+++ b/myia/operations/macro_conv2d_grad_input.py
@@ -67,7 +67,6 @@ async def conv2d_grad_input(
         P.conv_transpose2d,
         r_grad_output.node,
         r_weight.node,
-        Constant(None),
         r_stride.node,
         r_padding.node,
         Constant(grad_input_padding),

--- a/myia/operations/prim_conv_transpose2d.py
+++ b/myia/operations/prim_conv_transpose2d.py
@@ -18,7 +18,6 @@ async def infer_conv_transpose2d(
     engine,
     input: AbstractArray,
     weight: AbstractArray,
-    bias,  # un-typed, because it may be either None or an abstract array.
     stride: AbstractTuple,
     padding: AbstractTuple,
     output_padding: AbstractTuple,

--- a/myia/public_api.py
+++ b/myia/public_api.py
@@ -312,9 +312,12 @@ def conv_transpose2d(
     dilation=1,
 ):
     """Map of Pytorch method torch.nn.functional.conv_transpose2d."""
-    return P.conv_transpose2d(
-        input, weight, bias, stride, padding, output_padding, groups, dilation
+    ret = P.conv_transpose2d(
+        input, weight, stride, padding, output_padding, groups, dilation
     )
+    if bias is not None:
+        ret = ret + reshape(bias, (1, bias.shape[0], 1, 1))
+    return ret
 
 
 @core

--- a/requirements-cpu.conda
+++ b/requirements-cpu.conda
@@ -2,7 +2,7 @@ python>=3.7,<3.8a0
 colorama
 numpy
 opt_einsum
-abergeron::tvm==0.7dev1+0.*
+abergeron::tvm==0.7dev1+1.*
 pytest
 pytest-cov
 yaml

--- a/requirements-gpu.conda
+++ b/requirements-gpu.conda
@@ -4,7 +4,7 @@ numpy
 opt_einsum
 cudatoolkit=10.0.*
 cudnn
-abergeron::tvm==0.7dev1+0.*
+abergeron::tvm==0.7dev1+1.*
 pytest
 pytest-cov
 yaml

--- a/tests/multitest.py
+++ b/tests/multitest.py
@@ -91,7 +91,7 @@ class MyiaFunctionTest:
         """Configure this test with new kwargs."""
         return MyiaFunctionTest(self.runtest, spec={**self.spec, **spec})
 
-    def check(self, run, args, expected):
+    def check(self, run, args, expected, **kwargs):
         """Check the result of run() against expected.
 
         Expected can be either:
@@ -118,7 +118,7 @@ class MyiaFunctionTest:
                 if not expected(args, res):
                     raise Exception(f"Failed the result check function")
 
-            elif not eqtest(res, expected):
+            elif not eqtest(res, expected, **kwargs):
                 raise Exception(f"Mismatch: expected {expected}, got {res}")
 
     def generate_params(self):


### PR DESCRIPTION
This PR extracts code from #338 and adds supplementary code to fix `conv2d_transpose` in relay backend. It is currently implemented as a full relay graph and seems to correctly support all values for groups, dilations, and other parameters.

This PR needs relay operation `dilate` to be added in TVM backend. I made a PR for that: https://github.com/apache/incubator-tvm/pull/5331

This way to do was more easy than changing all conv2d_transpose implementations in TVM backend. If everything is confirmed and all tests pass, I may work on hardcoding the relay graph implementation directly into TVM backend.

@breuleux @abergeron @fosterrath-mila 