### PR TITLE
Disable parser optimizations.

### DIFF
--- a/myia/parser.py
+++ b/myia/parser.py
@@ -9,7 +9,6 @@ from typing import NamedTuple
 from . import basics
 from .ir import Apply, Constant, Graph, Parameter
 from .ir.node import SEQ
-from .parser_opt import parser_opts
 from .utils import ModuleNamespace, Named
 from .utils.info import about, debug_inherit, get_debug
 
@@ -109,9 +108,6 @@ def parse(func):
     if name is not None:
         graph.add_debug(name=name)
     _parse_cache[func] = graph
-
-    for post_opt in parser_opts:
-        post_opt(graph)
 
     return graph
 

--- a/myia/parser_opt.py
+++ b/myia/parser_opt.py
@@ -84,3 +84,9 @@ def remove_useless_universe_getitem(g: Graph):
 
 
 parser_opts = [remove_useless_universe_getitem]
+
+
+def apply_parser_opts(g: Graph):
+    """Apply all parser optimizations and return graph."""
+    remove_useless_universe_getitem(g)
+    return g


### PR DESCRIPTION
Hi @abergeron , this is a PR that disables the parser optimization. Instead I add a function to call explicitly in order to apply optimizations. I also added tests with/without optimizations to maintain coverage.