### PR TITLE
Rewrite convert

### DIFF
--- a/debug/bupdb.py
+++ b/debug/bupdb.py
@@ -1,0 +1,26 @@
+import os
+import pdb
+from buche import BucheDb
+
+
+global_interactor = None
+
+
+if os.environ.get("BUCHE"):
+    class BuDb(BucheDb):
+        def __init__(self):
+            super().__init__(None)
+            self.interactor = global_interactor
+
+        def set_trace(self, frame=None):
+            self.interactor.show(synchronous=True)
+            self.repl = self.interactor.repl
+            super().set_trace(frame)
+
+        def interaction(self, frame, tb):
+            self.interactor.show(synchronous=True)
+            self.repl = self.interactor.repl
+            super().interaction(frame, tb)
+
+else:
+    BuDb = pdb.Pdb

--- a/debug/bupdb.py
+++ b/debug/bupdb.py
@@ -1,7 +1,7 @@
 import os
 import pdb
-from buche import BucheDb
 
+from buche import BucheDb
 
 global_interactor = None
 

--- a/debug/bupdb.py
+++ b/debug/bupdb.py
@@ -7,6 +7,7 @@ global_interactor = None
 
 
 if os.environ.get("BUCHE"):
+
     class BuDb(BucheDb):
         def __init__(self):
             super().__init__(None)
@@ -21,6 +22,7 @@ if os.environ.get("BUCHE"):
             self.interactor.show(synchronous=True)
             self.repl = self.interactor.repl
             super().interaction(frame, tb)
+
 
 else:
     BuDb = pdb.Pdb

--- a/debug/butest.py
+++ b/debug/butest.py
@@ -7,8 +7,9 @@ from dataclasses import dataclass
 from itertools import count
 
 import pytest
-from buche import BucheDb, CodeGlobals, H, Reader, Repl, buche
+from buche import CodeGlobals, H, Reader, Repl, buche
 
+from . import bupdb
 from .gprint import mcss
 
 template_path = f"{os.path.dirname(__file__)}/test_template.html"
@@ -231,23 +232,8 @@ def pytest_runtest_setup(item):
     if id in _infos:
         raise Exception(id)
     interactor = ReportInteractor(id, item)
+    bupdb.global_interactor = interactor
     _infos[id] = Information(item, None, interactor)
-
-    class Db(BucheDb):
-        def __init__(self, skip=None):
-            super().__init__(None, skip=skip)
-
-        def set_trace(self, frame=None):
-            interactor.show(synchronous=True)
-            self.repl = interactor.repl
-            super().set_trace(frame)
-
-        def interaction(self, frame, tb):
-            interactor.show(synchronous=True)
-            self.repl = interactor.repl
-            super().interaction(frame, tb)
-
-    pytest.__pytestPDB._pdb_cls = Db
 
 
 def pytest_report_teststatus(report):

--- a/myia/abstract/infer.py
+++ b/myia/abstract/infer.py
@@ -336,7 +336,9 @@ class InferenceEngine(metaclass=OvldMC):
 
     async def infer_constant(self, ctref):
         """Infer the type of a ref of a Constant node."""
-        if getattr(ctref.node, "_converted", False):
+        cvt = self.resources.convert(ctref.node.value)
+
+        if cvt is ctref.node.value:
             return to_abstract(
                 ctref.node.value,
                 context=ctref.context,
@@ -345,8 +347,9 @@ class InferenceEngine(metaclass=OvldMC):
             )
 
         else:
-            newct = Constant(self.resources.convert(ctref.node.value))
-            newct._converted = True
+            # The current Constant's value is not compatible with the
+            # pipeline so we redirect to a correct one.
+            newct = Constant(cvt)
             new = self.ref(newct, ctref.context)
             return await self.reroute(ctref, new)
 

--- a/myia/operations/macro_universal.py
+++ b/myia/operations/macro_universal.py
@@ -4,6 +4,7 @@ from ovld import ovld
 
 from .. import lib, operations
 from ..lib import Constant, MetaGraph, core, macro
+from ..utils import untested
 
 
 @core(universal=True)
@@ -76,7 +77,8 @@ async def universal(info, fn):
         return Constant(StatePassthrough(fn.node.value))
 
     else:
-        return info.graph.apply(universal_wrapper, fn.node)
+        with untested():
+            return info.graph.apply(universal_wrapper, fn.node)
 
 
 __operation_defaults__ = {

--- a/myia/opt/lib.py
+++ b/myia/opt/lib.py
@@ -721,8 +721,9 @@ def force_constants(resources, node, equiv):
         val = build_value(node.abstract)
     except Exception:
         return None
-    if val is DEAD:
-        return None
+    with untested():
+        if val is DEAD:
+            return None
     ct = Constant(val)
     ct.abstract = node.abstract
     return ct

--- a/myia_frontend_pytorch/myia_frontend_pytorch/pytorch.py
+++ b/myia_frontend_pytorch/myia_frontend_pytorch/pytorch.py
@@ -273,8 +273,8 @@ def _to_abstract(self, v: torch.nn.Parameter, alias_map={}, **kwargs):
 
 
 @default_convert.register  # noqa: F811
-def _default_convert(env, x: torch.dtype):
-    return default_convert(env, pytorch_dtype_to_type(x))
+def _default_convert(env, x: torch.dtype, manage):
+    return env(pytorch_dtype_to_type(x), manage)
 
 
 __all__ = ["pytorch_dtype_to_type"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --capture=sys
+addopts = --capture=sys --pdbcls=debug.bupdb:BuDb
 python_files = test_*.py examples/*.py
 markers =
   gpu: Test that requires a GPU.


### PR DESCRIPTION
This rewrites the ConversionResource and infer_constant in the inferrer to be simpler. The tests seem to take 10-20% less time to execute overall with these changes. For example, for the RNN, `step_infer` is about 30% faster because it doesn't reroute to new constants when the constants already contain converted value (also, it doesn't set a `_converted` field in nodes anymore, which had always been a dirty hack).

I also fixed the debugger when using buche.
