### PR TITLE
Allow a RNG state to be returned from a compiled function and then used as argument for another compiled function.

### DIFF
--- a/myia/abstract/to_abstract.py
+++ b/myia/abstract/to_abstract.py
@@ -21,6 +21,7 @@ from ..utils import (
     is_dataclass_type,
     overload,
 )
+from ..utils.misc import RandomStateWrapper
 from .amerge import amerge
 from .data import (
     ALIASID,
@@ -35,6 +36,7 @@ from .data import (
     AbstractExternal,
     AbstractFunction,
     AbstractHandle,
+    AbstractRandomState,
     AbstractScalar,
     AbstractTuple,
     AbstractType,
@@ -173,6 +175,11 @@ def to_abstract(
 @overload  # noqa: F811
 def to_abstract(self, v: tuple, **kwargs):
     return AbstractTuple([self(elem, **kwargs) for elem in v])
+
+
+@overload  # noqa: F811
+def to_abstract(self, v: RandomStateWrapper, **kwargs):
+    return AbstractRandomState()
 
 
 @overload  # noqa: F811

--- a/myia/compile/backends/pytorch.py
+++ b/myia/compile/backends/pytorch.py
@@ -612,6 +612,8 @@ class PyTorchBackend(Backend):
         elif isinstance(t, abstract.AbstractTaggedUnion):
             real_t = t.options.get(v.tag)
             return TaggedValue(v.tag, self.to_backend_value(v.value, real_t))
+        elif isinstance(t, abstract.AbstractRandomState):
+            return self.from_numpy(v.state.copy())
         else:
             raise NotImplementedError(f"to_backend_value for {t}")
 

--- a/myia/compile/backends/relay.py
+++ b/myia/compile/backends/relay.py
@@ -15,7 +15,7 @@ from ...operations import Primitive, primitives as P
 from ...operations.primitives import BackendPrimitive
 from ...utils import HandleInstance, RandomStateWrapper, TaggedValue
 from ...utils.variables import X, Y
-from ...xtype import type_to_np_dtype
+from ...xtype import type_to_np_dtype, u32
 from ..channel import handle
 from ..transform import get_prim_graph, return_handles, wrap_result
 from . import Backend, Converter, HandleBackend, relay_philox
@@ -917,6 +917,9 @@ class RelayInputConverter(Converter):
 
     def convert_tuple(self, v, t):
         return tuple(self(e, et) for e, et in zip(v, t.elements))
+
+    def convert_random_state(self, v, t):
+        return tuple(self.convert_scalar(e, u32) for e in v.state)
 
     def convert_universe(self, v, t):
         return ()

--- a/myia/simplify_types.py
+++ b/myia/simplify_types.py
@@ -35,7 +35,6 @@ from .compile import BackendValue
 from .ir import Constant
 from .operations import primitives as P
 from .utils import HandleInstance, MyiaInputTypeError, TaggedValue, overload
-from .utils.misc import RandomStateWrapper
 from .xtype import Int, NDArray, String
 
 ####################

--- a/myia/simplify_types.py
+++ b/myia/simplify_types.py
@@ -35,6 +35,7 @@ from .compile import BackendValue
 from .ir import Constant
 from .operations import primitives as P
 from .utils import HandleInstance, MyiaInputTypeError, TaggedValue, overload
+from .utils.misc import RandomStateWrapper
 from .xtype import Int, NDArray, String
 
 ####################
@@ -304,6 +305,13 @@ def to_canonical(self, arg, orig_t: AbstractTuple, coerce):
 
 
 @overload  # noqa: F811
+def to_canonical(self, arg, orig_t: AbstractRandomState, coerce):
+    if not isinstance(arg, RandomStateWrapper):
+        raise MyiaInputTypeError("Expected %s" % RandomStateWrapper.__name__)
+    return arg
+
+
+@overload  # noqa: F811
 def to_canonical(self, arg, orig_t: AbstractDict, coerce):
     if not isinstance(arg, dict):
         raise MyiaInputTypeError("Expected dict")
@@ -448,7 +456,7 @@ def from_canonical(self, res, orig_t: AbstractTuple):
 
 @overload  # noqa: F811
 def from_canonical(self, res, orig_t: AbstractRandomState):
-    return res.state
+    return res
 
 
 @overload  # noqa: F811

--- a/myia/simplify_types.py
+++ b/myia/simplify_types.py
@@ -306,8 +306,7 @@ def to_canonical(self, arg, orig_t: AbstractTuple, coerce):
 
 @overload  # noqa: F811
 def to_canonical(self, arg, orig_t: AbstractRandomState, coerce):
-    if not isinstance(arg, RandomStateWrapper):
-        raise MyiaInputTypeError("Expected %s" % RandomStateWrapper.__name__)
+    # arg must be a RandomStateWrapper
     return arg
 
 

--- a/myia/simplify_types.py
+++ b/myia/simplify_types.py
@@ -35,6 +35,7 @@ from .compile import BackendValue
 from .ir import Constant
 from .operations import primitives as P
 from .utils import HandleInstance, MyiaInputTypeError, TaggedValue, overload
+from .utils.misc import RandomStateWrapper
 from .xtype import Int, NDArray, String
 
 ####################
@@ -306,6 +307,8 @@ def to_canonical(self, arg, orig_t: AbstractTuple, coerce):
 @overload  # noqa: F811
 def to_canonical(self, arg, orig_t: AbstractRandomState, coerce):
     # arg must be a RandomStateWrapper
+    if not isinstance(arg, RandomStateWrapper):
+        raise MyiaInputTypeError("Expected %s" % RandomStateWrapper.__name__)
     return arg
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from myia.abstract.data import AbstractRandomState
 from myia.api import myia, to_device
 from myia.compile import closure_convert
 from myia.ir import clone
@@ -11,6 +12,7 @@ from myia.pipeline import (
 )
 from myia.simplify_types import from_canonical, to_canonical
 from myia.utils import DoTrace, HandleInstance, InferenceError, TaggedValue
+from myia.utils.misc import RandomStateWrapper
 from myia.xtype import Bool
 
 from .common import (
@@ -88,6 +90,14 @@ def test_myia_dict_field():
 
     v = f({"x": 2})
     assert v == 2
+
+
+def test_random_state_to_canonical():
+    rsw = RandomStateWrapper(None)
+    ars = AbstractRandomState()
+    assert to_canonical(rsw, ars) is rsw
+    with pytest.raises(TypeError):
+        to_canonical(None, ars)
 
 
 def test_to_canonical():


### PR DESCRIPTION
@breuleux @abergeron

This PR should allow to return an RNG state from a compiled function and then use it as argument for other compiled functions. Python <-> Myia communication should be solved now.