### PR TITLE
Fix relation order in info.Labeler

### DIFF
--- a/myia/compile/backends/python/code_generator.py
+++ b/myia/compile/backends/python/code_generator.py
@@ -117,6 +117,7 @@ class NodeLabeler:
             name_generator=self._name_generator,
             disambiguator=self._disambiguator,
             object_describer=self._object_describer,
+            reverse_order=True,
         )
 
     def __call__(self, node):
@@ -130,7 +131,7 @@ class NodeLabeler:
 
     @classmethod
     def _relation_translator(cls, rel):
-        return f"{rel}_"
+        return ["_", rel]
 
     @classmethod
     def _name_generator(cls, identifier):

--- a/myia/ir/print.py
+++ b/myia/ir/print.py
@@ -130,7 +130,9 @@ class _NodeCache:
 
     def __init__(self):
         self.lbl = Labeler(
-            disambiguator=_disambiguator, object_describer=_constant_describer
+            disambiguator=_disambiguator,
+            object_describer=_constant_describer,
+            reverse_order=True,
         )
 
     def __call__(self, node):

--- a/myia/utils/info.py
+++ b/myia/utils/info.py
@@ -278,7 +278,8 @@ class Labeler:
         label.
         """
         chain = info.get_chain()
-        first = chain[-1][0]
+        chain.reverse()
+        first = chain[0][0]
         if first not in self.namecache:
             rval = first.name
             if rval is None:
@@ -287,7 +288,7 @@ class Labeler:
         else:
             rval = self.namecache[first]
 
-        for info, relation in chain[:-1]:
+        for info, relation in chain[1:]:
             rval = f"{self.relation_translator(relation)}{rval}"
         return rval
 

--- a/tests/utils/test_info.py
+++ b/tests/utils/test_info.py
@@ -152,6 +152,18 @@ def test_labeler(manyinfo):
     m = manyinfo
     lbl = Labeler()
     assert lbl(m.x1) == "toyota"
+    assert lbl(m.x2) == "toyota:apple"
+    assert lbl(m.x2c) == "toyota:apple//2"
+    assert lbl(m.x2b) == "toyota:apple//3"
+    assert lbl(m.x3) == "toyota:apple:blueberry"
+    assert lbl(m.x4) == "toyota:apple:blueberry:corn"
+    assert lbl(m.x4b) == "toyota:apple:blueberry:corn//2"
+
+
+def test_labeler_reverse(manyinfo):
+    m = manyinfo
+    lbl = Labeler(reverse_order=True)
+    assert lbl(m.x1) == "toyota"
     assert lbl(m.x2) == "apple:toyota"
     assert lbl(m.x2c) == "apple:toyota//2"
     assert lbl(m.x2b) == "apple:toyota//3"
@@ -168,7 +180,7 @@ def test_labeler_abbrv(manyinfo):
             "corn": "#",
         }
     )
-    lbl = Labeler(relation_translator=tr)
+    lbl = Labeler(relation_translator=tr, reverse_order=True)
     assert lbl(m.x1) == "toyota"
     assert lbl(m.x2) == "&toyota"
     assert lbl(m.x2c) == "&toyota//2"
@@ -186,7 +198,7 @@ def test_labeler_nonames():
 
     lbl = Labeler()
     assert lbl(x1) == "#1"
-    assert lbl(x2) == "assassin:#1"
+    assert lbl(x2) == "#1:assassin"
     assert lbl(x3) == "#2"
 
     o = Ob()

--- a/tests/utils/test_info.py
+++ b/tests/utils/test_info.py
@@ -155,9 +155,9 @@ def test_labeler(manyinfo):
     assert lbl(m.x2) == "apple:toyota"
     assert lbl(m.x2c) == "apple:toyota//2"
     assert lbl(m.x2b) == "apple:toyota//3"
-    assert lbl(m.x3) == "apple:blueberry:toyota"
-    assert lbl(m.x4) == "apple:blueberry:corn:toyota"
-    assert lbl(m.x4b) == "apple:blueberry:corn:toyota//2"
+    assert lbl(m.x3) == "blueberry:apple:toyota"
+    assert lbl(m.x4) == "corn:blueberry:apple:toyota"
+    assert lbl(m.x4b) == "corn:blueberry:apple:toyota//2"
 
 
 def test_labeler_abbrv(manyinfo):
@@ -173,9 +173,9 @@ def test_labeler_abbrv(manyinfo):
     assert lbl(m.x2) == "&toyota"
     assert lbl(m.x2c) == "&toyota//2"
     assert lbl(m.x2b) == "&toyota//3"
-    assert lbl(m.x3) == "&blueberry:toyota"
-    assert lbl(m.x4) == "&blueberry:#toyota"
-    assert lbl(m.x4b) == "&blueberry:#toyota//2"
+    assert lbl(m.x3) == "blueberry:&toyota"
+    assert lbl(m.x4) == "#blueberry:&toyota"
+    assert lbl(m.x4b) == "#blueberry:&toyota//2"
 
 
 def test_labeler_nonames():


### PR DESCRIPTION
The labeler currently produces stuff like `while:body:f` instead of `body:while:f`, this fixes the issue.
