### PR TITLE
Fix the inferrer when calling nullary functions

### DIFF
--- a/myia/infer/algo.py
+++ b/myia/infer/algo.py
@@ -261,6 +261,9 @@ class Inferrer:
             request.unif = self.unif
             request.payload = task
 
+            if not request.nodes:
+                return self._step(task, request.combine([]))
+
             # All requested nodes are scheduled
             for rnode in request.nodes:
                 self.bootstrap(rnode, origin=task)

--- a/tests/infer/test_infer.py
+++ b/tests/infer/test_infer.py
@@ -78,3 +78,19 @@ def test_fact(x):
 @infer(int, result=TypeError)
 def test_not_function(x):
     return x()
+
+
+@infer(result=int)
+def test_nullary_call():
+    def f():
+        return 1
+
+    return f()
+
+
+@infer(int, result=int)
+def test_constant_branch(x):
+    if x <= 0:
+        return 1
+    else:
+        return 2


### PR DESCRIPTION
This PR fixes bad behavior when calling nullary functions, or any situation where `RequestAll()` is used with an empty list of nodes.
