### PR TITLE
Add AbstractFunctionUnique to replace AbstractFunction after monomorphization

### DIFF
--- a/debug/gprint.py
+++ b/debug/gprint.py
@@ -1460,8 +1460,8 @@ class _JTransformedFunction:
         )
 
 
-@mixin(abstract.VirtualFunction2)
-class _VirtualFunction2:
+@mixin(abstract.AbstractFunctionUnique)
+class _AbstractFunctionUnique:
     def __hrepr__(self, H, hrepr):
         return hrepr.stdrepr_object(
             "★Function2",

--- a/debug/gprint.py
+++ b/debug/gprint.py
@@ -1452,11 +1452,14 @@ class _PrimitiveFunction:
         )
 
 
-@mixin(abstract.JTransformedFunction)
-class _JTransformedFunction:
+@mixin(abstract.TransformedFunction)
+class _TransformedFunction:
     def __hrepr__(self, H, hrepr):
         return hrepr.stdrepr_object(
-            "JTransformedFunction", (("fn", self.fn),), delimiter="↦",
+            "TransformedFunction",
+            (("fn", self.fn),),
+            (("transform", self.transform),),
+            delimiter="↦",
         )
 
 

--- a/debug/gprint.py
+++ b/debug/gprint.py
@@ -1457,8 +1457,7 @@ class _TransformedFunction:
     def __hrepr__(self, H, hrepr):
         return hrepr.stdrepr_object(
             "TransformedFunction",
-            (("fn", self.fn),
-             ("transform", self.transform)),
+            (("fn", self.fn), ("transform", self.transform)),
             delimiter="↦",
         )
 

--- a/debug/gprint.py
+++ b/debug/gprint.py
@@ -1468,3 +1468,13 @@ class _VirtualFunction:
             (("args", self.args), ("output", self.output)),
             delimiter="↦",
         )
+
+
+@mixin(abstract.VirtualFunction2)
+class _VirtualFunction2:
+    def __hrepr__(self, H, hrepr):
+        return hrepr.stdrepr_object(
+            "★Function2",
+            (("args", self.args), ("output", self.output)),
+            delimiter="↦",
+        )

--- a/debug/gprint.py
+++ b/debug/gprint.py
@@ -1457,8 +1457,8 @@ class _TransformedFunction:
     def __hrepr__(self, H, hrepr):
         return hrepr.stdrepr_object(
             "TransformedFunction",
-            (("fn", self.fn),),
-            (("transform", self.transform),),
+            (("fn", self.fn),
+             ("transform", self.transform)),
             delimiter="↦",
         )
 

--- a/debug/gprint.py
+++ b/debug/gprint.py
@@ -1460,16 +1460,6 @@ class _JTransformedFunction:
         )
 
 
-@mixin(abstract.VirtualFunction)
-class _VirtualFunction:
-    def __hrepr__(self, H, hrepr):
-        return hrepr.stdrepr_object(
-            "VirtualFunction",
-            (("args", self.args), ("output", self.output)),
-            delimiter="↦",
-        )
-
-
 @mixin(abstract.VirtualFunction2)
 class _VirtualFunction2:
     def __hrepr__(self, H, hrepr):

