### PR TITLE
Make inferrer support functions imported from a module

### DIFF
--- a/myia/abstract/to_abstract.py
+++ b/myia/abstract/to_abstract.py
@@ -1,4 +1,5 @@
 """Functions to convert data to an abstract data type."""
+from types import ModuleType
 from typing import Union
 
 from ovld import ovld
@@ -18,6 +19,15 @@ def to_abstract(self, xs: tuple):
     return data.AbstractStructure(
         [self(x) for x in xs], {"interface": type(xs)}
     )
+
+
+@ovld
+def to_abstract(self, x: ModuleType):  # noqa: F811
+    """Convert module to an AbstractValue.
+
+    Keep module as interface so that getattr(interface, name) is valid.
+    """
+    return data.AbstractAtom({"interface": x})
 
 
 @ovld

--- a/myia/infer/inferrers.py
+++ b/myia/infer/inferrers.py
@@ -52,10 +52,15 @@ def getattr_inferrer(node, args, unif):
     assert key_node.is_constant(str)
     obj = yield Require(obj_node)
     key = key_node.value
-    result = getattr(obj.tracks.interface, key)
+    interface = obj.tracks.interface
+    result = getattr(interface, key)
     if isinstance(result, (types.MethodType, types.WrapperDescriptorType)):
         ct = Constant(result)
         new_node = node.graph.apply(basics.partial, ct, obj_node)
+    elif isinstance(interface, types.ModuleType) and isinstance(
+        result, (types.FunctionType, types.BuiltinFunctionType)
+    ):
+        new_node = Constant(result)
     else:
         raise AssertionError("getattr can currently only be used for methods")
         # new_node = Constant(result)

--- a/tests/infer/test_infer.py
+++ b/tests/infer/test_infer.py
@@ -94,3 +94,8 @@ def test_constant_branch(x):
         return 1
     else:
         return 2
+
+
+@infer(int, result=int)
+def test_module_function_call(x):
+    return operator.neg(x)


### PR DESCRIPTION
- Overload to_abstract() for module objects: keep module as interface in an abstract atom.
- Allow getattr inferrer to retrieve symbol from module saved in abstract atom interface.
- Add a test: import `neg()` function from `operator` module.

Extracted from #421 

@breuleux @abergeron 