### PR TITLE
Add the `checked` API decorator

### DIFF
--- a/myia/api.py
+++ b/myia/api.py
@@ -1,0 +1,52 @@
+"""Myia's API functions."""
+
+from .abstract.to_abstract import to_abstract
+from .infer.infnode import infer_graph
+from .parser import parse
+from .utils.info import enable_debug
+
+
+class CheckedFunction:
+    """Decorates a function to turn on type checking with Myia."""
+
+    def __init__(self, fn, args=(), graph=None):
+        self.fn = fn
+        self.args = args
+        self.graph = graph
+        if graph is None:
+            with enable_debug():
+                self.graph = parse(self.fn)
+        self.cache = {}
+
+    def __call__(self, *args):
+        """Typecheck the function and then execute it."""
+        args = (*self.args, *args)
+        types = tuple(to_abstract(arg) for arg in args)
+        result = self.cache.get(types, None)
+        if result is None:
+            try:
+                with enable_debug():
+                    _ = infer_graph(self.graph, types)
+            except Exception as exc:
+                result = exc
+            else:
+                result = True
+            finally:
+                self.cache[types] = result
+
+        if result is True:
+            return self.fn(*args)
+        else:
+            raise result
+
+    def __myia__(self):
+        """Return the underlying object for Myia to interpret."""
+        return self.fn
+
+    def __get__(self, obj, objtype):
+        return CheckedFunction(
+            fn=self.fn, args=(*self.args, obj), graph=self.graph
+        )
+
+
+checked = CheckedFunction

--- a/myia/infer/inferrers.py
+++ b/myia/infer/inferrers.py
@@ -18,6 +18,8 @@ def resolve(node, args, unif):
     assert ns.is_constant(ModuleNamespace)
     assert name.is_constant(str)
     resolved = ns.value[name.value]
+    if hasattr(resolved, "__myia__"):
+        resolved = resolved.__myia__()
     ct = Constant(resolved)
     yield Replace(ct)
     res = yield Require(ct)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,43 @@
+import pytest
+
+from myia.abstract.map import MapError
+from myia.api import checked
+
+
+@checked
+def fact(x):
+    if x <= 1:
+        return x
+    else:
+        return x * fact(x - 1)
+
+
+class Banana:
+    def __init__(self, size):
+        self.size = size
+
+    @checked
+    def bigger(self, obj):
+        return obj <= self.size
+
+
+def test_good():
+    assert fact(5) == 120
+
+    # Should have been cached
+    assert fact(5) == 120
+
+
+def test_bad():
+    with pytest.raises(MapError):
+        fact(5.0)
+
+    # Should have been cached
+    with pytest.raises(MapError):
+        fact(5.0)
+
+
+@pytest.mark.xfail(reason="Objects are not represented properly yet")
+def test_method():
+    b = Banana(7)
+    assert b.bigger(4) is True


### PR DESCRIPTION
Add `myia.api.checked`. The `@checked` decorator can be used on a function to typecheck it and then execute it.