### PR TITLE
Add a tracing garbage collector to the manager

### DIFF
--- a/myia/ir/manager.py
+++ b/myia/ir/manager.py
@@ -612,7 +612,7 @@ class GraphManager(Partializable):
         Normally this is done incrementally through reference counting, but
         because of circular references, some graphs might remain.
         """
-        reach = set(self.roots)
+        reach = OrderedSet(self.roots)
         for root in self.roots:
             reach.update(self.graphs_reachable[root])
         # TODO: Ideally the two lines below should be replaced by the commented

--- a/myia/ir/manager.py
+++ b/myia/ir/manager.py
@@ -3,7 +3,7 @@
 from collections import Counter, defaultdict
 
 from ..graph_utils import EXCLUDE, FOLLOW, dfs
-from ..utils import Events, OrderedSet, Partializable, WorkSet
+from ..utils import Events, OrderedSet, Partializable, WorkSet, untested_legacy
 from .anf import ANFNode
 from .utils import succ_deeper
 
@@ -745,8 +745,9 @@ class GraphManager(Partializable):
 
     def _drop_all(self, dropped, drop_nodes=True):
         if drop_nodes:
-            for g in dropped:
-                self._maybe_drop_nodes(OrderedSet([g.return_]))
+            with untested_legacy():
+                for g in dropped:
+                    self._maybe_drop_nodes(OrderedSet([g.return_]))
 
         for g in dropped:
             self.events.drop_graph(g)

--- a/myia/opt/cse.py
+++ b/myia/opt/cse.py
@@ -38,6 +38,7 @@ def group_nodes(root, manager):
 
 def cse(root, manager):
     """Apply CSE on root."""
+    manager.gc()
     groups = group_nodes(root, manager)
     changes = False
 

--- a/myia/opt/dde.py
+++ b/myia/opt/dde.py
@@ -479,6 +479,7 @@ class DeadDataElimination(Partializable):
 
     def __call__(self, root):
         """Apply dead data elimination."""
+        self.resources.opt_manager.gc()
         args = dict(opt=self, node=None, manager=root.manager, profile=False)
         with tracer("opt", **args) as tr:
             tr.set_results(success=False, **args)

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -1100,7 +1100,7 @@ def expand_J(resources, node, equiv):
     This will not replace J(x) when x is not a constant graph.
     """
     from ..grad import Jimpl
-
+    resources.opt_manager.gc()
     arg = equiv[C].value
 
     if not hasattr(resources, "grad_cache"):

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -1100,6 +1100,7 @@ def expand_J(resources, node, equiv):
     This will not replace J(x) when x is not a constant graph.
     """
     from ..grad import Jimpl
+
     resources.opt_manager.gc()
     arg = equiv[C].value
 

--- a/myia/opt/llift.py
+++ b/myia/opt/llift.py
@@ -16,6 +16,7 @@ def lambda_lift(root):
     This is a destructive operation.
     """
     mng = manage(root)
+    mng.gc()
     graphs = WorkSet(mng.graphs)
     candidates = []
 

--- a/myia/pipeline/resources.py
+++ b/myia/pipeline/resources.py
@@ -131,14 +131,17 @@ class Tracker(Partializable):
         self.manager = resources.opt_manager
         self.activated = False
 
-    def activate(self):
+    def activate(self, force=False):
         """Activate the tracker.
 
         If the tracker is already activated, this does nothing.
         """
-        if not self.activated:
+        if force or not self.activated:
             self.manager.events.add_node.register(self._on_add_node)
             self.manager.events.drop_node.register(self._on_drop_node)
+            self.manager.events.post_reset.register(
+                lambda evt: self.activate(force=True)
+            )
             self.activated = True
 
     def _on_add_node(self, event, node):


### PR DESCRIPTION
As it turns out, the manager needs a garbage collector in some situations. It does have a GC of sorts which is based on refcounts of graph uses, but if there is a cycle somewhere, removing a pointer to the whole cycle won't reclaim it.

A `gc` method is therefore added to the manager which basically checks the `graphs_reachable` statistic from the roots and resets the manager if this is not the same as the current set of graphs. In theory it should be possible to do better than a reset, but there is unfortunately an issue with a new test in future PR #359 (which is not available yet, but it will come in its own time).
