### PR TITLE
Parse positional-only arguments

### DIFF
--- a/myia/ir/node.py
+++ b/myia/ir/node.py
@@ -22,6 +22,7 @@ class Graph:
         self.varargs = False
         self.kwargs = False
         self.defaults = {}
+        self.posonly = 0
         self.kwonly = 0
         self.debug = make_debug(obj=self)
 

--- a/myia/parser.py
+++ b/myia/parser.py
@@ -583,7 +583,7 @@ class Parser:
 
         This can be used for any argument list.
         """
-        pargs = args.args
+        pargs = args.posonlyargs + args.args
         nondefaults = [None] * (len(pargs) - len(args.defaults))
         defaults = nondefaults + args.defaults
 
@@ -593,9 +593,6 @@ class Parser:
 
         defaults_name = []
         defaults_list = []
-
-        # We don't handle this for now.
-        assert args.posonlyargs == []
 
         for arg, dflt in zip(pargs + kwargs, defaults + kwdefaults):
             with debug_inherit(name=arg.arg, location=self.make_location(arg)):
@@ -642,6 +639,7 @@ class Parser:
         function_block.graph.varargs = vararg_node
         function_block.graph.kwargs = kwarg_node
         function_block.graph.defaults = dict(zip(defaults_name, defaults_list))
+        function_block.graph.posonly = len(args.posonlyargs)
         function_block.graph.kwonly = len(args.kwonlyargs)
 
     def _create_function(self, block, node):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -5,6 +5,22 @@ from myia.parser import MyiaSyntaxError, parse
 from myia.utils.info import enable_debug
 
 
+def test_posonly_args():
+    def f1(a, b, c, d, e):  # pragma: no cover
+        pass
+
+    g1 = parse(f1)
+    assert len(g1.parameters) == 5
+    assert g1.posonly == 0
+
+    def f2(a, b, /, c, d, e):  # pragma: no cover
+        pass
+
+    g2 = parse(f2)
+    assert len(g2.parameters) == 5
+    assert g2.posonly == 2
+
+
 def test_same():
     def f():  # pragma: no cover
         return 1

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -5,22 +5,6 @@ from myia.parser import MyiaSyntaxError, parse
 from myia.utils.info import enable_debug
 
 
-def test_posonly_args():
-    def f1(a, b, c, d, e):  # pragma: no cover
-        pass
-
-    g1 = parse(f1)
-    assert len(g1.parameters) == 5
-    assert g1.posonly == 0
-
-    def f2(a, b, /, c, d, e):  # pragma: no cover
-        pass
-
-    g2 = parse(f2)
-    assert len(g2.parameters) == 5
-    assert g2.posonly == 2
-
-
 def test_same():
     def f():  # pragma: no cover
         return 1
@@ -426,6 +410,15 @@ graph g(a, b) {
 }
 """
         )
+
+
+def test_def_posonly():
+    def f(a, b, /, c, d, e):  # pragma: no cover
+        pass
+
+    g = parse(f)
+    assert len(g.parameters) == 5
+    assert g.posonly == 2
 
 
 def test_getattr():


### PR DESCRIPTION
Hi @abergeron , this is a PR that adds support for positional-only arguments to parser. I also updated the Python backend to correctly generate function parameters list.