### PR TITLE
Generate free variables instead of phi nodes when possible

### DIFF
--- a/myia/parser.py
+++ b/myia/parser.py
@@ -166,6 +166,38 @@ def parse(func, use_universe=False):
     return graph
 
 
+class FindPossiblePhi(ast.NodeVisitor):
+    def __init__(self, tree):
+        self.phis = set()
+        self.root = True
+        self.inloop = False
+        assert isinstance(tree, ast.FunctionDef)
+        self.generic_visit(tree)
+
+    def visit_loop(self, node):
+        prev = self.inloop
+        self.inloop = True
+        self.generic_visit(node)
+        self.inloop = prev
+
+    def visit_FunctionDef(self, node):
+        return
+
+    def visit_If(self, node):
+        self.visit_loop(node)
+
+    def visit_For(self, node):
+        self.visit_loop(node)
+
+    def visit_While(self, node):
+        self.visit_loop(node)
+
+    def visit_Name(self, node):
+        if isinstance(node.ctx, ast.Store) and self.inloop:
+            # breakpoint()
+            self.phis.add(node.id)
+
+
 class Parser:
     """Parser for a function.
 
@@ -211,6 +243,8 @@ class Parser:
         self.read_cache = OrderedSet()
         # Finalizers for functions
         self.finalizers = {}
+        # Variable names that could be phi nodes
+        self.possible_phis = set()
 
     def new_block(self, **kwargs) -> "Block":
         """Create a new block."""
@@ -341,6 +375,9 @@ class Parser:
     def _finalize_function(self, node, function_block):
         """Process a function definition."""
         # Process arguments and their defaults
+        possible_phis_bk = self.possible_phis
+        self.possible_phis = FindPossiblePhi(node).phis
+
         args = node.args.args
         nondefaults = [None] * (len(args) - len(node.args.defaults))
         defaults = nondefaults + node.args.defaults
@@ -400,6 +437,7 @@ class Parser:
         function_block.graph.return_.inputs[2:] = defaults_list
 
         # TODO: check that if after_block returns?
+        self.possible_phis = possible_phis_bk
         return function_block
 
     def process_node(self, block, node, used=True):  # noqa
@@ -1038,8 +1076,8 @@ class Block:
             if lock:
                 self.lock[varnum] = lock
             return _fresh(node)
-        if self.matured:
-
+        nophi = varnum not in self.parser.possible_phis
+        if self.matured or nophi:
             def _resolve():
                 if not resolve_globals:
                     return None
@@ -1050,7 +1088,9 @@ class Block:
                     ns = self.parser.global_namespace
                     return self.make_resolve(ns, varnum)
 
-            if len(self.preds) == 1:
+            if not self.preds:
+                return _resolve()
+            if len(self.preds) == 1 or nophi:
                 result = self.preds[0].read(
                     varnum,
                     resolve_globals=False,
@@ -1058,8 +1098,7 @@ class Block:
                     or (self.type == "function" and self.graph.debug.name),
                 )
                 return result or _resolve()
-            if not self.preds:
-                return _resolve()
+
         # TODO: point to the original definition
         with About(NamedDebugInfo(name=varnum), "phi"):
             phi = Parameter(self.graph)

--- a/myia/parser.py
+++ b/myia/parser.py
@@ -167,6 +167,16 @@ def parse(func, use_universe=False):
 
 
 class FindPossiblePhi(ast.NodeVisitor):
+    """Find all variable names that are not single static assigment.
+
+    These are variables in if/while/for statements. Multiple assignments to the
+    same variable in a linear sequence of statements do not count as "phi"
+    since each such occurrence can straightforwardly be renamed.
+
+    Attributes:
+        phis: set of variable names that are in if/while/for statements.
+    """
+
     def __init__(self, tree):
         self.phis = set()
         self.root = True
@@ -194,7 +204,6 @@ class FindPossiblePhi(ast.NodeVisitor):
 
     def visit_Name(self, node):
         if isinstance(node.ctx, ast.Store) and self.inloop:
-            # breakpoint()
             self.phis.add(node.id)
 
 

--- a/myia/parser.py
+++ b/myia/parser.py
@@ -1078,6 +1078,7 @@ class Block:
             return _fresh(node)
         nophi = varnum not in self.parser.possible_phis
         if self.matured or nophi:
+
             def _resolve():
                 if not resolve_globals:
                     return None

--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -32,6 +32,7 @@ from myia.abstract import (
     TaggedPossibilities,
     TrackDict,
     TransformedFunction,
+    abstract_check,
     abstract_clone,
     amerge,
     broaden,
@@ -305,6 +306,13 @@ def test_abstract_clone_pending():
     assert abstract_clone(sp) is sp
     p.set_result(ty.Int[32])
     assert abstract_clone(sp) is s1
+
+
+def test_abstract_clone_edge_cases():
+    tup = T(ANYTHING)
+    assert abstract_check(tup)
+    tup2 = abstract_clone(tup)
+    assert tup is tup2
 
 
 def test_broaden_recursive():


### PR DESCRIPTION
This modifies the parser a bit so that it will only create phi nodes for variables that are set inside if/for/while statements.

The one issue with this is that some graphs, such as the RNN, are not optimized as well, but this can likely be solved.
