### PR TITLE
Add cancel_tuple_reconstruction optimization

### DIFF
--- a/myia/operations/ops_tuple.py
+++ b/myia/operations/ops_tuple.py
@@ -58,6 +58,7 @@ class TupleReorganizer(MetaGraph):
     def generate_graph(self, args):
         """Generate the graph."""
         g = Graph()
+        g.set_flags("core")
         g.debug.name = self.gen.__name__
         for arg in args:
             g.add_parameter()

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -177,6 +177,18 @@ def bubble_op_tuple_binary(resources, node, equiv):
     return sexp_to_node((P.make_tuple, *elems), node.graph)
 
 
+@pattern_replacer(P.make_tuple, (P.tuple_getitem, X, 0), Xs)
+def cancel_tuple_reconstruction(resources, node, equiv):
+    """Replace (xs[0], xs[1], ..., xs[len(xs) - 1]) by xs."""
+    xs = equiv[X]
+    others = equiv[Xs]
+    if len(others) == len(xs.abstract.elements) - 1 and all(
+        node.match((P.tuple_getitem, xs, i + 1)) is not None
+        for i, node in enumerate(others)
+    ):
+        return xs
+
+
 ###########################
 # gadd optimizations #
 ###########################

--- a/myia/pipeline/steps.py
+++ b/myia/pipeline/steps.py
@@ -312,6 +312,7 @@ step_opt = Optimizer.partial(
             optlib.getitem_setitem_tuple,
             optlib.setitem_tuple,
             optlib.setitem_tuple_ct,
+            optlib.cancel_tuple_reconstruction,
             optlib.elim_j_jinv,
             optlib.elim_jinv_j,
             optlib.replace_Jinv_on_graph,


### PR DESCRIPTION
This adds an optimization to simplify code like this:

```python
xs = [a, b, c]
ys = [xs[0], xs[1], xs[2]]
```

In the above example, `cancel_tuple_reconstruction` would make ys to point to xs directly. This pattern can be found in the universe examples.

Some adjustments were needed in the backend so that it does not have to assume that the return value of the root graph, when the universe feature is active, is the explicit construction of a tuple.
