### PR TITLE
Improve inference for universe functions.

### DIFF
--- a/myia/infer/inferrers.py
+++ b/myia/infer/inferrers.py
@@ -95,6 +95,11 @@ def add_standard_inferrers(inferrers):
                 data.AbstractStructure([X], tracks={"interface": Handle}),
                 ret=X,
             ),
+            basics.global_universe_setitem: signature(
+                data.AbstractStructure([X], tracks={"interface": Handle}),
+                X,
+                ret=None,
+            ),
             basics.partial: inference_function(partial_inferrer),
         }
     )

--- a/myia/testing/common.py
+++ b/myia/testing/common.py
@@ -1,6 +1,7 @@
 """Common testing utilities."""
 from ovld import ovld
 
+from myia import basics
 from myia.abstract import data
 from myia.abstract.to_abstract import precise_abstract
 from myia.ir.node import Constant, Graph
@@ -28,6 +29,13 @@ def A(*args):
 def Un(*opts):
     """Convert given arguments to an abstract union for testing."""
     return data.AbstractUnion([A(opt) for opt in opts], tracks={})
+
+
+def H(*opts):
+    """Create an abstract handle."""
+    return data.AbstractStructure(
+        [_to_abstract(opt) for opt in opts], {"interface": basics.Handle}
+    )
 
 
 def build_node(g, descr, nodeset=set()):

--- a/tests/infer/from_master/test_universe.py
+++ b/tests/infer/from_master/test_universe.py
@@ -1,0 +1,46 @@
+from myia.abstract.map import MapError as InferenceError
+from myia.basics import (
+    global_universe_getitem as universe_getitem,
+    global_universe_setitem as universe_setitem,
+    make_handle,
+)
+from myia.testing.common import H
+from myia.testing.multitest import infer, mt
+
+typeof = type
+
+
+@mt(
+    infer(int, result=H(int)),
+    infer((int, float), result=H((int, float))),
+)
+def test_make_handle(x):
+    return make_handle(typeof(x))
+
+
+@mt(
+    infer(H(int), result=int),
+    infer(int, result=InferenceError),
+)
+def test_universe_getitem(h):
+    return universe_getitem(h)
+
+
+@mt(
+    infer(H(int), int, result=None),
+    infer(H(int), float, result=InferenceError),
+    infer(int, int, result=InferenceError),
+)
+def test_universe_setitem(h, v):
+    return universe_setitem(h, v)
+
+
+@mt(
+    infer(H(int), int, int, result=None),
+    infer(H(int), float, float, result=InferenceError),
+)
+def test_universe(h, x, y):
+    init = universe_getitem(h)
+    universe_setitem(h, x + y)
+    xy = universe_getitem(h)
+    return universe_setitem(h, init * xy)


### PR DESCRIPTION
- Add inference for global_unvierse_setitem.
- Improve parsing for inference signatures:
  - keep abstracts and generics if passed
  - use object type if an object is passed (e.g. None)
- Make sure inferrer resolves SEQ nodes.
- Add a utility symbol `H` to common module, to generate abstract handles.
- Add inference tests adapted from master branch.

All added tests should pass.

Extracted from #421 

@breuleux @abergeron 