### PR TITLE
Rewrite step_resolve, eager resources

### DIFF
--- a/debug/gprint.py
+++ b/debug/gprint.py
@@ -18,7 +18,7 @@ from myia.info import About
 from myia.ir import Apply, Constant, GraphCloner, manage
 from myia.ir.manager import ParentProxy
 from myia.operations import primitives as primops
-from myia.opt import LocalPassOptimizer, NodeMap, pattern_replacer
+from myia.opt import LocalPassOptimizer, pattern_replacer
 from myia.utils import UNKNOWN, Registry
 from myia.utils.unify import SVar, Var, var
 from myia.xtype import Float, Int, UInt

--- a/debug/gprint.py
+++ b/debug/gprint.py
@@ -803,10 +803,7 @@ def cosmetic_transformer(g):
         _opt_fancy_tagged,
         # careful=True
     )
-    nmap = NodeMap()
-    for optim in spec:
-        nmap.register(getattr(optim, "interest", None), optim)
-    optim = LocalPassOptimizer(nmap)
+    optim = LocalPassOptimizer(*spec)
     optim(g)
     return g
 

--- a/myia/grad.py
+++ b/myia/grad.py
@@ -514,7 +514,8 @@ def Jimpl(other: object, resources, node):
 default_grad_flags = {"ignore_values": True, "core": True, "reference": True}
 
 
-_is_mktuple = ((operations.resolve, operations_ns, "make_tuple"), Xs)
+_is_mktuple_resolve = ((operations.resolve, operations_ns, "make_tuple"), Xs)
+_is_mktuple_direct = (P.make_tuple, Xs)
 _is_raise = (P.raise_, Xs)
 
 
@@ -530,7 +531,9 @@ def _make_grad_transform(prim, fn, flags):
     bprop.debug.about = About(info, "grad_bprop")  # type: ignore
     if bprop.output.match(_is_raise):
         pass
-    elif bprop.output.match(_is_mktuple):
+    elif bprop.output.match(_is_mktuple_resolve) or bprop.output.match(
+        _is_mktuple_direct
+    ):
         bprop.output = bprop.apply(
             P.make_tuple, newenv, *bprop.output.inputs[1:]
         )

--- a/myia/opt/opt.py
+++ b/myia/opt/opt.py
@@ -170,14 +170,17 @@ class LocalPassOptimizer:
         for opt in opts:
             self.node_map.register(getattr(opt, "interest", None), opt)
 
-    def __call__(self, graph, resources=None):
+    def __call__(self, graph, resources=None, manager=None):
         """Apply optimizations on given graphs in node order.
 
         This will visit the nodes from the output to the inputs in a
         bfs manner while avoiding parts of the graph that are dropped
         due to optimizations.
         """
-        if resources is not None:
+        if manager is not None:
+            mng = manager
+            mng.add_graph(graph)
+        elif resources is not None:
             mng = resources.opt_manager
             mng.add_graph(graph)
         else:

--- a/myia/pipeline/resources.py
+++ b/myia/pipeline/resources.py
@@ -325,25 +325,14 @@ class Resources(Partializable):
 
     def __init__(self, **members):
         """Initialize the Resources."""
-        self._members = members
-        self._inst = {}
-
-    def __getattr__(self, attr):
-        if attr in self._inst:
-            return self._inst[attr]
-
-        if attr in self._members:
-            inst = self._members[attr]
+        for attr, inst in members.items():
             if isinstance(inst, Partial):
                 try:
                     inst = inst.partial(resources=self)
                 except TypeError:
                     pass
                 inst = inst()
-            self._inst[attr] = inst
-            return inst
-
-        raise AttributeError(f"No resource named {attr}.")
+            setattr(self, attr, inst)
 
 
 __consolidate__ = True

--- a/myia/pipeline/resources.py
+++ b/myia/pipeline/resources.py
@@ -40,12 +40,11 @@ def default_convert(env, g: Graph):
             opt_pass = Pipeline(
                 LocalPassOptimizer(optlib.resolve_globals, name="resolve")
             )
