### PR TITLE
Fix for intern WeakValueDirectory leak

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -52,12 +52,21 @@ def pytest_addoption(parser):
         default=False,
         help="Import Myia debug functions",
     )
+    parser.addoption(
+        "--bw",
+        action="store",
+        dest="breakword",
+        default=None,
+        help="Use the given breakword",
+    )
 
 
 def pytest_configure(config):
     listener_pairs = []
     if config.option.usepdb:
         os.environ["MYIA_PYTEST_USE_PDB"] = "1"
+    if config.option.breakword:
+        os.environ["BREAKWORD"] = config.option.breakword
     if config.option.do_inject:
         from debug import do_inject  # noqa
     if config.option.tracer:

--- a/debug/bupdb.py
+++ b/debug/bupdb.py
@@ -9,7 +9,7 @@ global_interactor = None
 if os.environ.get("BUCHE"):
 
     class BuDb(BucheDb):
-        def __init__(self):
+        def __init__(self, **kw):
             super().__init__(None)
             self.interactor = global_interactor
 

--- a/debug/gprint.py
+++ b/debug/gprint.py
@@ -1234,17 +1234,6 @@ class _AbstractScalar:
         )
 
 
-@mixin(abstract.AbstractFunction)
-class _AbstractFunction:
-    def __hrepr__(self, H, hrepr):
-        v = self.values[VALUE]
-        return hrepr.stdrepr_iterable(
-            v if isinstance(v, Possibilities) else [v],
-            before="★Function",
-            cls="abstract",
-        )
-
-
 @mixin(abstract.AbstractJTagged)
 class _AbstractJTagged:
     def __hrepr__(self, H, hrepr):
@@ -1344,7 +1333,7 @@ class _AbstractTuple:
         )
 
 
-@mixin(abstract.AbstractUnion)
+@mixin(abstract.AbstractChoices)
 class _AbstractUnion:
     def __hrepr__(self, H, hrepr):
         return hrepr.stdrepr_iterable(

--- a/debug/gprint.py
+++ b/debug/gprint.py
@@ -1234,6 +1234,17 @@ class _AbstractScalar:
         )
 
 
+@mixin(abstract.AbstractFunction)
+class _AbstractFunction:
+    def __hrepr__(self, H, hrepr):
+        v = self.values[VALUE]
+        return hrepr.stdrepr_iterable(
+            v if isinstance(v, Possibilities) else [v],
+            before="★Function",
+            cls="abstract",
+        )
+
+
 @mixin(abstract.AbstractJTagged)
 class _AbstractJTagged:
     def __hrepr__(self, H, hrepr):
@@ -1333,7 +1344,7 @@ class _AbstractTuple:
         )
 
 
-@mixin(abstract.AbstractChoices)
+@mixin(abstract.AbstractUnion)
 class _AbstractUnion:
     def __hrepr__(self, H, hrepr):
         return hrepr.stdrepr_iterable(

--- a/myia/utils/intern.py
+++ b/myia/utils/intern.py
@@ -1,7 +1,7 @@
 """Tools to intern the instances of certain classes."""
 
-from collections import defaultdict, deque
 import weakref
+from collections import defaultdict, deque
 
 from .misc import Named
 

--- a/myia/utils/intern.py
+++ b/myia/utils/intern.py
@@ -1,5 +1,6 @@
 """Tools to intern the instances of certain classes."""
 
+from collections import deque
 import weakref
 
 from .misc import Named
@@ -144,8 +145,6 @@ def deep_eqkey(obj, path=frozenset()):
 
 
 def _bfs(obj):
-    from collections import deque
-
     queue = deque()
     queue.append(obj)
 

--- a/tests/utils/test_intern.py
+++ b/tests/utils/test_intern.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 import gc
+import operator
 
 import pytest
 
@@ -144,7 +145,7 @@ class C:
 
 def test_weakrefs():
     c = C()
-    store = CanonStore()
+    store = CanonStore(hashfn=hash, eqfn=operator.eq)
     store.set_canonical(c)
     store.gc()
     assert len(store.hashes) == 1

--- a/tests/utils/test_intern.py
+++ b/tests/utils/test_intern.py
@@ -1,9 +1,11 @@
 from dataclasses import dataclass
+import gc
 
 import pytest
 
 from myia.utils.intern import (
     AttrEK,
+    CanonStore,
     IncompleteException,
     Interned,
     eq,
@@ -13,7 +15,7 @@ from myia.utils.intern import (
 )
 
 
-@dataclass
+@dataclass(eq=False)
 class Point(Interned):
     x: object
     y: object
@@ -134,3 +136,19 @@ def test_canonical():
     assert p1 is p2
     assert p1.x is p3.x
     assert p2.x is p3.x
+
+
+class C:
+    pass
+
+
+def test_weakrefs():
+    c = C()
+    store = CanonStore()
+    store.set_canonical(c)
+    store.gc()
+    assert len(store.hashes) == 1
+    del c
+    gc.collect()
+    store.gc()
+    assert len(store.hashes) == 0

--- a/tests/utils/test_intern.py
+++ b/tests/utils/test_intern.py
@@ -1,6 +1,6 @@
-from dataclasses import dataclass
 import gc
 import operator
+from dataclasses import dataclass
 
 import pytest
 


### PR DESCRIPTION
This fixes a leak in the WeakValueDirectory used in intern.py: the keys in that directory are Wrapper instances that themselves contain a weakref to the value which is used in eq/hash computations. This seems to cause an interference that prevents collection of dead values. I have written a new class, `CanonStore`, that fixes this issue.

It doesn't seem to change the test suite performance much if at all. I tried to find ways to reduce the overhead of intern besides that, but nothing really worked, so that's that.

Oh, I also added a `--bw` option for debugging with breakword more easily.