--- a/myia/abstract/amerge.py
+++ b/myia/abstract/amerge.py
@@ -14,6 +14,7 @@ from .data import (
     AbstractDict,
     AbstractError,
     AbstractFunction,
+    AbstractFunctionBase,
     AbstractScalar,
     AbstractTaggedUnion,
     AbstractTuple,
@@ -220,33 +221,6 @@ def amerge(
 
 @overload  # noqa: F811
 def amerge(self, x1: Possibilities, x2, forced, bp):
-    eng = amerge_engine.get()
-    poss = x1 + x2
-    # if all(isinstance(x, VirtualFunction) for x in poss):
-    #     assert not forced
-    #     return Possibilities(
-    #         [
-    #             VirtualFunction(
-    #                 reduce(self, [x.args for x in poss]),
-    #                 reduce(self, [x.output for x in poss]),
-    #             )
-    #         ]
-    #     )
-
-    for standard in poss:
-        # TODO: This is a hack of sorts until we replace Possibilities
-        # inside AbstractFunction by AbstractUnion, and AbsFunc only has
-        # one function inside it.
-        if isinstance(standard, VirtualFunction):
-            for entry in poss:
-                if not isinstance(entry, VirtualFunction):
-                    eng.loop.schedule(
-                        eng.infer_function(
-                            entry, standard.args, standard.output
-                        )
-                    )
-            break
-
     if set(x1).issuperset(set(x2)):
         return x1
     if forced:
@@ -357,32 +331,50 @@ def amerge(self, x1: AbstractError, x2, forced, bp):
 
 
 @overload  # noqa: F811
-def amerge(self, x1: AbstractFunction, x2, forced, bp):
-    x1poss = x1.get_sync()
-    if isinstance(x2, VirtualFunction2):
-        x2poss = Possibilities([VirtualFunction(x2.args, x2.output)])
-    elif isinstance(x2, AbstractFunction):
-        x2poss = x2.get_sync()
+def amerge(self, x1: AbstractFunctionBase, x2, forced, bp):
+    if not isinstance(x2, AbstractFunctionBase):
+        raise MyiaTypeError(f"Expected function, but got {x2}")
+
+    elif isinstance(x1, AbstractFunction) and isinstance(x2, AbstractFunction):
+        values = self(x1.get_sync(), x2.get_sync(), forced, bp)
+        if forced or values is x1.values:
+            return x1
+        return AbstractFunction(*values)
+
+    elif isinstance(x1, VirtualFunction2) and isinstance(x2, VirtualFunction2):
+        args1 = (x1.args, x1.output, x1.values)
+        args2 = (x2.args, x2.output, x2.values)
+        merged = self(args1, args2, forced, bp)
+        if forced or merged is args1:
+            return x1
+        return VirtualFunction2(*merged)
+
     else:
-        raise MyiaTypeError(f"Expected a function, not {x2}")
-    values = self(x1poss, x2poss, forced, bp)
-    if forced or values is x1.values:
-        return x1
-    if len(values) == 1:
-        vfn, = values
-        if isinstance(vfn, VirtualFunction):
-            return VirtualFunction2(vfn.args, vfn.output)
-    return AbstractFunction(*values)
+        if isinstance(x1, VirtualFunction2):
+            assert isinstance(x2, AbstractFunction)
+            vfn = x1
+            poss = x2.get_sync()
 
+        else:
+            assert isinstance(x2, VirtualFunction2)
+            assert isinstance(x1, AbstractFunction)
+            vfn = x2
+            poss = x1.get_sync()
 
-@overload  # noqa: F811
-def amerge(self, x1: VirtualFunction2, x2, forced, bp):
-    args1 = (x1.args, x1.output, x1.values)
-    args2 = (x2.args, x2.output, x2.values)
-    merged = self(args1, args2, forced, bp)
-    if forced or merged is args1:
-        return x1
-    return VirtualFunction2(*merged)
+        if poss is ANYTHING:
+            return x1 if forced else vfn
+
+        assert not forced
+        eng = amerge_engine.get()
+
+        for entry in poss:
+            eng.loop.schedule(
+                eng.infer_function(
+                    entry, vfn.args, vfn.output
+                )
+            )
+
+        return vfn
 
 
 @overload  # noqa: F811

--- a/myia/abstract/amerge.py
+++ b/myia/abstract/amerge.py
@@ -15,6 +15,7 @@ from .data import (
     AbstractError,
     AbstractFunction,
     AbstractFunctionBase,
+    AbstractFunctionUnique,
     AbstractScalar,
     AbstractTaggedUnion,
     AbstractTuple,
@@ -23,7 +24,6 @@ from .data import (
     Possibilities,
     TaggedPossibilities,
     TrackDict,
-    VirtualFunction2,
 )
 from .loop import (
     Pending,
@@ -202,7 +202,7 @@ def amerge(
                 raise TypeMismatchError(x1, x2)
             return x2
         elif type(x1) is not type(x2) and not isinstance(
-            x1, (int, float, bool, AbstractFunction, VirtualFunction2)
+            x1, (int, float, bool, AbstractFunctionBase)
         ):
             raise MyiaTypeError(
                 f"Type mismatch: {type(x1)} != {type(x2)}; {x1} != {x2}"
@@ -340,23 +340,25 @@ def amerge(self, x1: AbstractFunctionBase, x2, forced, bp):
             return x1
         return AbstractFunction(*values)
 
-    elif isinstance(x1, VirtualFunction2) and isinstance(x2, VirtualFunction2):
+    elif isinstance(x1, AbstractFunctionUnique) and isinstance(
+        x2, AbstractFunctionUnique
+    ):
         args1 = (x1.args, x1.output, x1.values)
         args2 = (x2.args, x2.output, x2.values)
         merged = self(args1, args2, forced, bp)
         if forced or merged is args1:
             return x1
-        return VirtualFunction2(*merged)
+        return AbstractFunctionUnique(*merged)
 
     else:
-        if isinstance(x1, VirtualFunction2):
+        if isinstance(x1, AbstractFunctionUnique):
             with untested_legacy():
                 assert isinstance(x2, AbstractFunction)
                 vfn = x1
                 poss = x2.get_sync()
 
         else:
-            assert isinstance(x2, VirtualFunction2)
+            assert isinstance(x2, AbstractFunctionUnique)
             assert isinstance(x1, AbstractFunction)
             vfn = x2
             poss = x1.get_sync()

--- a/myia/abstract/amerge.py
+++ b/myia/abstract/amerge.py
@@ -368,11 +368,7 @@ def amerge(self, x1: AbstractFunctionBase, x2, forced, bp):
         eng = amerge_engine.get()
 
         for entry in poss:
-            eng.loop.schedule(
-                eng.infer_function(
-                    entry, vfn.args, vfn.output
-                )
-            )
+            eng.loop.schedule(eng.infer_function(entry, vfn.args, vfn.output))
 
         return vfn
 

--- a/myia/abstract/amerge.py
+++ b/myia/abstract/amerge.py
@@ -5,7 +5,7 @@ from functools import reduce
 from itertools import chain
 
 from .. import xtype
-from ..utils import MyiaTypeError, TypeMismatchError, overload
+from ..utils import MyiaTypeError, TypeMismatchError, overload, untested_legacy
 from .data import (
     ABSENT,
     ANYTHING,
@@ -350,9 +350,10 @@ def amerge(self, x1: AbstractFunctionBase, x2, forced, bp):
 
     else:
         if isinstance(x1, VirtualFunction2):
-            assert isinstance(x2, AbstractFunction)
-            vfn = x1
-            poss = x2.get_sync()
+            with untested_legacy():
+                assert isinstance(x2, AbstractFunction)
+                vfn = x1
+                poss = x2.get_sync()
 
         else:
             assert isinstance(x2, VirtualFunction2)
@@ -363,7 +364,7 @@ def amerge(self, x1: AbstractFunctionBase, x2, forced, bp):
         if poss is ANYTHING:
             return x1 if forced else vfn
 
-        assert not forced
+        assert vfn is x1 or not forced
         eng = amerge_engine.get()
 
         for entry in poss:

--- a/myia/abstract/amerge.py
+++ b/myia/abstract/amerge.py
@@ -23,7 +23,6 @@ from .data import (
     Possibilities,
     TaggedPossibilities,
     TrackDict,
-    VirtualFunction,
     VirtualFunction2,
 )
 from .loop import (

--- a/myia/abstract/amerge.py
+++ b/myia/abstract/amerge.py
@@ -222,16 +222,16 @@ def amerge(
 def amerge(self, x1: Possibilities, x2, forced, bp):
     eng = amerge_engine.get()
     poss = x1 + x2
-    if all(isinstance(x, VirtualFunction) for x in poss):
-        assert not forced
-        return Possibilities(
-            [
-                VirtualFunction(
-                    reduce(self, [x.args for x in poss]),
-                    reduce(self, [x.output for x in poss]),
-                )
-            ]
-        )
+    # if all(isinstance(x, VirtualFunction) for x in poss):
+    #     assert not forced
+    #     return Possibilities(
+    #         [
+    #             VirtualFunction(
+    #                 reduce(self, [x.args for x in poss]),
+    #                 reduce(self, [x.output for x in poss]),
+    #             )
+    #         ]
+    #     )
 
     for standard in poss:
         # TODO: This is a hack of sorts until we replace Possibilities

--- a/myia/abstract/data.py
+++ b/myia/abstract/data.py
@@ -38,8 +38,6 @@ VOID = Named("VOID")
 # Represents specialization problems
 DEAD = Named("DEAD")
 register_serialize(DEAD, "DEAD")
-DUMMY = Named("DUMMY")
-register_serialize(DUMMY, "DUMMY")
 POLY = Named("POLY")
 
 
@@ -1001,7 +999,6 @@ __all__ = [
     "ANYTHING",
     "DATA",
     "DEAD",
-    "DUMMY",
     "POLY",
     "SHAPE",
     "TYPE",

--- a/myia/abstract/data.py
+++ b/myia/abstract/data.py
@@ -194,29 +194,6 @@ class JTransformedFunction(Function):
     fn: object
 
 
-@serializable("VirtualFunction")
-class VirtualFunction(Function, Interned, PossiblyRecursive):
-    """Represents some function with an explicitly given type signature.
-
-    Attributes:
-        args: The abstract arguments given to the function
-        output: The abstract output
-
-    """
-
-    args: List["AbstractValue"]
-    output: "AbstractValue"
-
-    def __init__(self, args, output):
-        """Initialize a VirtualFunction."""
-        self.args = list(args)
-        self.output = output
-        self._incomplete = False
-
-    def __eqkey__(self):
-        return AttrEK(self, ["args", "output"])
-
-
 @serializable("TypedPrimitive")
 @dataclass(frozen=True)
 class TypedPrimitive(Function):
@@ -1068,7 +1045,6 @@ __all__ = [
     "Track",
     "TrackDict",
     "TypedPrimitive",
-    "VirtualFunction",
     "VirtualFunction2",
     "empty",
     "format_abstract",

--- a/myia/abstract/data.py
+++ b/myia/abstract/data.py
@@ -409,8 +409,8 @@ class AbstractFunction(AbstractFunctionBase):
         return pretty_join(fns, sep=" | ")
 
 
-@serializable("VirtualFunction2")
-class VirtualFunction2(AbstractFunctionBase):
+@serializable("AbstractFunctionUnique")
+class AbstractFunctionUnique(AbstractFunctionBase):
     def __init__(self, args, output, values={}):
         super().__init__(values)
         self.args = list(args)
@@ -1039,7 +1039,7 @@ __all__ = [
     "Track",
     "TrackDict",
     "TypedPrimitive",
-    "VirtualFunction2",
+    "AbstractFunctionUnique",
     "empty",
     "format_abstract",
     "i64tup_typecheck",

--- a/myia/abstract/data.py
+++ b/myia/abstract/data.py
@@ -183,15 +183,17 @@ class PartialApplication(Function):
 
 
 @dataclass(frozen=True)
-class JTransformedFunction(Function):
-    """Represents a Function transformed through the application of J.
+class TransformedFunction(Function):
+    """Represents a Function processed through some transform.
 
     Attributes:
         fn: A Function
+        transform: The applied transform
 
     """
 
     fn: object
+    transform: object
 
 
 @serializable("TypedPrimitive")
@@ -1029,7 +1031,6 @@ __all__ = [
     "AbstractValue",
     "Function",
     "GraphFunction",
-    "JTransformedFunction",
     "MacroFunction",
     "MetaGraphFunction",
     "PartialApplication",
@@ -1038,6 +1039,7 @@ __all__ = [
     "TaggedPossibilities",
     "Track",
     "TrackDict",
+    "TransformedFunction",
     "TypedPrimitive",
     "AbstractFunctionUnique",
     "empty",

--- a/myia/abstract/data.py
+++ b/myia/abstract/data.py
@@ -46,7 +46,6 @@ POLY = Named("POLY")
 #####################
 
 
-@serializable("Possibilities", sequence=True)
 class Possibilities(list):
     """Represents a set of possible values.
 

--- a/myia/abstract/data.py
+++ b/myia/abstract/data.py
@@ -65,15 +65,6 @@ class Possibilities(list):
         # list is different.
         super().__init__(OrderedSet(options))
 
-    def _serialize(self):
-        return self
-
-    @classmethod
-    def _construct(cls):
-        p = Possibilities([])
-        data = yield p
-        p[:] = data
-
     def __hash__(self):
         return hash(tuple(self))
 
@@ -224,17 +215,6 @@ class VirtualFunction(Function, Interned, PossiblyRecursive):
 
     def __eqkey__(self):
         return AttrEK(self, ["args", "output"])
-
-    def _serialize(self):
-        return {"args": self.args, "output": self.output}
-
-    @classmethod
-    def _construct(cls):
-        obj = cls.empty()
-        data = yield obj
-        obj.args = data["args"]
-        obj.output = data["output"]
-        obj._incomplete = False
 
 
 @serializable("TypedPrimitive")

--- a/myia/abstract/data.py
+++ b/myia/abstract/data.py
@@ -211,11 +211,6 @@ class TypedPrimitive(Function):
     output: "AbstractValue"
 
 
-@dataclass(frozen=True)
-class DummyFunction(Function):
-    """Represents a function that can't be called."""
-
-
 #################
 # Abstract data #
 #################
@@ -1032,7 +1027,6 @@ __all__ = [
     "AbstractType",
     "AbstractUnion",
     "AbstractValue",
-    "DummyFunction",
     "Function",
     "GraphFunction",
     "JTransformedFunction",

--- a/myia/abstract/data.py
+++ b/myia/abstract/data.py
@@ -327,6 +327,13 @@ class AbstractExternal(AbstractAtom):
 class AbstractFunctionBase(AbstractAtom):
     """Base for function types."""
 
+    def get_prim(self):
+        """If this AbstractFunction represents a a Primitive, return it.
+
+        Otherwise, return None.
+        """
+        return None
+
 
 @serializable("AbstractFunction")
 class AbstractFunction(AbstractFunctionBase):
@@ -411,7 +418,18 @@ class AbstractFunction(AbstractFunctionBase):
 
 @serializable("AbstractFunctionUnique")
 class AbstractFunctionUnique(AbstractFunctionBase):
+    """Represents some function with an explicitly given type signature.
+
+    Unlike AbstractFunction, this represents the type of a single function
+    rather than a set of possible functions.
+
+    Attributes:
+        args: The abstract arguments given to the function
+        output: The abstract output
+    """
+
     def __init__(self, args, output, values={}):
+        """Initialize the AbstractFunctionUnique."""
         super().__init__(values)
         self.args = list(args)
         self.output = output
@@ -440,9 +458,6 @@ class AbstractFunctionUnique(AbstractFunctionBase):
 
     def __pretty__(self, ctx):
         return pretty_call(ctx, "Fn", (self.args, self.output))
-
-    def get_prim(self):
-        return None
 
 
 @serializable("AbstractRandomState")

--- a/myia/abstract/data.py
+++ b/myia/abstract/data.py
@@ -352,8 +352,12 @@ class AbstractExternal(AbstractAtom):
         return rval
 
 
+class AbstractFunctionBase(AbstractAtom):
+    """Base for function types."""
+
+
 @serializable("AbstractFunction")
-class AbstractFunction(AbstractAtom):
+class AbstractFunction(AbstractFunctionBase):
     """Represents a function or set of functions.
 
     The VALUE track for an AbstractFunction contains a Possibilities object
@@ -433,12 +437,8 @@ class AbstractFunction(AbstractAtom):
         return pretty_join(fns, sep=" | ")
 
 
-class AbstractStructure(AbstractValue):
-    """Base class for abstract values that are structures."""
-
-
 @serializable("VirtualFunction2")
-class VirtualFunction2(AbstractStructure):
+class VirtualFunction2(AbstractFunctionBase):
     def __init__(self, args, output, values={}):
         super().__init__(values)
         self.args = list(args)
@@ -462,10 +462,6 @@ class VirtualFunction2(AbstractStructure):
         except StopIteration:
             pass
 
-    def children(self):
-        """Return all elements in the tuple."""
-        return [*self.args, self.output]
-
     def __eqkey__(self):
         v = AbstractValue.__eqkey__(self)
         return AttrEK(self, (v, "args", "output"))
@@ -484,6 +480,10 @@ class AbstractRandomState(AbstractAtom):
     def __init__(self):
         """Initialize an AbstractRandomState."""
         super().__init__({})
+
+
+class AbstractStructure(AbstractValue):
+    """Base class for abstract values that are structures."""
 
 
 class AbstractWrapper(AbstractStructure):
@@ -1043,6 +1043,7 @@ __all__ = [
     "AbstractError",
     "AbstractExternal",
     "AbstractFunction",
+    "AbstractFunctionBase",
     "AbstractHandle",
     "AbstractJTagged",
     "AbstractKeywordArgument",

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -774,11 +774,10 @@ class JInferrer(Inferrer):
         self.orig_fn = orig_fn
 
     async def _jtag(self, x):
+        assert not isinstance(x, VirtualFunction2)
         if isinstance(x, AbstractFunction):
             v = await x.get()
             return AbstractFunction(*[JTransformedFunction(poss) for poss in v])
-        elif isinstance(x, VirtualFunction2):
-            assert False
         return AbstractJTagged(x)
 
     async def run(self, engine, outref, argrefs):

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -23,15 +23,16 @@ from ..utils import (
 from .amerge import amerge, bind
 from .data import (
     ANYTHING,
+    DUMMY,
     TYPE,
     VALUE,
+    AbstractError,
     AbstractFunction,
     AbstractJTagged,
     AbstractKeywordArgument,
     AbstractScalar,
     AbstractTuple,
     AbstractValue,
-    DummyFunction,
     Function,
     GraphFunction,
     JTransformedFunction,
@@ -740,7 +741,7 @@ async def compute_jinv_type(x):
                     # point to the transformed nodes of the
                     # parent. This is fixable, and will need
                     # to be fixed to support a few edge cases.
-                    res = DummyFunction()
+                    res = AbstractError(DUMMY)
                 else:
                     with untested_legacy():
                         # Not sure why this never happens anymore

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -23,7 +23,6 @@ from ..utils import (
 from .amerge import amerge, bind
 from .data import (
     ANYTHING,
-    DUMMY,
     TYPE,
     VALUE,
     AbstractError,

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -710,7 +710,7 @@ class VirtualInferrer(Inferrer):
         return self.output
 
 
-def compute_bprop_type(orig_fn, args, out, vfn2=True):
+def compute_bprop_type(orig_fn, args, out):
     """Compute the abstract type of the bprop for orig_fn."""
     fn = AbstractFunction(orig_fn)
     bparams = [sensitivity_transform(fn)]

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -18,14 +18,12 @@ from ..utils import (
     infer_trace,
     tracer,
     type_error_nargs,
-    untested_legacy,
 )
 from .amerge import amerge, bind
 from .data import (
     ANYTHING,
     TYPE,
     VALUE,
-    AbstractError,
     AbstractFunction,
     AbstractFunctionUnique,
     AbstractJTagged,
@@ -38,7 +36,6 @@ from .data import (
     MacroFunction,
     MetaGraphFunction,
     PartialApplication,
-    Primitive,
     PrimitiveFunction,
     TransformedFunction,
     TypedPrimitive,

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -41,7 +41,6 @@ from .data import (
     Primitive,
     PrimitiveFunction,
     TypedPrimitive,
-    VirtualFunction,
     VirtualFunction2,
 )
 from .loop import InferenceLoop, Pending, force_pending
@@ -266,7 +265,7 @@ class InferenceEngine:
         return JInferrer(self.get_inferrer_for(j.fn), j.fn)
 
     @get_inferrer_for.register
-    def get_inferrer_for(self, vf: (VirtualFunction, TypedPrimitive, VirtualFunction2)):
+    def get_inferrer_for(self, vf: (TypedPrimitive, VirtualFunction2)):
         return VirtualInferrer(vf.args, vf.output)
 
     @get_inferrer_for.register

--- a/myia/abstract/utils.py
+++ b/myia/abstract/utils.py
@@ -29,11 +29,11 @@ from .data import (
     AbstractValue,
     AbstractWrapper,
     GraphFunction,
-    JTransformedFunction,
     PartialApplication,
     Possibilities,
     TaggedPossibilities,
     TrackDict,
+    TransformedFunction,
 )
 from .loop import Pending
 from .ref import Context, Reference
@@ -213,7 +213,7 @@ def abstract_check(self, t: PartialApplication, *args):
 
 
 @overload  # noqa: F811
-def abstract_check(self, t: JTransformedFunction, *args):
+def abstract_check(self, t: TransformedFunction, *args):
     return self(t.fn, *args)
 
 
@@ -378,8 +378,8 @@ def abstract_clone(self, x: PartialApplication, *args):
 
 
 @overload  # noqa: F811
-def abstract_clone(self, x: JTransformedFunction, *args):
-    return JTransformedFunction(self(x.fn, *args))
+def abstract_clone(self, x: TransformedFunction, *args):
+    return TransformedFunction(self(x.fn, *args), x.transform)
 
 
 @overload  # noqa: F811

--- a/myia/abstract/utils.py
+++ b/myia/abstract/utils.py
@@ -180,7 +180,11 @@ def abstract_check(self, x: AbstractFunction, *args):
 
 @overload  # noqa: F811
 def abstract_check(self, x: VirtualFunction2, *args):
-    return self(x.values, *args) and all(self(v, *args) for v in x.args) and self(x.output, *args)
+    return (
+        self(x.values, *args)
+        and all(self(v, *args) for v in x.args)
+        and self(x.output, *args)
+    )
 
 
 @overload  # noqa: F811

--- a/myia/abstract/utils.py
+++ b/myia/abstract/utils.py
@@ -34,6 +34,7 @@ from .data import (
     TaggedPossibilities,
     TrackDict,
     VirtualFunction,
+    VirtualFunction2,
 )
 from .loop import Pending
 from .ref import Context, Reference
@@ -386,6 +387,13 @@ def abstract_clone(self, x: VirtualFunction, *args):
 
 
 @overload  # noqa: F811
+def abstract_clone(self, x: VirtualFunction2, *args):
+    return (yield VirtualFunction2)(
+        [self(arg, *args) for arg in x.args], self(x.output, *args)
+    )
+
+
+@overload  # noqa: F811
 def abstract_clone(self, x: Pending, *args):
     if x.done():
         return self(x.result(), *args)
@@ -489,7 +497,7 @@ def broaden(self, d: TrackDict, *args):  # noqa: D417
 
 
 @abstract_clone.variant
-def sensitivity_transform(self, x: AbstractFunction):
+def sensitivity_transform(self, x: (AbstractFunction, VirtualFunction2)):
     """Return an abstract value for the sensitivity of x.
 
     * The sensitivity of a function is an Env

--- a/myia/abstract/utils.py
+++ b/myia/abstract/utils.py
@@ -33,7 +33,6 @@ from .data import (
     Possibilities,
     TaggedPossibilities,
     TrackDict,
-    VirtualFunction,
     VirtualFunction2,
 )
 from .loop import Pending
@@ -204,11 +203,6 @@ def abstract_check(self, x: TaggedPossibilities, *args):
     return all(self(v, *args) for _, v in x)
 
 
-# @overload  # noqa: F811
-# def abstract_check(self, t: VirtualFunction, *args):
-#     return all(self(v, *args) for v in t.args) and self(t.output, *args)
-
-
 @overload  # noqa: F811
 def abstract_check(self, t: PartialApplication, *args):
     return self(t.fn, *args) and all(self(v, *args) for v in t.args)
@@ -258,7 +252,7 @@ def abstract_clone(__call__, self, x, *args):
     """Clone an abstract value."""
 
     def proceed():
-        if isinstance(x, (AbstractValue, VirtualFunction)) and x in cache:
+        if isinstance(x, AbstractValue) and x in cache:
             return cache[x]
         result = __call__(self, x, *args)
         if not isinstance(result, GeneratorType):
@@ -382,13 +376,6 @@ def abstract_clone(self, x: PartialApplication, *args):
 @overload  # noqa: F811
 def abstract_clone(self, x: JTransformedFunction, *args):
     return JTransformedFunction(self(x.fn, *args))
-
-
-@overload  # noqa: F811
-def abstract_clone(self, x: VirtualFunction, *args):
-    return (yield VirtualFunction)(
-        [self(arg, *args) for arg in x.args], self(x.output, *args)
-    )
 
 
 @overload  # noqa: F811

--- a/myia/abstract/utils.py
+++ b/myia/abstract/utils.py
@@ -17,6 +17,7 @@ from .data import (
     AbstractClassBase,
     AbstractDict,
     AbstractFunction,
+    AbstractFunctionUnique,
     AbstractJTagged,
     AbstractKeywordArgument,
     AbstractScalar,
@@ -33,7 +34,6 @@ from .data import (
     Possibilities,
     TaggedPossibilities,
     TrackDict,
-    VirtualFunction2,
 )
 from .loop import Pending
 from .ref import Context, Reference
@@ -179,7 +179,7 @@ def abstract_check(self, x: AbstractFunction, *args):
 
 
 @overload  # noqa: F811
-def abstract_check(self, x: VirtualFunction2, *args):
+def abstract_check(self, x: AbstractFunctionUnique, *args):
     return (
         self(x.values, *args)
         and all(self(v, *args) for v in x.args)
@@ -383,8 +383,8 @@ def abstract_clone(self, x: JTransformedFunction, *args):
 
 
 @overload  # noqa: F811
-def abstract_clone(self, x: VirtualFunction2, *args):
-    return (yield VirtualFunction2)(
+def abstract_clone(self, x: AbstractFunctionUnique, *args):
+    return (yield AbstractFunctionUnique)(
         [self(arg, *args) for arg in x.args], self(x.output, *args)
     )
 
@@ -493,7 +493,7 @@ def broaden(self, d: TrackDict, *args):  # noqa: D417
 
 
 @abstract_clone.variant
-def sensitivity_transform(self, x: (AbstractFunction, VirtualFunction2)):
+def sensitivity_transform(self, x: (AbstractFunction, AbstractFunctionUnique)):
     """Return an abstract value for the sensitivity of x.
 
     * The sensitivity of a function is an Env

--- a/myia/abstract/utils.py
+++ b/myia/abstract/utils.py
@@ -199,9 +199,9 @@ def abstract_check(self, x: TaggedPossibilities, *args):
     return all(self(v, *args) for _, v in x)
 
 
-@overload  # noqa: F811
-def abstract_check(self, t: VirtualFunction, *args):
-    return all(self(v, *args) for v in t.args) and self(t.output, *args)
+# @overload  # noqa: F811
+# def abstract_check(self, t: VirtualFunction, *args):
+#     return all(self(v, *args) for v in t.args) and self(t.output, *args)
 
 
 @overload  # noqa: F811

--- a/myia/abstract/utils.py
+++ b/myia/abstract/utils.py
@@ -180,6 +180,11 @@ def abstract_check(self, x: AbstractFunction, *args):
 
 
 @overload  # noqa: F811
+def abstract_check(self, x: VirtualFunction2, *args):
+    return self(x.values, *args) and all(self(v, *args) for v in x.args) and self(x.output, *args)
+
+
+@overload  # noqa: F811
 def abstract_check(self, x: AbstractUnion, *args):
     return self(x.options, *args)
 

--- a/myia/compile/backends/relay_helpers.py
+++ b/myia/compile/backends/relay_helpers.py
@@ -20,6 +20,7 @@ from ...abstract import (
     AbstractType,
     TypedPrimitive,
     VirtualFunction,
+    VirtualFunction2,
 )
 from ...operations import primitives as P
 from ...utils import overload
@@ -198,7 +199,7 @@ def to_relay_type(self, a: AbstractFunction):
 
 
 @overload  # noqa: F811
-def to_relay_type(self, a: (VirtualFunction, TypedPrimitive)):
+def to_relay_type(self, a: (VirtualFunction, VirtualFunction2, TypedPrimitive)):
     return relay.ty.FuncType([self(aa) for aa in a.args], self(a.output))
 
 

--- a/myia/compile/backends/relay_helpers.py
+++ b/myia/compile/backends/relay_helpers.py
@@ -11,6 +11,7 @@ from tvm.runtime.object import Object
 from ...abstract import (
     AbstractArray,
     AbstractError,
+    AbstractFunctionUnique,
     AbstractHandle,
     AbstractRandomState,
     AbstractScalar,
@@ -18,7 +19,6 @@ from ...abstract import (
     AbstractTuple,
     AbstractType,
     TypedPrimitive,
-    VirtualFunction2,
 )
 from ...operations import primitives as P
 from ...utils import overload
@@ -190,7 +190,7 @@ def to_relay_type(self, a: AbstractArray):
 
 
 @overload  # noqa: F811
-def to_relay_type(self, a: (VirtualFunction2, TypedPrimitive)):
+def to_relay_type(self, a: (AbstractFunctionUnique, TypedPrimitive)):
     return relay.ty.FuncType([self(aa) for aa in a.args], self(a.output))
 
 

--- a/myia/compile/backends/relay_helpers.py
+++ b/myia/compile/backends/relay_helpers.py
@@ -191,11 +191,11 @@ def to_relay_type(self, a: AbstractArray):
     return relay.ty.TensorType(a.xshape(), type_to_np_dtype(tp))
 
 
-@overload  # noqa: F811
-def to_relay_type(self, a: AbstractFunction):
-    sings = list(self(sing) for sing in a.get_sync())
-    assert len(sings) == 1
-    return sings[0]
+# @overload  # noqa: F811
+# def to_relay_type(self, a: AbstractFunction):
+#     sings = list(self(sing) for sing in a.get_sync())
+#     assert len(sings) == 1
+#     return sings[0]
 
 
 @overload  # noqa: F811

--- a/myia/compile/backends/relay_helpers.py
+++ b/myia/compile/backends/relay_helpers.py
@@ -11,7 +11,6 @@ from tvm.runtime.object import Object
 from ...abstract import (
     AbstractArray,
     AbstractError,
-    AbstractFunction,
     AbstractHandle,
     AbstractRandomState,
     AbstractScalar,
@@ -19,7 +18,6 @@ from ...abstract import (
     AbstractTuple,
     AbstractType,
     TypedPrimitive,
-    VirtualFunction,
     VirtualFunction2,
 )
 from ...operations import primitives as P
@@ -191,15 +189,8 @@ def to_relay_type(self, a: AbstractArray):
     return relay.ty.TensorType(a.xshape(), type_to_np_dtype(tp))
 
 
-# @overload  # noqa: F811
-# def to_relay_type(self, a: AbstractFunction):
-#     sings = list(self(sing) for sing in a.get_sync())
-#     assert len(sings) == 1
-#     return sings[0]
-
-
 @overload  # noqa: F811
-def to_relay_type(self, a: (VirtualFunction, VirtualFunction2, TypedPrimitive)):
+def to_relay_type(self, a: (VirtualFunction2, TypedPrimitive)):
     return relay.ty.FuncType([self(aa) for aa in a.args], self(a.output))
 
 

--- a/myia/compile/transform.py
+++ b/myia/compile/transform.py
@@ -42,15 +42,14 @@ def get_prim_graph(cache, prim, typ):
     if (prim, typ) not in cache:
         g = Graph()
         args = []
-        tp = list(typ.xvalue())[0]
-        for t in tp.args:
+        for t in typ.args:
             p = g.add_parameter()
             p.abstract = t
             args.append(p)
         primct = Constant(prim)
         primct.abstract = typ
         out = g.apply(primct, *args)
-        out.abstract = tp.output
+        out.abstract = typ.output
         g.output = out
         cache[(prim, typ)] = g
     return cache[(prim, typ)]

--- a/myia/ir/anf.py
+++ b/myia/ir/anf.py
@@ -95,16 +95,15 @@ class Graph:
     @property
     def abstract(self):
         """Return the graph's type based on parameter/output types."""
-        from ..abstract import VirtualFunction, AbstractFunction
+        from ..abstract import VirtualFunction2
 
         if any(p.abstract is None for p in self.parameters):
             return None
         if self.return_.abstract is None:
             return None
-        vf = VirtualFunction(
+        return VirtualFunction2(
             tuple(p.abstract for p in self.parameters), self.return_.abstract
         )
-        return AbstractFunction(vf)
 
     @property
     def output(self) -> "ANFNode":

--- a/myia/ir/anf.py
+++ b/myia/ir/anf.py
@@ -95,13 +95,13 @@ class Graph:
     @property
     def abstract(self):
         """Return the graph's type based on parameter/output types."""
-        from ..abstract import VirtualFunction2
+        from ..abstract import AbstractFunctionUnique
 
         if any(p.abstract is None for p in self.parameters):
             return None
         if self.return_.abstract is None:
             return None
-        return VirtualFunction2(
+        return AbstractFunctionUnique(
             tuple(p.abstract for p in self.parameters), self.return_.abstract
         )
 

--- a/myia/monomorphize.py
+++ b/myia/monomorphize.py
@@ -118,7 +118,7 @@ def _fix_type(self, a: PartialApplication, finder, monomorphizer):
 
 
 @overload  # noqa: F811
-def _fix_type(self, a: VirtualFunction, finder, monomorphizer):
+def _fix_type(self, a: (VirtualFunction, VirtualFunction2), finder, monomorphizer):
     return (yield VirtualFunction2)(
         tuple(self(arg, finder, monomorphizer) for arg in a.args),
         self(a.output, finder, monomorphizer),
@@ -145,7 +145,7 @@ def _fix_type(self, a: JTransformedFunction, finder, monomorphizer):
     vfn = self(a.fn, finder, monomorphizer)
     jargs = tuple(_jtag(arg) for arg in vfn.args)
     jres = _jtag(vfn.output)
-    bprop = compute_bprop_type(vfn, vfn.args, vfn.output, vfn2=True)
+    bprop = compute_bprop_type(vfn, vfn.args, vfn.output)
     out = AbstractTuple([jres, bprop])
     return VirtualFunction2(jargs, out)
 

--- a/myia/monomorphize.py
+++ b/myia/monomorphize.py
@@ -32,7 +32,6 @@ from .abstract import (
     Reference,
     TrackedInferrer,
     TypedPrimitive,
-    VirtualFunction,
     VirtualFunction2,
     VirtualReference,
     abstract_check,
@@ -118,7 +117,7 @@ def _fix_type(self, a: PartialApplication, finder, monomorphizer):
 
 
 @overload  # noqa: F811
-def _fix_type(self, a: (VirtualFunction, VirtualFunction2), finder, monomorphizer):
+def _fix_type(self, a: VirtualFunction2, finder, monomorphizer):
     return (yield VirtualFunction2)(
         tuple(self(arg, finder, monomorphizer) for arg in a.args),
         self(a.output, finder, monomorphizer),
@@ -523,9 +522,7 @@ class Monomorphizer:
                 else:
                     ctabs = ref.node.abstract
 
-                if ctabs is None or not (isinstance(ctabs, VirtualFunction2) or isinstance(
-                    ctabs.get_unique(), VirtualFunction
-                )):
+                if ctabs is None or not isinstance(ctabs, VirtualFunction2):
                     fn = a.get_unique()
                     with About(ref.node.debug, "equiv"):
                         try:

--- a/myia/monomorphize.py
+++ b/myia/monomorphize.py
@@ -110,6 +110,8 @@ def _fix_type(self, a: GraphFunction, finder, monomorphizer):
 @overload  # noqa: F811
 def _fix_type(self, a: PartialApplication, finder, monomorphizer):
     vfn = self(a.fn, finder, monomorphizer)
+    if isinstance(vfn, AbstractError) and vfn.xvalue() is DUMMY:
+        return vfn
     assert isinstance(vfn, VirtualFunction2)
     vfn = VirtualFunction2(vfn.args[len(a.args) :], vfn.output)
     return vfn

--- a/myia/monomorphize.py
+++ b/myia/monomorphize.py
@@ -25,12 +25,12 @@ from .abstract import (
     Context,
     GraphFunction,
     GraphInferrer,
-    JTransformedFunction,
     MetaGraphFunction,
     PartialApplication,
     PrimitiveFunction,
     Reference,
     TrackedInferrer,
+    TransformedFunction,
     TypedPrimitive,
     VirtualReference,
     abstract_check,
@@ -55,7 +55,7 @@ from .ir import (
     MetaGraph,
     succ_incoming,
 )
-from .operations import Primitive
+from .operations import Primitive, primitives as P
 from .utils import InferenceError, MyiaTypeError, OrderedSet, overload
 
 
@@ -75,7 +75,7 @@ def _chk(
     a: (
         GraphFunction,
         PartialApplication,
-        JTransformedFunction,
+        TransformedFunction,
         PrimitiveFunction,
         MetaGraphFunction,
         TypedPrimitive,
@@ -123,15 +123,16 @@ def _fix_type(self, a: AbstractFunctionUnique, finder, monomorphizer):
 
 
 @overload  # noqa: F811
-def _fix_type(self, a: JTransformedFunction, finder, monomorphizer):
+def _fix_type(self, a: TransformedFunction, finder, monomorphizer):
     def _jtag(x):
         assert not isinstance(x, AbstractFunction)
         if isinstance(x, AbstractFunctionUnique):
-            return self(JTransformedFunction(x), finder, monomorphizer)
+            return self(TransformedFunction(x, P.J), finder, monomorphizer)
         else:
             rval = AbstractJTagged(self(x, finder, monomorphizer))
         return rval
 
+    assert a.transform is P.J
     vfn = self(a.fn, finder, monomorphizer)
     jargs = tuple(_jtag(arg) for arg in vfn.args)
     jres = _jtag(vfn.output)

--- a/myia/monomorphize.py
+++ b/myia/monomorphize.py
@@ -13,7 +13,6 @@ from warnings import warn
 
 from .abstract import (
     DEAD,
-    DUMMY,
     POLY,
     AbstractError,
     AbstractFunction,
@@ -101,13 +100,13 @@ def _fix_type(self, a: GraphFunction, finder, monomorphizer):
             self(g.return_.abstract, finder, monomorphizer),
         )
     else:
-        return AbstractError(DUMMY)
+        return AbstractError(DEAD)
 
 
 @overload  # noqa: F811
 def _fix_type(self, a: PartialApplication, finder, monomorphizer):
     vfn = self(a.fn, finder, monomorphizer)
-    if isinstance(vfn, AbstractError) and vfn.xvalue() is DUMMY:
+    if isinstance(vfn, AbstractError) and vfn.xvalue() is DEAD:
         return vfn
     assert isinstance(vfn, AbstractFunctionUnique)
     vfn = AbstractFunctionUnique(vfn.args[len(a.args) :], vfn.output)
@@ -162,8 +161,8 @@ def _fix_type(self, a: PrimitiveFunction, finder, monomorphizer):
         return self(
             finder.analyze_function(None, a, None)[0], finder, monomorphizer
         )
-    except Unspecializable:
-        return AbstractError(DUMMY)
+    except Unspecializable as err:
+        return AbstractError(err.problem)
 
 
 @overload  # noqa: F811

--- a/myia/monomorphize.py
+++ b/myia/monomorphize.py
@@ -125,15 +125,8 @@ def _fix_type(self, a: VirtualFunction2, finder, monomorphizer):
 @overload  # noqa: F811
 def _fix_type(self, a: JTransformedFunction, finder, monomorphizer):
     def _jtag(x):
-        if isinstance(x, AbstractFunction):
-            v = x.get_sync()
-            rval = AbstractFunction(
-                *[
-                    self(JTransformedFunction(poss), finder, monomorphizer)
-                    for poss in v
-                ]
-            )
-        elif isinstance(x, VirtualFunction2):
+        assert not isinstance(x, AbstractFunction)
+        if isinstance(x, VirtualFunction2):
             return self(JTransformedFunction(x), finder, monomorphizer)
         else:
             rval = AbstractJTagged(self(x, finder, monomorphizer))

--- a/myia/monomorphize.py
+++ b/myia/monomorphize.py
@@ -22,7 +22,6 @@ from .abstract import (
     CheckState,
     CloneState,
     Context,
-    DummyFunction,
     GraphFunction,
     GraphInferrer,
     JTransformedFunction,
@@ -102,7 +101,6 @@ def _fix_type(self, a: GraphFunction, finder, monomorphizer):
             self(g.return_.abstract, finder, monomorphizer),
         )
     else:
-        # return DummyFunction()
         return AbstractError(DUMMY)
 
 
@@ -155,7 +153,7 @@ def _fix_type(self, a: AbstractFunction, finder, monomorphizer):
     if len(vfns) == 1:
         (vfn,) = vfns
     else:
-        vfns = [v for v in vfns if not isinstance(v, (DummyFunction, AbstractError))]
+        vfns = [v for v in vfns if not isinstance(v, AbstractError)]
         assert vfns and all(isinstance(v, VirtualFunction2) for v in vfns)
         vfn = VirtualFunction2(
             reduce(amerge, [v.args for v in vfns]),
@@ -171,7 +169,6 @@ def _fix_type(self, a: PrimitiveFunction, finder, monomorphizer):
             finder.analyze_function(None, a, None)[0], finder, monomorphizer
         )
     except Unspecializable:
-        # return DummyFunction()
         return AbstractError(DUMMY)
 
 

--- a/myia/operations/prim_J.py
+++ b/myia/operations/prim_J.py
@@ -19,16 +19,16 @@ async def infer_J(self, engine, x):
     """Infer the return type of primitive `J`."""
     if isinstance(x, AbstractFunction):
         v = await x.get()
-        if len(v) == 1:
-            # If applied to a VirtualFunction (after infer/monomorphize)
-            # we return another VirtualFunction
-            (vfn,) = v
-            if isinstance(vfn, VirtualFunction):
-                vfn = type_fixer(None)(JTransformedFunction(vfn))
-                return AbstractFunction(vfn)
+        # if len(v) == 1:
+        #     # If applied to a VirtualFunction (after infer/monomorphize)
+        #     # we return another VirtualFunction
+        #     (vfn,) = v
+        #     if isinstance(vfn, VirtualFunction):
+        #         vfn = type_fixer(None)(JTransformedFunction(vfn))
+        #         return AbstractFunction(vfn)
         return AbstractFunction(*[JTransformedFunction(poss) for poss in v])
     elif isinstance(x, VirtualFunction2):
-        vfn = type_fixer(None)(JTransformedFunction(VirtualFunction(
+        vfn = type_fixer(None)(JTransformedFunction(VirtualFunction2(
             x.args, x.output
         )))
         assert isinstance(vfn, VirtualFunction2)

--- a/myia/operations/prim_J.py
+++ b/myia/operations/prim_J.py
@@ -5,6 +5,7 @@ from ..lib import (
     AbstractJTagged,
     JTransformedFunction,
     VirtualFunction,
+    VirtualFunction2,
     bprop_to_grad_transform,
     standard_prim,
 )
@@ -26,7 +27,14 @@ async def infer_J(self, engine, x):
                 vfn = type_fixer(None)(JTransformedFunction(vfn))
                 return AbstractFunction(vfn)
         return AbstractFunction(*[JTransformedFunction(poss) for poss in v])
-    return AbstractJTagged(x)
+    elif isinstance(x, VirtualFunction2):
+        vfn = type_fixer(None)(JTransformedFunction(VirtualFunction(
+            x.args, x.output
+        )))
+        assert isinstance(vfn, VirtualFunction2)
+        return vfn
+    else:
+        return AbstractJTagged(x)
 
 
 @bprop_to_grad_transform(P.J)

--- a/myia/operations/prim_J.py
+++ b/myia/operations/prim_J.py
@@ -4,7 +4,7 @@ from ..lib import (
     AbstractFunction,
     AbstractFunctionUnique,
     AbstractJTagged,
-    JTransformedFunction,
+    TransformedFunction,
     bprop_to_grad_transform,
     standard_prim,
 )
@@ -18,10 +18,10 @@ async def infer_J(self, engine, x):
     """Infer the return type of primitive `J`."""
     if isinstance(x, AbstractFunction):
         v = await x.get()
-        return AbstractFunction(*[JTransformedFunction(poss) for poss in v])
+        return AbstractFunction(*[TransformedFunction(poss, P.J) for poss in v])
     elif isinstance(x, AbstractFunctionUnique):
         vfn = type_fixer(None)(
-            JTransformedFunction(AbstractFunctionUnique(x.args, x.output))
+            TransformedFunction(AbstractFunctionUnique(x.args, x.output), P.J)
         )
         assert isinstance(vfn, AbstractFunctionUnique)
         return vfn

--- a/myia/operations/prim_J.py
+++ b/myia/operations/prim_J.py
@@ -20,9 +20,9 @@ async def infer_J(self, engine, x):
         v = await x.get()
         return AbstractFunction(*[JTransformedFunction(poss) for poss in v])
     elif isinstance(x, VirtualFunction2):
-        vfn = type_fixer(None)(JTransformedFunction(VirtualFunction2(
-            x.args, x.output
-        )))
+        vfn = type_fixer(None)(
+            JTransformedFunction(VirtualFunction2(x.args, x.output))
+        )
         assert isinstance(vfn, VirtualFunction2)
         return vfn
     else:

--- a/myia/operations/prim_J.py
+++ b/myia/operations/prim_J.py
@@ -4,7 +4,6 @@ from ..lib import (
     AbstractFunction,
     AbstractJTagged,
     JTransformedFunction,
-    VirtualFunction,
     VirtualFunction2,
     bprop_to_grad_transform,
     standard_prim,
@@ -19,13 +18,6 @@ async def infer_J(self, engine, x):
     """Infer the return type of primitive `J`."""
     if isinstance(x, AbstractFunction):
         v = await x.get()
-        # if len(v) == 1:
-        #     # If applied to a VirtualFunction (after infer/monomorphize)
-        #     # we return another VirtualFunction
-        #     (vfn,) = v
-        #     if isinstance(vfn, VirtualFunction):
-        #         vfn = type_fixer(None)(JTransformedFunction(vfn))
-        #         return AbstractFunction(vfn)
         return AbstractFunction(*[JTransformedFunction(poss) for poss in v])
     elif isinstance(x, VirtualFunction2):
         vfn = type_fixer(None)(JTransformedFunction(VirtualFunction2(

--- a/myia/operations/prim_J.py
+++ b/myia/operations/prim_J.py
@@ -2,9 +2,9 @@
 
 from ..lib import (
     AbstractFunction,
+    AbstractFunctionUnique,
     AbstractJTagged,
     JTransformedFunction,
-    VirtualFunction2,
     bprop_to_grad_transform,
     standard_prim,
 )
@@ -19,11 +19,11 @@ async def infer_J(self, engine, x):
     if isinstance(x, AbstractFunction):
         v = await x.get()
         return AbstractFunction(*[JTransformedFunction(poss) for poss in v])
-    elif isinstance(x, VirtualFunction2):
+    elif isinstance(x, AbstractFunctionUnique):
         vfn = type_fixer(None)(
-            JTransformedFunction(VirtualFunction2(x.args, x.output))
+            JTransformedFunction(AbstractFunctionUnique(x.args, x.output))
         )
-        assert isinstance(vfn, VirtualFunction2)
+        assert isinstance(vfn, AbstractFunctionUnique)
         return vfn
     else:
         return AbstractJTagged(x)

--- a/myia/operations/prim_array_map.py
+++ b/myia/operations/prim_array_map.py
@@ -10,6 +10,7 @@ from ..lib import (
     TYPE,
     AbstractArray,
     AbstractFunction,
+    VirtualFunction2,
     Graph,
     MetaGraph,
     MyiaShapeError,
@@ -35,12 +36,15 @@ def debugvm_array_map(vm, fn, *arrays):
 
 
 @standard_prim(P.array_map)
-async def infer_array_map(self, engine, fn: AbstractFunction, *arrays):
+async def infer_array_map(self, engine, fn, *arrays):
     """Infer the return type of primitive `array_map`."""
     if len(arrays) < 1:
         raise MyiaTypeError("array_map requires at least one array")
     for arr in arrays:
         await engine.check_immediate(AbstractArray, arr)
+
+    if not isinstance(fn, (AbstractFunction, VirtualFunction2)):
+        raise MyiaTypeError("Expected function for array_map")
 
     subargs = [a.element for a in arrays]
     result = await engine.execute(fn, *subargs)

--- a/myia/operations/prim_array_map.py
+++ b/myia/operations/prim_array_map.py
@@ -9,7 +9,7 @@ from ..lib import (
     SHAPE,
     TYPE,
     AbstractArray,
-    AbstractFunction,
+    AbstractFunctionBase,
     VirtualFunction2,
     Graph,
     MetaGraph,
@@ -36,15 +36,12 @@ def debugvm_array_map(vm, fn, *arrays):
 
 
 @standard_prim(P.array_map)
-async def infer_array_map(self, engine, fn, *arrays):
+async def infer_array_map(self, engine, fn: AbstractFunctionBase, *arrays):
     """Infer the return type of primitive `array_map`."""
     if len(arrays) < 1:
         raise MyiaTypeError("array_map requires at least one array")
     for arr in arrays:
         await engine.check_immediate(AbstractArray, arr)
-
-    if not isinstance(fn, (AbstractFunction, VirtualFunction2)):
-        raise MyiaTypeError("Expected function for array_map")
 
     subargs = [a.element for a in arrays]
     result = await engine.execute(fn, *subargs)

--- a/myia/operations/prim_array_map.py
+++ b/myia/operations/prim_array_map.py
@@ -10,7 +10,6 @@ from ..lib import (
     TYPE,
     AbstractArray,
     AbstractFunctionBase,
-    VirtualFunction2,
     Graph,
     MetaGraph,
     MyiaShapeError,

--- a/myia/operations/prim_array_reduce.py
+++ b/myia/operations/prim_array_reduce.py
@@ -10,6 +10,7 @@ from ..lib import (
     AbstractFunction,
     MetaGraph,
     MyiaShapeError,
+    VirtualFunction2,
     bprop_to_grad_transform,
     build_value,
     force_pending,
@@ -68,9 +69,12 @@ def debugvm_array_reduce(vm, fn, array, shp):
 
 @standard_prim(P.array_reduce)
 async def infer_array_reduce(
-    self, engine, fn: AbstractFunction, a: AbstractArray, shp: u64tup_typecheck
+    self, engine, fn, a: AbstractArray, shp: u64tup_typecheck
 ):
     """Infer the return type of primitive `array_reduce`."""
+    if not isinstance(fn, (AbstractFunction, VirtualFunction2)):
+        raise MyiaTypeError("Expected function for array_map")
+
     shp_i = await force_pending(a.xshape())
     shp_v = build_value(shp, default=ANYTHING)
     if shp_v == ANYTHING:

--- a/myia/operations/prim_array_reduce.py
+++ b/myia/operations/prim_array_reduce.py
@@ -7,7 +7,7 @@ from ..lib import (
     SHAPE,
     TYPE,
     AbstractArray,
-    AbstractFunction,
+    AbstractFunctionBase,
     MetaGraph,
     MyiaShapeError,
     VirtualFunction2,
@@ -69,12 +69,9 @@ def debugvm_array_reduce(vm, fn, array, shp):
 
 @standard_prim(P.array_reduce)
 async def infer_array_reduce(
-    self, engine, fn, a: AbstractArray, shp: u64tup_typecheck
+    self, engine, fn: AbstractFunctionBase, a: AbstractArray, shp: u64tup_typecheck
 ):
     """Infer the return type of primitive `array_reduce`."""
-    if not isinstance(fn, (AbstractFunction, VirtualFunction2)):
-        raise MyiaTypeError("Expected function for array_map")
-
     shp_i = await force_pending(a.xshape())
     shp_v = build_value(shp, default=ANYTHING)
     if shp_v == ANYTHING:

--- a/myia/operations/prim_array_reduce.py
+++ b/myia/operations/prim_array_reduce.py
@@ -10,7 +10,6 @@ from ..lib import (
     AbstractFunctionBase,
     MetaGraph,
     MyiaShapeError,
-    VirtualFunction2,
     bprop_to_grad_transform,
     build_value,
     force_pending,

--- a/myia/operations/prim_array_reduce.py
+++ b/myia/operations/prim_array_reduce.py
@@ -68,7 +68,11 @@ def debugvm_array_reduce(vm, fn, array, shp):
 
 @standard_prim(P.array_reduce)
 async def infer_array_reduce(
-    self, engine, fn: AbstractFunctionBase, a: AbstractArray, shp: u64tup_typecheck
+    self,
+    engine,
+    fn: AbstractFunctionBase,
+    a: AbstractArray,
+    shp: u64tup_typecheck,
 ):
     """Infer the return type of primitive `array_reduce`."""
     shp_i = await force_pending(a.xshape())

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -8,6 +8,7 @@ from ..abstract import (
     CheckState,
     CloneState,
     VirtualFunction,
+    VirtualFunction2,
     abstract_check,
     abstract_clone,
     build_value,
@@ -900,7 +901,7 @@ def specialize_on_graph_arguments(resources, node, equiv):
 def _set_out_abstract(g, a):
     g.output.abstract = a
     g.return_.abstract = a
-    g.return_.inputs[0].abstract = AbstractFunction(VirtualFunction([a], a))
+    g.return_.inputs[0].abstract = VirtualFunction2([a], a)
 
 
 @GraphTransform
@@ -1019,7 +1020,7 @@ def call_output_transform(orig_graph, abstracts):
         p.abstract = a
         newp.append(p)
     graph.output = graph.apply(graph.output, *newp)
-    _set_out_abstract(graph, orig_graph.return_.abstract.get_unique().output)
+    _set_out_abstract(graph, orig_graph.return_.abstract.output)
     return graph
 
 
@@ -1121,7 +1122,7 @@ def expand_J(resources, node, equiv):
     except NotImplementedError:
         return None
 
-    vfn = node.abstract.get_unique()
+    vfn = node.abstract
     newg = resources.incorporate(newg, vfn.args, vfn.output)
 
     if isinstance(arg, Graph):
@@ -1147,7 +1148,7 @@ def _jelim_retype(self, j: AbstractJTagged):
 
 
 @abstract_check.variant(initial_state=lambda: CheckState({}, "_nofunc"))
-def _jelim_nofunc(self, f: AbstractFunction):
+def _jelim_nofunc(self, f: (AbstractFunction, VirtualFunction2)):
     return False
 
 

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -7,7 +7,6 @@ from ..abstract import (
     AbstractJTagged,
     CheckState,
     CloneState,
-    VirtualFunction,
     VirtualFunction2,
     abstract_check,
     abstract_clone,

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -4,10 +4,10 @@ from .. import operations
 from ..abstract import (
     DEAD,
     AbstractFunction,
+    AbstractFunctionUnique,
     AbstractJTagged,
     CheckState,
     CloneState,
-    VirtualFunction2,
     abstract_check,
     abstract_clone,
     build_value,
@@ -900,7 +900,7 @@ def specialize_on_graph_arguments(resources, node, equiv):
 def _set_out_abstract(g, a):
     g.output.abstract = a
     g.return_.abstract = a
-    g.return_.inputs[0].abstract = VirtualFunction2([a], a)
+    g.return_.inputs[0].abstract = AbstractFunctionUnique([a], a)
 
 
 @GraphTransform
@@ -1147,7 +1147,7 @@ def _jelim_retype(self, j: AbstractJTagged):
 
 
 @abstract_check.variant(initial_state=lambda: CheckState({}, "_nofunc"))
-def _jelim_nofunc(self, f: (AbstractFunction, VirtualFunction2)):
+def _jelim_nofunc(self, f: (AbstractFunction, AbstractFunctionUnique)):
     return False
 
 

--- a/myia/pipeline/steps.py
+++ b/myia/pipeline/steps.py
@@ -484,7 +484,7 @@ def step_wrap(
     fn = output
     orig_arg_t = argspec if orig_argspec is None else orig_argspec
     orig_out_t = outspec if orig_outspec is None else orig_outspec
-    vm_arg_t = graph.abstract.get_sync()[0].args
+    vm_arg_t = graph.abstract.args
     vm_out_t = graph.return_.abstract
     if resources.universal:
         vm_unv_in_t, vm_arg_t = vm_arg_t[0], vm_arg_t[1:]

--- a/myia/simplify_types.py
+++ b/myia/simplify_types.py
@@ -23,6 +23,7 @@ from .abstract import (
     AbstractType,
     AbstractUnion,
     AbstractValue,
+    VirtualFunction2,
     abstract_clone,
     empty,
     from_value,
@@ -259,7 +260,7 @@ def simplify_types(root, manager):
             node.is_constant()
             and node.abstract
             and not isinstance(
-                node.abstract, (AbstractFunction, AbstractExternal)
+                node.abstract, (VirtualFunction2, AbstractFunction, AbstractExternal)
             )
         ):
             node.value = to_canonical(node.value, node.abstract, coerce=True)

--- a/myia/simplify_types.py
+++ b/myia/simplify_types.py
@@ -260,7 +260,8 @@ def simplify_types(root, manager):
             node.is_constant()
             and node.abstract
             and not isinstance(
-                node.abstract, (VirtualFunction2, AbstractFunction, AbstractExternal)
+                node.abstract,
+                (VirtualFunction2, AbstractFunction, AbstractExternal),
             )
         ):
             node.value = to_canonical(node.value, node.abstract, coerce=True)

--- a/myia/simplify_types.py
+++ b/myia/simplify_types.py
@@ -13,7 +13,7 @@ from .abstract import (
     AbstractDict,
     AbstractError,
     AbstractExternal,
-    AbstractFunction,
+    AbstractFunctionBase,
     AbstractHandle,
     AbstractKeywordArgument,
     AbstractRandomState,
@@ -23,7 +23,6 @@ from .abstract import (
     AbstractType,
     AbstractUnion,
     AbstractValue,
-    VirtualFunction2,
     abstract_clone,
     empty,
     from_value,
@@ -260,8 +259,7 @@ def simplify_types(root, manager):
             node.is_constant()
             and node.abstract
             and not isinstance(
-                node.abstract,
-                (VirtualFunction2, AbstractFunction, AbstractExternal),
+                node.abstract, (AbstractFunctionBase, AbstractExternal),
             )
         ):
             node.value = to_canonical(node.value, node.abstract, coerce=True)

--- a/myia/validate.py
+++ b/myia/validate.py
@@ -16,8 +16,6 @@ from .abstract import (
     AbstractJTagged,
     AbstractScalar,
     AbstractType,
-    DummyFunction,
-    VirtualFunction,
     abstract_check,
 )
 from .operations import Primitive
@@ -167,7 +165,7 @@ class CallValidator(NodeValidator):  # pragma: no cover
                     raise ValidationError(f"None in call")
                 else:
                     return
-            vfn = fn.abstract.get_unique()
+            vfn = fn.abstract
             argv = [broaden(arg) for arg in vfn.args]
             argt = [broaden(arg.abstract) for arg in args]
             if argv != argt:

--- a/myia/validate.py
+++ b/myia/validate.py
@@ -6,6 +6,7 @@ from . import xtype
 from .abstract import (
     ANYTHING,
     DEAD,
+    DUMMY,
     POLY,
     AbstractArray,
     AbstractClass,
@@ -41,14 +42,16 @@ def validate_abstract(self, a: (AbstractClass, AbstractJTagged), uses):
 
 @overload  # noqa: F811
 def validate_abstract(self, a: AbstractError, uses):
-    with untested_legacy():
-        kind = a.xvalue()
-        if kind is DEAD:
-            return True
-        elif kind is POLY:
+    kind = a.xvalue()
+    if kind is DEAD or kind is DUMMY:
+        return True
+    elif kind is POLY:
+        with untested_legacy():
             return not any(key == 0 for node, key in uses)
-        else:
-            raise ValidationError(f"Illegal type in the graph: {a}", type=a)
+    else:  # pragma: no cover
+        # As it turns out, the inferrer now catches this error before we get to
+        # validation.
+        raise ValidationError(f"Illegal type in the graph: {a}", type=a)
 
 
 @overload  # noqa: F811

--- a/myia/validate.py
+++ b/myia/validate.py
@@ -19,7 +19,7 @@ from .abstract import (
 )
 from .operations import Primitive
 from .operations.primitives import BackendPrimitive
-from .utils import ErrorPool, Partializable, overload, untested_legacy
+from .utils import ErrorPool, Partializable, overload
 
 
 class ValidationError(Exception):

--- a/myia/validate.py
+++ b/myia/validate.py
@@ -6,7 +6,6 @@ from . import xtype
 from .abstract import (
     ANYTHING,
     DEAD,
-    DUMMY,
     POLY,
     AbstractArray,
     AbstractClass,
@@ -41,16 +40,14 @@ def validate_abstract(self, a: (AbstractClass, AbstractJTagged), uses):
 @overload  # noqa: F811
 def validate_abstract(self, a: AbstractError, uses):
     kind = a.xvalue()
-    if kind is DEAD or kind is DUMMY:
+    if kind is DEAD:
         return True
-    else:
-        with untested_legacy():
-            if kind is POLY:
-                return not any(key == 0 for node, key in uses)
-            else:  # pragma: no cover
-                # As it turns out, the inferrer now catches this error before we get to
-                # validation.
-                raise ValidationError(f"Illegal type in the graph: {a}", type=a)
+    elif kind is POLY:
+        return not any(key == 0 for node, key in uses)
+    else:  # pragma: no cover
+        # As it turns out, the inferrer now catches this error before we get to
+        # validation.
+        raise ValidationError(f"Illegal type in the graph: {a}", type=a)
 
 
 @overload  # noqa: F811

--- a/myia/validate.py
+++ b/myia/validate.py
@@ -92,15 +92,7 @@ def validate_abstract(self, a: AbstractType, uses):
 
 @overload  # noqa: F811
 def validate_abstract(self, a: AbstractFunction, uses):
-    fns = a.get_sync()
-    if len(fns) != 1:
-        raise ValidationError(f"Only one function type should be here: {a}")
-    (fn,) = fns
-    if not isinstance(fn, (VirtualFunction, DummyFunction)):
-        raise ValidationError(
-            f"All function types should be VirtualFunction, not {fn}"
-        )
-    return self(a.values, uses)
+    raise ValidationError("Only VirtualFunction is allowed in the final graph")
 
 
 class NodeValidator:

--- a/myia/validate.py
+++ b/myia/validate.py
@@ -43,13 +43,14 @@ def validate_abstract(self, a: AbstractError, uses):
     kind = a.xvalue()
     if kind is DEAD or kind is DUMMY:
         return True
-    elif kind is POLY:
+    else:
         with untested_legacy():
-            return not any(key == 0 for node, key in uses)
-    else:  # pragma: no cover
-        # As it turns out, the inferrer now catches this error before we get to
-        # validation.
-        raise ValidationError(f"Illegal type in the graph: {a}", type=a)
+            if kind is POLY:
+                return not any(key == 0 for node, key in uses)
+            else:  # pragma: no cover
+                # As it turns out, the inferrer now catches this error before we get to
+                # validation.
+                raise ValidationError(f"Illegal type in the graph: {a}", type=a)
 
 
 @overload  # noqa: F811

--- a/tests/ir/test_anf.py
+++ b/tests/ir/test_anf.py
@@ -1,6 +1,6 @@
 import pytest
 
-from myia.abstract import VirtualFunction2
+from myia.abstract import AbstractFunctionUnique
 from myia.ir.anf import PARAMETER, Apply, Constant, Graph, Parameter
 from myia.operations import primitives as primops
 
@@ -35,7 +35,7 @@ def test_graph():
     g.return_.abstract = 456
     assert g.abstract is None
     g.parameters[0].abstract = 123
-    assert g.abstract == VirtualFunction2([123], 456)
+    assert g.abstract == AbstractFunctionUnique([123], 456)
 
 
 def test_graph_helpers():

--- a/tests/ir/test_anf.py
+++ b/tests/ir/test_anf.py
@@ -1,6 +1,6 @@
 import pytest
 
-from myia.abstract import AbstractFunction, VirtualFunction
+from myia.abstract import AbstractFunction, VirtualFunction2
 from myia.ir.anf import PARAMETER, Apply, Constant, Graph, Parameter
 from myia.operations import primitives as primops
 
@@ -35,7 +35,7 @@ def test_graph():
     g.return_.abstract = 456
     assert g.abstract is None
     g.parameters[0].abstract = 123
-    assert g.abstract == AbstractFunction(VirtualFunction([123], 456))
+    assert g.abstract == VirtualFunction2([123], 456)
 
 
 def test_graph_helpers():

--- a/tests/ir/test_anf.py
+++ b/tests/ir/test_anf.py
@@ -1,6 +1,6 @@
 import pytest
 
-from myia.abstract import AbstractFunction, VirtualFunction2
+from myia.abstract import VirtualFunction2
 from myia.ir.anf import PARAMETER, Apply, Constant, Graph, Parameter
 from myia.operations import primitives as primops
 

--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -31,7 +31,7 @@ from myia.abstract import (
     Possibilities,
     TaggedPossibilities,
     TrackDict,
-    VirtualFunction,
+    VirtualFunction2,
     abstract_clone,
     amerge,
     broaden,
@@ -289,7 +289,7 @@ def test_abstract_clone():
     a2 = T([s2, AbstractClass(object, {"field": s2})])
     assert upcast(a1, 64) is a2
 
-    jt = JTransformedFunction(VirtualFunction((s1,), s1))
+    jt = JTransformedFunction(VirtualFunction2((s1,), s1))
     assert upcast(jt, 64).fn.args == [s2]
     assert upcast(jt, 64).fn.output is s2
 

--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -26,12 +26,12 @@ from myia.abstract import (
     AbstractUnion,
     Context,
     InferenceLoop,
-    JTransformedFunction,
     Pending,
     PendingFromList,
     Possibilities,
     TaggedPossibilities,
     TrackDict,
+    TransformedFunction,
     abstract_clone,
     amerge,
     broaden,
@@ -292,7 +292,7 @@ def test_abstract_clone():
     a2 = T([s2, AbstractClass(object, {"field": s2})])
     assert upcast(a1, 64) is a2
 
-    jt = JTransformedFunction(AbstractFunctionUnique((s1,), s1))
+    jt = TransformedFunction(AbstractFunctionUnique((s1,), s1), P.J)
     assert upcast(jt, 64).fn.args == [s2]
     assert upcast(jt, 64).fn.output is s2
 

--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -258,6 +258,9 @@ def test_repr():
     f1 = AbstractFunction(P.scalar_mul)
     assert repr(f1) == "AbstractFunction(scalar_mul)"
 
+    fa = AbstractFunction(value=ANYTHING)
+    assert repr(fa) == "AbstractFunction(ANYTHING)"
+
     tu1 = AbstractTaggedUnion([[13, s2], [4, to_abstract_test(i16)]])
     assert repr(tu1) == "AbstractTaggedUnion(U(4 :: Int[16], 13 :: Float[32]))"
 

--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -15,6 +15,7 @@ from myia.abstract import (
     AbstractClass,
     AbstractError,
     AbstractFunction,
+    AbstractFunctionUnique,
     AbstractHandle,
     AbstractJTagged,
     AbstractKeywordArgument,
@@ -31,7 +32,6 @@ from myia.abstract import (
     Possibilities,
     TaggedPossibilities,
     TrackDict,
-    VirtualFunction2,
     abstract_clone,
     amerge,
     broaden,
@@ -292,7 +292,7 @@ def test_abstract_clone():
     a2 = T([s2, AbstractClass(object, {"field": s2})])
     assert upcast(a1, 64) is a2
 
-    jt = JTransformedFunction(VirtualFunction2((s1,), s1))
+    jt = JTransformedFunction(AbstractFunctionUnique((s1,), s1))
     assert upcast(jt, 64).fn.args == [s2]
     assert upcast(jt, 64).fn.output is s2
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -5,7 +5,7 @@ from myia.abstract import (
     TYPE,
     AbstractArray,
     AbstractFunction,
-    VirtualFunction,
+    TypedPrimitive,
 )
 from myia.frontends.pytorch_abstract_types import PyTorchTensor
 from myia.operations import partial, primitives as P
@@ -136,22 +136,17 @@ def test_clean():
 
 
 def test_validate_abstract():
+    scalar_i64 = to_abstract_test(i64)
     fn = AbstractFunction(
-        VirtualFunction((), to_abstract_test(i64)),
-        VirtualFunction((), to_abstract_test(f64)),
+        TypedPrimitive(P.scalar_add, (scalar_i64, scalar_i64), scalar_i64),
     )
     with pytest.raises(ValidationError):
         validate_abstract(fn, {})
 
 
 def test_validate_abstract_2():
-    fn = AbstractFunction(
-        VirtualFunction(
-            (),
-            AbstractArray(
-                to_abstract_test(f64), {SHAPE: (1, 2), TYPE: PyTorchTensor}
-            ),
-        ),
+    bad_array = AbstractArray(
+        to_abstract_test(f64), {SHAPE: (1, 2), TYPE: PyTorchTensor}
     )
     with pytest.raises(ValidationError):
-        validate_abstract(fn, {})
+        validate_abstract(bad_array, {})


### PR DESCRIPTION
`VirtualFunction` essentially becomes `AbstractFunctionUnique` which inherits from `AbstractValue`. After monomorphization, `AbstractFunction` is removed from the graph and all functions have `AbstractFunctionUnique` as their type.

`AbstractFunctionUnique` does not contain a `Possibilities` list, just a plain list of argument types and an output type. As such it is much closer to a conventional representation of a function type. This simplifies processing in the optimizer and in the backend.

Note that in the future, we might want to replace `AbstractFunction` during inference by an `AbstractUnion` of `AbstractFunctionUnique`.

`JTransformedFunction(fn)` is also replaced by `TransformedFunction(fn, P.J)` which creates opportunities to have other transforms, like `TransformedFunction(fn, P.Jinv)` to represent the inverse.