-            results = opt_pass(
+            opt_pass(
                 graph=g2,
                 resources=env.resources,
                 manager=env.resources.infer_manager,
             )
-            g2 = clone(g2)
         env.object_map[g] = g2
         return g2
     else:

--- a/myia/pipeline/resources.py
+++ b/myia/pipeline/resources.py
@@ -9,7 +9,6 @@ from .. import parser, xtype
 from ..abstract import InferenceEngine, LiveInferenceEngine, type_to_abstract
 from ..compile import load_backend
 from ..ir import Graph, clone
-from ..modules.impl import core_modules
 from ..monomorphize import Monomorphizer
 from ..operations.utils import Operation
 from ..opt import LocalPassOptimizer, lib as optlib

--- a/myia/pipeline/standard.py
+++ b/myia/pipeline/standard.py
@@ -289,7 +289,7 @@ standard_resources = Resources.partial(
     incorporate=Incorporator.partial(),
     return_backend=False,
     universal=False,
-    preresolve=False,
+    preresolve=True,
 )
 
 
@@ -350,25 +350,21 @@ scalar_debug_pipeline = standard_debug_pipeline.configure(
 ######################
 
 
-standard_parse = standard_pipeline.with_steps(
-    steps.step_parse
-).make_transformer("input", "graph")
-
-
-scalar_parse = (
-    scalar_pipeline.with_steps(steps.step_parse, steps.step_copy)
-    .configure(preresolve=True)
+standard_parse = (
+    standard_pipeline.with_steps(steps.step_parse)
+    .configure(preresolve=False)
     .make_transformer("input", "graph")
 )
 
 
-scalar_debug_compile = (
-    scalar_debug_pipeline.with_steps(
-        steps.step_parse, steps.step_copy, steps.step_debug_export
-    )
-    .configure(preresolve=True)
-    .make_transformer("input", "output")
-)
+scalar_parse = scalar_pipeline.with_steps(
+    steps.step_parse, steps.step_copy
+).make_transformer("input", "graph")
+
+
+scalar_debug_compile = scalar_debug_pipeline.with_steps(
+    steps.step_parse, steps.step_copy, steps.step_debug_export
+).make_transformer("input", "output")
 
 
 __consolidate__ = True

--- a/myia/pipeline/standard.py
+++ b/myia/pipeline/standard.py
@@ -289,6 +289,7 @@ standard_resources = Resources.partial(
     incorporate=Incorporator.partial(),
     return_backend=False,
     universal=False,
+    preresolve=False,
 )
 
 
@@ -354,14 +355,20 @@ standard_parse = standard_pipeline.with_steps(
 ).make_transformer("input", "graph")
 
 
-scalar_parse = scalar_pipeline.with_steps(
-    steps.step_parse, steps.step_resolve,
-).make_transformer("input", "graph")
+scalar_parse = (
+    scalar_pipeline.with_steps(steps.step_parse, steps.step_copy)
+    .configure(preresolve=True)
+    .make_transformer("input", "graph")
+)
 
 
-scalar_debug_compile = scalar_debug_pipeline.with_steps(
-    steps.step_parse, steps.step_resolve, steps.step_debug_export,
-).make_transformer("input", "output")
+scalar_debug_compile = (
+    scalar_debug_pipeline.with_steps(
+        steps.step_parse, steps.step_copy, steps.step_debug_export
+    )
+    .configure(preresolve=True)
+    .make_transformer("input", "output")
+)
 
 
 __consolidate__ = True

--- a/myia/pipeline/steps.py
+++ b/myia/pipeline/steps.py
@@ -19,7 +19,7 @@ from ..simplify_types import from_canonical, simplify_types, to_canonical
 from ..utils import InferenceError, MyiaInputTypeError, new_universe
 from ..validate import ValidationError
 from ..xtype import UniverseType
-from .pipeline import LoopPipeline, Pipeline
+from .pipeline import LoopPipeline
 
 #########
 # Parse #

--- a/myia/pipeline/steps.py
+++ b/myia/pipeline/steps.py
@@ -52,20 +52,14 @@ def step_parse(resources, input, argspec=None):
 ###########
 
 
-def step_resolve(resources, graph, argspec=None, outspec=None):
-    """Resolve all global symbols in the graph.
-
-    This will remove all resolve(...) calls in the graph.
+def step_copy(resources, graph):
+    """Copy the graph into opt_manager for optimization/execution.
 
     This step is unnecessary if the infer/specialize steps are in the pipeline.
     """
     new_graph = clone(graph, total=True)
     resources.opt_manager.add_graph(new_graph, root=True)
-    resources.infer_manager = resources.opt_manager
-    opt_pass = Pipeline(
-        LocalPassOptimizer(optlib.resolve_globals, name="resolve")
-    )
-    return opt_pass(graph=new_graph, resources=resources)
+    return {"graph": new_graph}
 
 
 #########

--- a/myia_backend_relay/tests/test_universal.py
+++ b/myia_backend_relay/tests/test_universal.py
@@ -6,7 +6,7 @@ from myia import myia
 from myia.compile.backends import load_backend
 from myia.lib import Empty, HandleInstance, core
 from myia.operations import cell_get, cell_set, make_cell
-from myia.pipeline import standard_pipeline, steps
+from myia.pipeline import standard_pipeline
 
 load_backend("relay")
 

--- a/myia_backend_relay/tests/test_universal.py
+++ b/myia_backend_relay/tests/test_universal.py
@@ -11,7 +11,7 @@ from myia.pipeline import standard_pipeline, steps
 load_backend("relay")
 
 
-upipeline = standard_pipeline.insert_after(steps.step_parse, steps.step_resolve)
+upipeline = standard_pipeline
 
 umyia = myia(
     use_universe=True,

--- a/poetry.lock
+++ b/poetry.lock
@@ -123,8 +123,8 @@ category = "dev"
 description = "Extended pickling support for Python objects"
 name = "cloudpickle"
 optional = false
-python-versions = "*"
-version = "1.3.0"
+python-versions = ">=3.5"
+version = "1.6.0"
 
 [[package]]
 category = "main"
@@ -132,7 +132,7 @@ description = "Cross-platform colored terminal text."
 name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.4.3"
+version = "0.4.4"
 
 [[package]]
 category = "main"
@@ -208,10 +208,10 @@ description = "The OpenAI Gym: A toolkit for developing and comparing your reinf
 name = "gym"
 optional = false
 python-versions = ">=3.5"
-version = "0.17.2"
+version = "0.17.3"
 
 [package.dependencies]
-cloudpickle = ">=1.2.0,<1.4.0"
+cloudpickle = ">=1.2.0,<1.7.0"
 numpy = ">=1.10.4"
 pyglet = ">=1.4.0,<=1.5.0"
 scipy = "*"
@@ -336,7 +336,7 @@ description = "Overloading Python functions"
 name = "ovld"
 optional = false
 python-versions = ">=3.6,<4.0"
-version = "0.2.4"
+version = "0.2.6"
 
 [[package]]
 category = "dev"
@@ -446,7 +446,7 @@ description = "Pygments is a syntax highlighting package written in Python."
 name = "pygments"
 optional = false
 python-versions = ">=3.5"
-version = "2.7.1"
+version = "2.7.2"
 
 [[package]]
 category = "dev"
@@ -511,7 +511,7 @@ description = "Alternative regular expression module, to replace re."
 name = "regex"
 optional = false
 python-versions = "*"
-version = "2020.9.27"
+version = "2020.10.23"
 
 [[package]]
 category = "dev"
@@ -537,7 +537,7 @@ description = "SciPy: Scientific Library for Python"
 name = "scipy"
 optional = false
 python-versions = ">=3.6"
-version = "1.5.2"
+version = "1.5.3"
 
 [package.dependencies]
 numpy = ">=1.14.5"
@@ -682,11 +682,11 @@ description = "HTTP library with thread-safe connection pooling, file post, and 
 name = "urllib3"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "1.25.10"
+version = "1.25.11"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
-secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0.14)", "ipaddress"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [[package]]
@@ -715,15 +715,14 @@ marker = "python_version < \"3.8\""
 name = "zipp"
 optional = false
 python-versions = ">=3.6"
-version = "3.2.0"
+version = "3.4.0"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "4f347a57d9936142cea8e44c0e72fc94a22a56573d3562aab2813027181e287f"
-lock-version = "1.0"
+content-hash = "bac29435692e552bcff87087a5f7f93ed9fc84ee6acd80fea70cf9d761b55511"
 python-versions = "~3.7"
 
 [metadata.files]
@@ -772,12 +771,12 @@ click = [
     {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
 ]
 cloudpickle = [
-    {file = "cloudpickle-1.3.0-py2.py3-none-any.whl", hash = "sha256:8664761f810efc07dbb301459e413c99b68fcc6d8703912bd39d86618ac631e3"},
-    {file = "cloudpickle-1.3.0.tar.gz", hash = "sha256:38af54d0e7705d87a287bdefe1df00f936aadb1f629dca383e825cca927fa753"},
+    {file = "cloudpickle-1.6.0-py3-none-any.whl", hash = "sha256:3a32d0eb0bc6f4d0c57fbc4f3e3780f7a81e6fee0fa935072884d58ae8e1cc7c"},
+    {file = "cloudpickle-1.6.0.tar.gz", hash = "sha256:9bc994f9e9447593bd0a45371f0e7ac7333710fcf64a4eb9834bf149f4ef2f32"},
 ]
 colorama = [
-    {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
-    {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
+    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 colorful = [
     {file = "colorful-0.5.4-py2.py3-none-any.whl", hash = "sha256:8d264b52a39aae4c0ba3e2a46afbaec81b0559a99be0d2cfe2aba4cf94531348"},
@@ -838,7 +837,7 @@ future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
 ]
 gym = [
-    {file = "gym-0.17.2.tar.gz", hash = "sha256:bb495aa56995b01274a2213423bf5ba05b8f4fd51c6dc61e9d4abddd1189718e"},
+    {file = "gym-0.17.3.tar.gz", hash = "sha256:96a7dd4e9cdb39e30c7a79e5773570fd9408f7fdb58c714c293cfbb314818eb6"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -936,8 +935,8 @@ opt-einsum = [
     {file = "opt_einsum-3.3.0.tar.gz", hash = "sha256:59f6475f77bbc37dcf7cd748519c0ec60722e91e63ca114e68821c0c54a46549"},
 ]
 ovld = [
-    {file = "ovld-0.2.4-py3-none-any.whl", hash = "sha256:377d28851b2abafe58e93543316816311add60e2e6700d427627dd757665ad98"},
-    {file = "ovld-0.2.4.tar.gz", hash = "sha256:60f296457cc4858cf3728cadad914a177927501a610dc917ab259e813e19280c"},
+    {file = "ovld-0.2.6-py3-none-any.whl", hash = "sha256:ba019fe01aec852dba421c4ce8cc34862a83c35fb1fcdf9d00ad1172610a07e7"},
+    {file = "ovld-0.2.6.tar.gz", hash = "sha256:64dd7ab98cc058a1cfba1d5af1b41f2db2c9cc5c0448704eb74b8f22dea2aabd"},
 ]
 packaging = [
     {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
@@ -1008,8 +1007,8 @@ pyglet = [
     {file = "pyglet-1.5.0.zip", hash = "sha256:6ea918985feddfa9bf0fcc01ffe9ff5849e7b6e832d9b2e03b9d2a36369cb6ee"},
 ]
 pygments = [
-    {file = "Pygments-2.7.1-py3-none-any.whl", hash = "sha256:307543fe65c0947b126e83dd5a61bd8acbd84abec11f43caebaf5534cbc17998"},
-    {file = "Pygments-2.7.1.tar.gz", hash = "sha256:926c3f319eda178d1bd90851e4317e6d8cdb5e292a3386aac9bd75eca29cf9c7"},
+    {file = "Pygments-2.7.2-py3-none-any.whl", hash = "sha256:88a0bbcd659fcb9573703957c6b9cff9fab7295e6e76db54c9d00ae42df32773"},
+    {file = "Pygments-2.7.2.tar.gz", hash = "sha256:381985fcc551eb9d37c52088a32914e00517e57f4a21609f48141ba08e193fa0"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
@@ -1028,49 +1027,58 @@ pytz = [
     {file = "pytz-2020.1.tar.gz", hash = "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"},
 ]
 regex = [
-    {file = "regex-2020.9.27-cp27-cp27m-win32.whl", hash = "sha256:d23a18037313714fb3bb5a94434d3151ee4300bae631894b1ac08111abeaa4a3"},
-    {file = "regex-2020.9.27-cp27-cp27m-win_amd64.whl", hash = "sha256:84e9407db1b2eb368b7ecc283121b5e592c9aaedbe8c78b1a2f1102eb2e21d19"},
-    {file = "regex-2020.9.27-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5f18875ac23d9aa2f060838e8b79093e8bb2313dbaaa9f54c6d8e52a5df097be"},
-    {file = "regex-2020.9.27-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ae91972f8ac958039920ef6e8769277c084971a142ce2b660691793ae44aae6b"},
-    {file = "regex-2020.9.27-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:9a02d0ae31d35e1ec12a4ea4d4cca990800f66a917d0fb997b20fbc13f5321fc"},
-    {file = "regex-2020.9.27-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:ebbe29186a3d9b0c591e71b7393f1ae08c83cb2d8e517d2a822b8f7ec99dfd8b"},
-    {file = "regex-2020.9.27-cp36-cp36m-win32.whl", hash = "sha256:4707f3695b34335afdfb09be3802c87fa0bc27030471dbc082f815f23688bc63"},
-    {file = "regex-2020.9.27-cp36-cp36m-win_amd64.whl", hash = "sha256:9bc13e0d20b97ffb07821aa3e113f9998e84994fe4d159ffa3d3a9d1b805043b"},
-    {file = "regex-2020.9.27-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:f1b3afc574a3db3b25c89161059d857bd4909a1269b0b3cb3c904677c8c4a3f7"},
-    {file = "regex-2020.9.27-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5533a959a1748a5c042a6da71fe9267a908e21eded7a4f373efd23a2cbdb0ecc"},
-    {file = "regex-2020.9.27-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:1fe0a41437bbd06063aa184c34804efa886bcc128222e9916310c92cd54c3b4c"},
-    {file = "regex-2020.9.27-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:c570f6fa14b9c4c8a4924aaad354652366577b4f98213cf76305067144f7b100"},
-    {file = "regex-2020.9.27-cp37-cp37m-win32.whl", hash = "sha256:eda4771e0ace7f67f58bc5b560e27fb20f32a148cbc993b0c3835970935c2707"},
-    {file = "regex-2020.9.27-cp37-cp37m-win_amd64.whl", hash = "sha256:60b0e9e6dc45683e569ec37c55ac20c582973841927a85f2d8a7d20ee80216ab"},
-    {file = "regex-2020.9.27-cp38-cp38-manylinux1_i686.whl", hash = "sha256:088afc8c63e7bd187a3c70a94b9e50ab3f17e1d3f52a32750b5b77dbe99ef5ef"},
-    {file = "regex-2020.9.27-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:eaf548d117b6737df379fdd53bdde4f08870e66d7ea653e230477f071f861121"},
-    {file = "regex-2020.9.27-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:41bb65f54bba392643557e617316d0d899ed5b4946dccee1cb6696152b29844b"},
-    {file = "regex-2020.9.27-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:8d69cef61fa50c8133382e61fd97439de1ae623fe943578e477e76a9d9471637"},
-    {file = "regex-2020.9.27-cp38-cp38-win32.whl", hash = "sha256:f2388013e68e750eaa16ccbea62d4130180c26abb1d8e5d584b9baf69672b30f"},
-    {file = "regex-2020.9.27-cp38-cp38-win_amd64.whl", hash = "sha256:4318d56bccfe7d43e5addb272406ade7a2274da4b70eb15922a071c58ab0108c"},
-    {file = "regex-2020.9.27.tar.gz", hash = "sha256:a6f32aea4260dfe0e55dc9733ea162ea38f0ea86aa7d0f77b15beac5bf7b369d"},
+    {file = "regex-2020.10.23-cp27-cp27m-win32.whl", hash = "sha256:781906e45ef1d10a0ed9ec8ab83a09b5e0d742de70e627b20d61ccb1b1d3964d"},
+    {file = "regex-2020.10.23-cp27-cp27m-win_amd64.whl", hash = "sha256:8cd0d587aaac74194ad3e68029124c06245acaeddaae14cb45844e5c9bebeea4"},
+    {file = "regex-2020.10.23-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:af360e62a9790e0a96bc9ac845d87bfa0e4ee0ee68547ae8b5a9c1030517dbef"},
+    {file = "regex-2020.10.23-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e21340c07090ddc8c16deebfd82eb9c9e1ec5e62f57bb86194a2595fd7b46e0"},
+    {file = "regex-2020.10.23-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:e5f6aa56dda92472e9d6f7b1e6331f4e2d51a67caafff4d4c5121cadac03941e"},
+    {file = "regex-2020.10.23-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:c30d8766a055c22e39dd7e1a4f98f6266169f2de05db737efe509c2fb9c8a3c8"},
+    {file = "regex-2020.10.23-cp36-cp36m-win32.whl", hash = "sha256:1a065e7a6a1b4aa851a0efa1a2579eabc765246b8b3a5fd74000aaa3134b8b4e"},
+    {file = "regex-2020.10.23-cp36-cp36m-win_amd64.whl", hash = "sha256:c95d514093b80e5309bdca5dd99e51bcf82c44043b57c34594d9d7556bd04d05"},
+    {file = "regex-2020.10.23-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:f4b1c65ee86bfbf7d0c3dfd90592a9e3d6e9ecd36c367c884094c050d4c35d04"},
+    {file = "regex-2020.10.23-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d62205f00f461fe8b24ade07499454a3b7adf3def1225e258b994e2215fd15c5"},
+    {file = "regex-2020.10.23-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:b706c70070eea03411b1761fff3a2675da28d042a1ab7d0863b3efe1faa125c9"},
+    {file = "regex-2020.10.23-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:d43cf21df524283daa80ecad551c306b7f52881c8d0fe4e3e76a96b626b6d8d8"},
+    {file = "regex-2020.10.23-cp37-cp37m-win32.whl", hash = "sha256:570e916a44a361d4e85f355aacd90e9113319c78ce3c2d098d2ddf9631b34505"},
+    {file = "regex-2020.10.23-cp37-cp37m-win_amd64.whl", hash = "sha256:1c447b0d108cddc69036b1b3910fac159f2b51fdeec7f13872e059b7bc932be1"},
+    {file = "regex-2020.10.23-cp38-cp38-manylinux1_i686.whl", hash = "sha256:8469377a437dbc31e480993399fd1fd15fe26f382dc04c51c9cb73e42965cc06"},
+    {file = "regex-2020.10.23-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:59d5c6302d22c16d59611a9fd53556554010db1d47e9df5df37be05007bebe75"},
+    {file = "regex-2020.10.23-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:a973d5a7a324e2a5230ad7c43f5e1383cac51ef4903bf274936a5634b724b531"},
+    {file = "regex-2020.10.23-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:97a023f97cddf00831ba04886d1596ef10f59b93df7f855856f037190936e868"},
+    {file = "regex-2020.10.23-cp38-cp38-win32.whl", hash = "sha256:e289a857dca3b35d3615c3a6a438622e20d1bf0abcb82c57d866c8d0be3f44c4"},
+    {file = "regex-2020.10.23-cp38-cp38-win_amd64.whl", hash = "sha256:0cb23ed0e327c18fb7eac61ebbb3180ebafed5b9b86ca2e15438201e5903b5dd"},
+    {file = "regex-2020.10.23-cp39-cp39-manylinux1_i686.whl", hash = "sha256:c53dc8ee3bb7b7e28ee9feb996a0c999137be6c1d3b02cb6b3c4cba4f9e5ed09"},
+    {file = "regex-2020.10.23-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:6a46eba253cedcbe8a6469f881f014f0a98819d99d341461630885139850e281"},
+    {file = "regex-2020.10.23-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:240509721a663836b611fa13ca1843079fc52d0b91ef3f92d9bba8da12e768a0"},
+    {file = "regex-2020.10.23-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:6f567df0601e9c7434958143aebea47a9c4b45434ea0ae0286a4ec19e9877169"},
+    {file = "regex-2020.10.23-cp39-cp39-win32.whl", hash = "sha256:bfd7a9fddd11d116a58b62ee6c502fd24cfe22a4792261f258f886aa41c2a899"},
+    {file = "regex-2020.10.23-cp39-cp39-win_amd64.whl", hash = "sha256:1a511470db3aa97432ac8c1bf014fcc6c9fbfd0f4b1313024d342549cf86bcd6"},
+    {file = "regex-2020.10.23.tar.gz", hash = "sha256:2278453c6a76280b38855a263198961938108ea2333ee145c5168c36b8e2b376"},
 ]
 requests = [
     {file = "requests-2.24.0-py2.py3-none-any.whl", hash = "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"},
     {file = "requests-2.24.0.tar.gz", hash = "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b"},
 ]
 scipy = [
-    {file = "scipy-1.5.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cca9fce15109a36a0a9f9cfc64f870f1c140cb235ddf27fe0328e6afb44dfed0"},
-    {file = "scipy-1.5.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:1c7564a4810c1cd77fcdee7fa726d7d39d4e2695ad252d7c86c3ea9d85b7fb8f"},
-    {file = "scipy-1.5.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:07e52b316b40a4f001667d1ad4eb5f2318738de34597bd91537851365b6c61f1"},
-    {file = "scipy-1.5.2-cp36-cp36m-win32.whl", hash = "sha256:d56b10d8ed72ec1be76bf10508446df60954f08a41c2d40778bc29a3a9ad9bce"},
-    {file = "scipy-1.5.2-cp36-cp36m-win_amd64.whl", hash = "sha256:8e28e74b97fc8d6aa0454989db3b5d36fc27e69cef39a7ee5eaf8174ca1123cb"},
-    {file = "scipy-1.5.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6e86c873fe1335d88b7a4bfa09d021f27a9e753758fd75f3f92d714aa4093768"},
-    {file = "scipy-1.5.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:a0afbb967fd2c98efad5f4c24439a640d39463282040a88e8e928db647d8ac3d"},
-    {file = "scipy-1.5.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:eecf40fa87eeda53e8e11d265ff2254729d04000cd40bae648e76ff268885d66"},
-    {file = "scipy-1.5.2-cp37-cp37m-win32.whl", hash = "sha256:315aa2165aca31375f4e26c230188db192ed901761390be908c9b21d8b07df62"},
-    {file = "scipy-1.5.2-cp37-cp37m-win_amd64.whl", hash = "sha256:ec5fe57e46828d034775b00cd625c4a7b5c7d2e354c3b258d820c6c72212a6ec"},
-    {file = "scipy-1.5.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fc98f3eac993b9bfdd392e675dfe19850cc8c7246a8fd2b42443e506344be7d9"},
-    {file = "scipy-1.5.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:a785409c0fa51764766840185a34f96a0a93527a0ff0230484d33a8ed085c8f8"},
-    {file = "scipy-1.5.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:0a0e9a4e58a4734c2eba917f834b25b7e3b6dc333901ce7784fd31aefbd37b2f"},
-    {file = "scipy-1.5.2-cp38-cp38-win32.whl", hash = "sha256:dac09281a0eacd59974e24525a3bc90fa39b4e95177e638a31b14db60d3fa806"},
-    {file = "scipy-1.5.2-cp38-cp38-win_amd64.whl", hash = "sha256:92eb04041d371fea828858e4fff182453c25ae3eaa8782d9b6c32b25857d23bc"},
-    {file = "scipy-1.5.2.tar.gz", hash = "sha256:066c513d90eb3fd7567a9e150828d39111ebd88d3e924cdfc9f8ce19ab6f90c9"},
+    {file = "scipy-1.5.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f574558f1b774864516f3c3fe072ebc90a29186f49b720f60ed339294b7f32ac"},
+    {file = "scipy-1.5.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:e527c9221b6494bcd06a17f9f16874406b32121385f9ab353b8a9545be458f0b"},
+    {file = "scipy-1.5.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:b9751b39c52a3fa59312bd2e1f40144ee26b51404db5d2f0d5259c511ff6f614"},
+    {file = "scipy-1.5.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:d5e3cc60868f396b78fc881d2c76460febccfe90f6d2f082b9952265c79a8788"},
+    {file = "scipy-1.5.3-cp36-cp36m-win32.whl", hash = "sha256:1fee28b6641ecbff6e80fe7788e50f50c5576157d278fa40f36c851940eb0aff"},
+    {file = "scipy-1.5.3-cp36-cp36m-win_amd64.whl", hash = "sha256:ffcbd331f1ffa82e22f1d408e93c37463c9a83088243158635baec61983aaacf"},
+    {file = "scipy-1.5.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:07b083128beae040f1129bd8a82b01804f5e716a7fd2962c1053fa683433e4ab"},
+    {file = "scipy-1.5.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:e2602f79c85924e4486f684aa9bbab74afff90606100db88d0785a0088be7edb"},
+    {file = "scipy-1.5.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:aebb69bcdec209d874fc4b0c7ac36f509d50418a431c1422465fa34c2c0143ea"},
+    {file = "scipy-1.5.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:bc0e63daf43bf052aefbbd6c5424bc03f629d115ece828e87303a0bcc04a37e4"},
+    {file = "scipy-1.5.3-cp37-cp37m-win32.whl", hash = "sha256:8cc5c39ed287a8b52a5509cd6680af078a40b0e010e2657eca01ffbfec929468"},
+    {file = "scipy-1.5.3-cp37-cp37m-win_amd64.whl", hash = "sha256:0edd67e8a00903aaf7a29c968555a2e27c5a69fea9d1dcfffda80614281a884f"},
+    {file = "scipy-1.5.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:66ec29348444ed6e8a14c9adc2de65e74a8fc526dc2c770741725464488ede1f"},
+    {file = "scipy-1.5.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:12fdcbfa56cac926a0a9364a30cbf4ad03c2c7b59f75b14234656a5e4fd52bf3"},
+    {file = "scipy-1.5.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:a1a13858b10d41beb0413c4378462b43eafef88a1948d286cb357eadc0aec024"},
+    {file = "scipy-1.5.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:5163200ab14fd2b83aba8f0c4ddcc1fa982a43192867264ab0f4c8065fd10d17"},
+    {file = "scipy-1.5.3-cp38-cp38-win32.whl", hash = "sha256:33e6a7439f43f37d4c1135bc95bcd490ffeac6ef4b374892c7005ce2c729cf4a"},
+    {file = "scipy-1.5.3-cp38-cp38-win_amd64.whl", hash = "sha256:a3db1fe7c6cb29ca02b14c9141151ebafd11e06ffb6da8ecd330eee5c8283a8a"},
+    {file = "scipy-1.5.3.tar.gz", hash = "sha256:ddae76784574cc4c172f3d5edd7308be16078dd3b977e8746860c76c195fa707"},
 ]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
@@ -1136,8 +1144,8 @@ typed-ast = [
     {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
 ]
 urllib3 = [
-    {file = "urllib3-1.25.10-py2.py3-none-any.whl", hash = "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"},
-    {file = "urllib3-1.25.10.tar.gz", hash = "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a"},
+    {file = "urllib3-1.25.11-py2.py3-none-any.whl", hash = "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"},
+    {file = "urllib3-1.25.11.tar.gz", hash = "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
@@ -1148,6 +1156,6 @@ wheel = [
     {file = "wheel-0.35.1.tar.gz", hash = "sha256:99a22d87add3f634ff917310a3d87e499f19e663413a52eb9232c447aa646c9f"},
 ]
 zipp = [
-    {file = "zipp-3.2.0-py3-none-any.whl", hash = "sha256:43f4fa8d8bb313e65d8323a3952ef8756bf40f9a5c3ea7334be23ee4ec8278b6"},
-    {file = "zipp-3.2.0.tar.gz", hash = "sha256:b52f22895f4cfce194bc8172f3819ee8de7540aa6d873535a8668b730b8b411f"},
+    {file = "zipp-3.4.0-py3-none-any.whl", hash = "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108"},
+    {file = "zipp-3.4.0.tar.gz", hash = "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ colorama = "^0.4.3"
 numpy = "^1.16"
 opt_einsum = "^3.1.0"
 prettyprinter = "^0.18.0"
-ovld = "^0.2.3"
+ovld = "^0.2.6"
 
 [tool.poetry.dev-dependencies]
 black = "~19.10b0"

--- a/tests/compile/test_cconv.py
+++ b/tests/compile/test_cconv.py
@@ -16,8 +16,8 @@ def step_cconv(resources, graph, use_llift):
 
 
 cconv_pipeline = scalar_debug_pipeline.with_steps(
-    steps.step_parse, steps.step_resolve, step_cconv, steps.step_debug_export,
-)
+    steps.step_parse, steps.step_copy, step_cconv, steps.step_debug_export,
+).configure(preresolve=True)
 
 
 def check_no_free_variables(root):

--- a/tests/compile/test_cconv.py
+++ b/tests/compile/test_cconv.py
@@ -16,8 +16,8 @@ def step_cconv(resources, graph, use_llift):
 
 
 cconv_pipeline = scalar_debug_pipeline.with_steps(
-    steps.step_parse, steps.step_copy, step_cconv, steps.step_debug_export,
-).configure(preresolve=True)
+    steps.step_parse, steps.step_copy, step_cconv, steps.step_debug_export
+)
 
 
 def check_no_free_variables(root):

--- a/tests/opt/test_opt.py
+++ b/tests/opt/test_opt.py
@@ -23,7 +23,6 @@ V = var(lambda n: n.is_constant())
 parse = (
     scalar_pipeline.configure(
         {
-            "preresolve": True,
             "convert.object_map": Merge(
                 {
                     operations.getitem: prim.tuple_getitem,
@@ -38,10 +37,7 @@ parse = (
 
 
 specialize = scalar_pipeline.configure(
-    {
-        "convert.object_map": Merge({operations.getitem: prim.tuple_getitem}),
-        "preresolve": True,
-    }
+    {"convert.object_map": Merge({operations.getitem: prim.tuple_getitem})}
 ).with_steps(steps.step_parse, steps.step_infer, steps.step_specialize)
 
 

--- a/tests/opt/test_opt.py
+++ b/tests/opt/test_opt.py
@@ -23,27 +23,26 @@ V = var(lambda n: n.is_constant())
 parse = (
     scalar_pipeline.configure(
         {
+            "preresolve": True,
             "convert.object_map": Merge(
                 {
                     operations.getitem: prim.tuple_getitem,
                     operations.user_switch: prim.switch,
                 }
-            )
+            ),
         }
     )
-    .with_steps(steps.step_parse, steps.step_resolve,)
+    .with_steps(steps.step_parse, steps.step_copy)
     .make_transformer("input", "graph")
 )
 
 
 specialize = scalar_pipeline.configure(
-    {"convert.object_map": Merge({operations.getitem: prim.tuple_getitem})}
-).with_steps(
-    steps.step_parse,
-    steps.step_resolve,
-    steps.step_infer,
-    steps.step_specialize,
-)
+    {
+        "convert.object_map": Merge({operations.getitem: prim.tuple_getitem}),
+        "preresolve": True,
+    }
+).with_steps(steps.step_parse, steps.step_infer, steps.step_specialize)
 
 
 # We will optimize patterns of these fake primitives

--- a/tests/opt/test_rewrite.py
+++ b/tests/opt/test_rewrite.py
@@ -14,13 +14,9 @@ def step_rmunused(resources):
         pass
 
 
-rmunused = (
-    scalar_pipeline.with_steps(
-        steps.step_parse, steps.step_copy, step_rmunused,
-    )
-    .configure(preresolve=True)
-    .make_transformer("input", "graph")
-)
+rmunused = scalar_pipeline.with_steps(
+    steps.step_parse, steps.step_copy, step_rmunused,
+).make_transformer("input", "graph")
 
 
 def test_rmunused_simple():

--- a/tests/opt/test_rewrite.py
+++ b/tests/opt/test_rewrite.py
@@ -14,9 +14,13 @@ def step_rmunused(resources):
         pass
 
 
-rmunused = scalar_pipeline.with_steps(
-    steps.step_parse, steps.step_resolve, step_rmunused,
-).make_transformer("input", "graph")
+rmunused = (
+    scalar_pipeline.with_steps(
+        steps.step_parse, steps.step_copy, step_rmunused,
+    )
+    .configure(preresolve=True)
+    .make_transformer("input", "graph")
+)
 
 
 def test_rmunused_simple():
@@ -176,9 +180,13 @@ def test_rmunused_switch_edge_case():
 #######################
 
 
-llift = scalar_pipeline.with_steps(
-    steps.step_parse, steps.step_resolve, steps.step_llift,
-).make_transformer("input", "graph")
+llift = (
+    scalar_pipeline.with_steps(
+        steps.step_parse, steps.step_copy, steps.step_llift,
+    )
+    .configure(preresolve=True)
+    .make_transformer("input", "graph")
+)
 
 
 def test_lambda_lift_simple():

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -12,7 +12,7 @@ from myia.operations import array_map
 from myia.pipeline import standard_pipeline, steps
 from myia.testing.multitest import eqtest
 
-pipeline2 = standard_pipeline.insert_after(steps.step_parse, steps.step_resolve)
+pipeline2 = standard_pipeline.configure(preresolve=True)
 
 
 @pytest.fixture(

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -9,7 +9,7 @@ from myia import myia
 from myia.compile.backends import get_backend_names
 from myia.lib import core
 from myia.operations import array_map
-from myia.pipeline import standard_pipeline, steps
+from myia.pipeline import standard_pipeline
 from myia.testing.multitest import eqtest
 
 pipeline2 = standard_pipeline.configure(preresolve=True)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -134,11 +134,13 @@ def _to_i64(x: Number) -> Int[64]:
     return int(x)
 
 
-infer_pipeline = scalar_pipeline.with_steps(steps.step_parse, steps.step_infer)
+infer_pipeline = scalar_pipeline.with_steps(
+    steps.step_parse, steps.step_infer
+).configure(preresolve=False)
 
 infer_pipeline_std = standard_pipeline.with_steps(
     steps.step_parse, steps.step_infer
-)
+).configure(preresolve=False)
 
 
 infer_standard = mt_infer.configure(pipeline=infer_pipeline_std)

--- a/tests/test_lang.py
+++ b/tests/test_lang.py
@@ -6,10 +6,10 @@ from myia.testing.multitest import mt, run, run_debug
 
 lang_pipeline = scalar_debug_pipeline.with_steps(
     steps.step_parse,
-    steps.step_resolve,
+    steps.step_copy,
     steps.step_llift,
     steps.step_debug_export,
-)
+).configure(preresolve=True)
 
 
 run_lang = run.configure(pipeline=lang_pipeline, backend=False)

--- a/tests/test_lang.py
+++ b/tests/test_lang.py
@@ -9,7 +9,7 @@ lang_pipeline = scalar_debug_pipeline.with_steps(
     steps.step_copy,
     steps.step_llift,
     steps.step_debug_export,
-).configure(preresolve=True)
+)
 
 
 run_lang = run.configure(pipeline=lang_pipeline, backend=False)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -143,8 +143,10 @@ def test_forward_reference():
         return h()
 
     # No resolve
-    parse2 = scalar_pipeline.with_steps(steps.step_parse).make_transformer(
-        "input", "graph"
+    parse2 = (
+        scalar_pipeline.with_steps(steps.step_parse)
+        .configure(preresolve=False)
+        .make_transformer("input", "graph")
     )
 
     parse2(g)


### PR DESCRIPTION
* `step_resolve` is replaced by the `preresolve` flag which triggers resolve_globals in `convert`.
* Resources now instantiates the resources eagerly instead of lazily using an override on `__getattr__`.
* Upgrade ovld 0.2.3 -> 0.2.6
