### PR TITLE
Improve convert_type for constants in all backends.

### DIFF
--- a/myia/abstract/to_abstract.py
+++ b/myia/abstract/to_abstract.py
@@ -412,6 +412,11 @@ def pytype_to_abstract(main: RandomStateWrapper, args):
 
 
 @ovld  # noqa: F811
+def pytype_to_abstract(main: HandleInstance, args):
+    return AbstractHandle(None)
+
+
+@ovld  # noqa: F811
 def pytype_to_abstract(main: dict, args):
     if args is None:
         # Just provide an empty dict as entries.

--- a/myia/simplify_types.py
+++ b/myia/simplify_types.py
@@ -491,6 +491,11 @@ def from_canonical(self, arg, orig_t: AbstractUnion):
         raise AssertionError(f"Badly formed TaggedValue")
 
 
+@ovld  # noqa: F811
+def from_canonical(self, arg, orig_t: AbstractType):
+    return arg
+
+
 __consolidate__ = True
 __all__ = [
     "from_canonical",

--- a/myia/simplify_types.py
+++ b/myia/simplify_types.py
@@ -493,7 +493,10 @@ def from_canonical(self, arg, orig_t: AbstractUnion):
 
 @ovld  # noqa: F811
 def from_canonical(self, arg, orig_t: AbstractType):
-    return arg
+    if isinstance(orig_t.element, AbstractHandle):
+        return HandleInstance
+    else:
+        return arg
 
 
 __consolidate__ = True

--- a/myia/simplify_types.py
+++ b/myia/simplify_types.py
@@ -493,10 +493,7 @@ def from_canonical(self, arg, orig_t: AbstractUnion):
 
 @ovld  # noqa: F811
 def from_canonical(self, arg, orig_t: AbstractType):
-    if isinstance(orig_t.element, AbstractHandle):
-        return HandleInstance
-    else:
-        return arg
+    return arg
 
 
 __consolidate__ = True

--- a/myia_backend_python/myia_backend_python/python.py
+++ b/myia_backend_python/myia_backend_python/python.py
@@ -442,7 +442,7 @@ class PythonConstantConverter(_PythonConverter):
 
     def convert_type(self, v, t):
         # Return type name as a string.
-        if isinstance(v, AbstractHandle):
+        if isinstance(t.element, AbstractHandle):
             return "HandleInstance"
         else:
             myia_type = t.element.xtype()

--- a/myia_backend_python/myia_backend_python/python.py
+++ b/myia_backend_python/myia_backend_python/python.py
@@ -442,13 +442,14 @@ class PythonConstantConverter(_PythonConverter):
 
     def convert_type(self, v, t):
         # Return type name as a string.
-        myia_type = t.element.xtype()
-        if myia_type is None:
-            if isinstance(v, AbstractHandle):
-                return "HandleInstance"
-        if myia_type is Tuple:
-            return "tuple"
-        return f"np.{type_to_np_dtype(myia_type)}"
+        if isinstance(v, AbstractHandle):
+            return "HandleInstance"
+        else:
+            myia_type = t.element.xtype()
+            if myia_type is Tuple:
+                return "tuple"
+            else:
+                return f"np.{type_to_np_dtype(myia_type)}"
 
     def convert_handle(self, v, t):
         return f"HandleInstance({self(v.state, v.abstract or to_abstract(v.state))})"

--- a/myia_backend_python/myia_backend_python/python.py
+++ b/myia_backend_python/myia_backend_python/python.py
@@ -13,9 +13,9 @@ from myia.compile.transform import convert_grad, get_prim_graph
 from myia.debug.label import NodeLabeler
 from myia.graph_utils import toposort
 from myia.ir import Graph, manage
-from myia.lib import ANYTHING, AbstractArray, AbstractTuple
+from myia.lib import ANYTHING, AbstractArray, AbstractHandle, AbstractTuple
 from myia.operations import Primitive, primitives as P
-from myia.xtype import type_to_np_dtype
+from myia.xtype import Tuple, type_to_np_dtype
 
 
 def python_array_map(c, fn, *arrays):
@@ -441,9 +441,14 @@ class PythonConstantConverter(_PythonConverter):
         return "()"
 
     def convert_type(self, v, t):
-        myia_type = t.element.xtype()
         # Return type name as a string.
-        return f"'{type_to_np_dtype(myia_type)}'"
+        myia_type = t.element.xtype()
+        if myia_type is None:
+            if isinstance(v, AbstractHandle):
+                return "HandleInstance"
+        if myia_type is Tuple:
+            return "tuple"
+        return f"np.{type_to_np_dtype(myia_type)}"
 
     def convert_handle(self, v, t):
         return f"HandleInstance({self(v.state, v.abstract or to_abstract(v.state))})"

--- a/myia_backend_pytorch/myia_backend_pytorch/pytorch.py
+++ b/myia_backend_pytorch/myia_backend_pytorch/pytorch.py
@@ -10,6 +10,7 @@ from myia.compile.transform import CompileGraphs, nonlinear_ops
 from myia.ir import manage
 from myia.operations import Primitive, primitives as P
 from myia.utils import RandomStateWrapper, TaggedValue, untested
+from myia.utils.universe import HandleInstance
 from myia.xtype import Bool, Float, Int, UInt, type_to_np_dtype
 
 from .pytorch_conv_grad import conv2d_weight
@@ -583,10 +584,14 @@ class PyTorchBackend(Backend):
         elif isinstance(t, abstract.AbstractRandomState):
             return RandomStateWrapper(self.to_numpy(v))
         elif isinstance(t, abstract.AbstractType):
-            myia_type = t.element.xtype()
-            if myia_type in _type_map:
-                return getattr(np, type_to_np_dtype(myia_type))
-            return v
+            if isinstance(t.element, abstract.AbstractHandle):
+                return HandleInstance
+            else:
+                myia_type = t.element.xtype()
+                if myia_type in _type_map:
+                    return getattr(np, type_to_np_dtype(myia_type))
+                else:
+                    return v
         else:
             raise NotImplementedError(f"Don't know what to do for {t}")
 

--- a/myia_backend_relay/myia_backend_relay/relay.py
+++ b/myia_backend_relay/myia_backend_relay/relay.py
@@ -1012,13 +1012,14 @@ class RelayOutputConverter(Converter):
         return RandomStateWrapper(tuple(el.asnumpy().item() for el in v))
 
     def convert_type(self, v, t):
-        myia_type = t.element.xtype()
-        if myia_type is None:
-            if isinstance(v, AbstractHandle):
-                return HandleInstance
-        if myia_type is Tuple:
-            return tuple
-        return getattr(np, type_to_np_dtype(myia_type))
+        if isinstance(t.element, AbstractHandle):
+            return HandleInstance
+        else:
+            myia_type = t.element.xtype()
+            if myia_type is Tuple:
+                return tuple
+            else:
+                return getattr(np, type_to_np_dtype(myia_type))
 
 
 def make_handle_to_make_cell(g):

--- a/myia_backend_relay/myia_backend_relay/relay.py
+++ b/myia_backend_relay/myia_backend_relay/relay.py
@@ -8,7 +8,7 @@ from tvm import relay
 from tvm.relay import adt
 from tvm.relay.backend import interpreter
 
-from myia.abstract import AbstractTaggedUnion
+from myia.abstract import AbstractHandle, AbstractTaggedUnion
 from myia.compile.backends import Backend, Converter
 from myia.compile.transform import convert_grad, get_prim_graph, return_handles
 from myia.graph_utils import toposort
@@ -17,7 +17,7 @@ from myia.operations import Primitive, primitives as P
 from myia.operations.primitives import BackendPrimitive
 from myia.utils import HandleInstance, RandomStateWrapper, TaggedValue
 from myia.utils.variables import X, Y
-from myia.xtype import type_to_np_dtype, u32
+from myia.xtype import Tuple, type_to_np_dtype, u32
 
 from . import relay_philox
 from .relay_helpers import (
@@ -778,6 +778,12 @@ class RelayConstantConverter(Converter):
         conv_val = self(v.value, real_t)
         return ctr(conv_val)
 
+    def convert_type(self, v, t):
+        # abstract type will be replaced with an integer type as placeholder
+        # (see to_relay_type(AbstractType), so we must return an integer
+        # of same type here.
+        return relay.const(0, "int32")
+
 
 class CompileGraph:
     """Step to convert a myia graph to a relay graph.
@@ -1004,6 +1010,15 @@ class RelayOutputConverter(Converter):
 
     def convert_random_state(self, v, t):
         return RandomStateWrapper(tuple(el.asnumpy().item() for el in v))
+
+    def convert_type(self, v, t):
+        myia_type = t.element.xtype()
+        if myia_type is None:
+            if isinstance(v, AbstractHandle):
+                return HandleInstance
+        if myia_type is Tuple:
+            return tuple
+        return getattr(np, type_to_np_dtype(myia_type))
 
 
 def make_handle_to_make_cell(g):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -437,3 +437,17 @@ def test_env_tracer(monkeypatch, backend):
 
     assert _flag1[0] is True
     assert _flag2[0] is True
+
+
+@bt()
+def test_convert_type(backend):
+    @myia(backend=backend)
+    def f(v):
+        return tuple
+
+    @myia(backend=backend)
+    def g():
+        return np.float16
+
+    assert f((1, 2)) is tuple
+    assert g() is np.float16

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -442,12 +442,12 @@ def test_env_tracer(monkeypatch, backend):
 @bt()
 def test_convert_type(backend):
     @myia(backend=backend)
-    def f(v):
+    def f():
         return tuple
 
     @myia(backend=backend)
     def g():
         return np.float16
 
-    assert f((1, 2)) is tuple
+    assert f() is tuple
     assert g() is np.float16

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -449,5 +449,10 @@ def test_convert_type(backend):
     def g():
         return np.float16
 
+    @myia(backend=backend)
+    def h():
+        return HandleInstance
+
     assert f() is tuple
     assert g() is np.float16
+    assert h() is HandleInstance


### PR DESCRIPTION
Hi @breuleux this is a small PR to improve `convert_type` for constants in backends.

Initially, I should have made it only for Python backend, but I was unable to write a good test, because either raw types are deleted from graph if not used, or generated compilation error because they are not handled by all backends.

So, I try to improve type support (at least as constant) in all backend, and I add a simple test that return a type.