### PR TITLE
Two fixes in parser and IR

### DIFF
--- a/myia/ir/node.py
+++ b/myia/ir/node.py
@@ -116,9 +116,14 @@ class Graph:
             if node in seen:
                 continue
             seen.add(node)
-            for edge in node.edges.values():
+            for edge in list(node.edges.values()):
                 if edge.label is SEQ and edge.node in mapping_seq:
-                    edge.node = mapping_seq[edge.node]
+                    repl = mapping_seq[edge.node]
+                    if repl is None:
+                        edge.node = None
+                        del node.edges[SEQ]
+                    else:
+                        edge.node = mapping_seq[edge.node]
                 elif edge.node in mapping:
                     edge.node = mapping[edge.node]
                 if edge.node and edge.node.is_apply():

--- a/myia/ir/node.py
+++ b/myia/ir/node.py
@@ -98,7 +98,7 @@ class Graph:
         res.debug = clone_debug(self.debug, objmap)
         return res
 
-    def replace(self, mapping, mapping_seq={}):
+    def replace(self, mapping, mapping_seq={}, recursive=True):
         """Replace nodes in the graph.
 
         This will recursively replace `node` with `mapping[node]` in
@@ -106,6 +106,9 @@ class Graph:
 
         If `node` comes from a sequence edge, it will first look in
         `mapping_seq` for a replacement.
+
+        If `recursive` is True, it will also replace nodes in the
+        children of this graph.
 
         A node can be in either mapping or mapping_seq or both.
         """
@@ -126,8 +129,17 @@ class Graph:
                         edge.node = mapping_seq[edge.node]
                 elif edge.node in mapping:
                     edge.node = mapping[edge.node]
-                if edge.node and edge.node.is_apply():
-                    todo.append(edge.node)
+                if edge.node:
+                    if edge.node.is_apply():
+                        todo.append(edge.node)
+                    elif (
+                        recursive
+                        and edge.node.is_constant_graph()
+                        and edge.node.value.parent is self
+                    ):
+                        edge.node.value.replace(
+                            mapping, mapping_seq, recursive=True
+                        )
 
     def add_debug(self, **kwargs):
         """Add debug information.

--- a/myia/ir/print.py
+++ b/myia/ir/print.py
@@ -79,22 +79,18 @@ def str_graph(g, allow_cycles=False, recursive=True):
             applies.append(node)
 
             seq = node.edges.get(SEQ, None)
-            if seq and seq.node is not None:
+            if seq:
                 todo.append(seq.node)
             if recursive:
                 nodes = [e.node for e in node.edges.values()]
                 for node in nodes:
-                    if node is not None and node.is_constant_graph():
+                    if node.is_constant_graph():
                         todo_graphs.append(node.value)
 
         def _print_stragglers(n):
             nodes = [e.node for e in n.edges.values()]
             for node in nodes:
-                if (
-                    node is not None
-                    and node.is_apply()
-                    and node not in seen_nodes
-                ):
+                if node.is_apply() and node not in seen_nodes:
                     seen_nodes.add(node)
                     _print_stragglers(node)
                     _print_node(node, buf, nodecache, offset=2)

--- a/myia/parser.py
+++ b/myia/parser.py
@@ -376,10 +376,9 @@ class Parser:
         elif var in function.variables_local:
             assert st.is_apply()
             repl[ld] = st.edges[1].node
-            if SEQ in ld.edges:
-                repl_seq[ld] = ld.edges[SEQ].node
-            else:
-                repl_seq[ld] = None
+            # There should always be at least one store before this load
+            assert SEQ in ld.edges
+            repl_seq[ld] = ld.edges[SEQ].node
         else:
             raise AssertionError(
                 f"unclassified variable '{var}'"

--- a/tests/ir/test_node.py
+++ b/tests/ir/test_node.py
@@ -154,9 +154,46 @@ def test_graph_replace():
     r_s = {a: None}
     g.replace(r, r_s)
 
-    assert g.output.edges[SEQ].node.edges[SEQ].node is None
+    assert SEQ not in g.output.edges[SEQ].node.edges
     assert g.output.edges[1].node is p
     assert g.output.edges[0].node.edges[1].node is p
+
+
+def test_graph_replace2():
+    g = Graph()
+    p = g.add_parameter("p")
+    a = g.apply("add", p, 0)
+    a2 = g.apply("add", p, a)
+    a2.add_edge(SEQ, a)
+    a3 = g.apply("op", a2, a)
+    a3.add_edge(SEQ, a2)
+    g.output = a3
+
+    b = g.apply("make_int", p)
+
+    r = {a: b}
+    r_s = {a2: b}
+    g.replace(r, r_s)
+
+    assert g.output.edges[SEQ].node is b
+    assert g.output.edges[1].node is b
+    assert g.output.edges[0].node.edges[0].node is p
+
+
+def test_graph_replace3():
+    g = Graph()
+    p = g.add_parameter("p")
+    a = g.apply("add", p, 0)
+    g2 = Graph(parent=g)
+    g2.output = g2.apply("add", p, a)
+    g.output = g.apply(g2)
+    g.output.add_edge(SEQ, a)
+
+    r = {a: p}
+    r_s = {a: None}
+    g.replace(r, r_s)
+
+    assert g.output.fn.value.output.edges[1].node is p
 
 
 def test_graph_add_debug():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -178,6 +178,29 @@ def test_seq2():
         )
 
 
+def test_resolve_read():
+    def f():
+        global a
+        global b
+        a2 = a + 1
+        b2 = b + 2
+        return a2 + b2
+
+    with enable_debug():
+        assert (
+            str_graph(parse(f))
+            == """graph f() {
+  #1 = resolve(:tests.test_parser, a)
+  a2 = <built-in function add>(#1, 1)
+  #2 = resolve(:tests.test_parser, b)
+  b2 = <built-in function add>(#2, 2)
+  #3 = <built-in function add>(a2, b2)
+  return #3
+}
+"""
+        )
+
+
 def test_def():
     def f():  # pragma: no cover
         def g(a):


### PR DESCRIPTION
- The parser no longer ends a SEQ chain with None.  Instead the last node in the chain doesn't have a SEQ edge.
- Replace now covers child graphs for the closed-over values.