### PR TITLE
Change gradient generation around free variables

### DIFF
--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -18,6 +18,7 @@ from ..utils import (
     infer_trace,
     tracer,
     type_error_nargs,
+    untested_legacy,
 )
 from .amerge import amerge, bind
 from .data import (
@@ -140,7 +141,8 @@ class InferenceEngine:
             return Reference(self, node, CONTEXTLESS)
         if node.is_constant_graph():
             if node.value.abstract is not None:
-                return Reference(self, node, CONTEXTLESS)
+                with untested_legacy():
+                    return Reference(self, node, CONTEXTLESS)
             graph = node.value.parent
         else:
             graph = node.graph

--- a/myia/grad.py
+++ b/myia/grad.py
@@ -441,8 +441,9 @@ class SensRemapper(GradRemapper):
         fv_sens = Constant(newenv)
         for fv in g.free_variables_total:
             sens = self.get(g, fv)
-            # NOTE: If sens is an application of zeros_like, it would be
-            # possible to skip adding it to the env.
+            if sens.is_apply(zeros_like):
+                # Skip if there is no gradient
+                continue
             fv_sens = ng.apply(
                 P.env_setitem,
                 fv_sens,

--- a/myia/grad.py
+++ b/myia/grad.py
@@ -319,7 +319,7 @@ class SensRemapper(GradRemapper):
         with About(child.debug, self.relation):
             self.remap_node((g, child), g, child, ng, ng.apply())
 
-    def gen_fv(self, g, ng, node):
+    def gen_fv_extended(self, g, ng, node):
         """Generate sensitivities for free variables.
 
         Note that the default gen_fv does nothing, so this is different
@@ -394,7 +394,7 @@ class SensRemapper(GradRemapper):
         children = {
             g2
             for g2 in self.graphs
-            if g2.parent is g and node in g2.free_variables_total
+            if (g, g2) in self.repl and node in g2.free_variables_extended
         }
 
         # This is equivalent to the original node. Note that we aren't really
@@ -439,7 +439,7 @@ class SensRemapper(GradRemapper):
           all parameter sensitivities.
         """
         fv_sens = Constant(newenv)
-        for fv in g.free_variables_total:
+        for fv in g.free_variables_extended:
             sens = self.get(g, fv)
             if sens.is_apply(zeros_like):
                 # Skip if there is no gradient

--- a/myia/grad.py
+++ b/myia/grad.py
@@ -322,8 +322,8 @@ class SensRemapper(GradRemapper):
     def gen_fv_extended(self, g, ng, node):
         """Generate sensitivities for free variables.
 
-        Note that the default gen_fv does nothing, so this is different
-        behavior.
+        Note that the default gen_fv_extended does nothing, so this is
+        different behavior.
         """
         with About(node.debug, self.relation):
             self.remap_node((g, node), g, node, ng, ng.apply())

--- a/myia/ir/clone.py
+++ b/myia/ir/clone.py
@@ -98,6 +98,7 @@ class GraphRemapper(Partializable):
     gen_fv_direct = NotImplemented
     gen_fv = NotImplemented
     gen_fv_graph = NotImplemented
+    gen_fv_extended = NotImplemented
 
     def gen_rogue_parameter(self, graph, new_graph, p):  # pragma: no cover
         """Generate something for a parameter not in the parameter list."""
@@ -179,6 +180,10 @@ class GraphRemapper(Partializable):
                 for node in mng.free_variables_total[graph]:
                     if isinstance(node, Graph):
                         self.gen_fv_graph(graph, target_graph, node)
+
+            if self.gen_fv_extended is not NotImplemented:
+                for node in mng.free_variables_extended[graph]:
+                    self.gen_fv_extended(graph, target_graph, node)
 
             for ct in mng.constants[graph]:
                 if ct.is_constant_graph():

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -721,8 +721,7 @@ def force_constants(resources, node, equiv):
     except Exception:
         return None
     if val is DEAD:
-        with untested_legacy():
-            return None
+        return None
     ct = Constant(val)
     ct.abstract = node.abstract
     return ct

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -382,7 +382,7 @@ def test_list_for(xs):
     return y
 
 
-@gradient(4.5)
+@mt(gradient(4.5), gradient(-7.9))
 def test_nested_closure(x):
     a = x * x
 
@@ -400,8 +400,7 @@ def test_nested_closure(x):
     return f()()
 
 
-@mark.xfail(reason="Recursive closures do not work at the moment")
-@gradient(4.0)
+@gradient(4.3, pipeline=standard_pipeline)
 def test_recursive_closure(x):
     def f(y):
         if y <= 0:

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -400,6 +400,18 @@ def test_nested_closure(x):
     return f()()
 
 
+@mark.xfail(reason="Recursive closures do not work at the moment")
+@gradient(4.0)
+def test_recursive_closure(x):
+    def f(y):
+        if y <= 0:
+            return x
+        else:
+            return f(y - 1)
+
+    return f(7)
+
+
 @gradient(4.5, 6.7)
 def test_functions_in_tuples(x, y):
     tup = scalar_add, scalar_mul


### PR DESCRIPTION
The generation of the gradient around free variables is modified in order to support recursive closures. More specifically, we use `free_variables_extended` to generate an entry in the env for the gradient of the closure for each non-graph free variable instead of packing some of them into entries that are themselves environments.

A test is added for recursive closures. That test would not work before this PR -- mutually recursive nodes would be created by the grad function, which constitutes an invalid computation graph.
