### PR TITLE
Improve inference for apply nodes if FN node is from a parameter

### DIFF
--- a/myia/infer/inferrers.py
+++ b/myia/infer/inferrers.py
@@ -9,7 +9,12 @@ from ..basics import Handle
 from ..ir import Constant
 from ..utils.misc import ModuleNamespace
 from .algo import Require, RequireAll
-from .infnode import Replace, inference_function, signature
+from .infnode import (
+    Replace,
+    dispatch_inferences,
+    inference_function,
+    signature,
+)
 
 
 def resolve(node, args, unif):
@@ -85,6 +90,24 @@ def add_standard_inferrers(inferrers):
             basics.return_: signature(X, ret=X),
             basics.resolve: inference_function(resolve),
             basics.user_switch: inference_function(user_switch),
+            # builtin constructors
+            type(None): signature(ret=None),
+            bool: dispatch_inferences(
+                (bool, bool),
+                (int, bool),
+                (float, bool),
+            ),
+            int: dispatch_inferences(
+                (bool, int),
+                (int, int),
+                (float, int),
+            ),
+            float: dispatch_inferences(
+                (bool, float),
+                (int, float),
+                (float, float),
+            ),
+            # builtin functions
             int.__add__: signature(int, int, ret=int),
             float.__add__: signature(float, float, ret=float),
             getattr: inference_function(getattr_inferrer),

--- a/myia/infer/infnode.py
+++ b/myia/infer/infnode.py
@@ -4,8 +4,6 @@ import types
 from dataclasses import dataclass
 from typing import Dict, Sequence, Tuple
 
-from ovld import OvldMC
-
 from myia.ir.node import SEQ
 
 from ..abstract import data, utils as autils
@@ -103,7 +101,7 @@ def signature(*arg_types, ret):
     return inference_function(_infer)
 
 
-class InferenceDefinition(metaclass=OvldMC):
+class InferenceDefinition:
     """Helper class to represent a signature."""
 
     __slots__ = "arg_types", "ret_type"
@@ -113,14 +111,6 @@ class InferenceDefinition(metaclass=OvldMC):
             _type_to_abstract(arg_type) for arg_type in arg_types
         )
         self.ret_type = _type_to_abstract(ret_type)
-
-    @classmethod
-    def without_value(cls, abstract: data.AbstractAtom):
-        """Get pure type from given abstract, without associated value.
-
-        Useful to lookup node abstract in registered signatures.
-        """
-        return data.AbstractAtom({"interface": abstract.tracks.interface})
 
 
 def dispatch_inferences(*signatures: Sequence, default=None):
@@ -146,7 +136,7 @@ def dispatch_inferences(*signatures: Sequence, default=None):
         inp_types = []
         for inp in args:
             inp_type = yield Require(inp)
-            inp_types.append(InferenceDefinition.without_value(inp_type))
+            inp_types.append(inp_type)
         inp_types = tuple(inp_types)
         inf_def = def_map[len(inp_types)][inp_types]
         for inp_type, expected_type in zip(inp_types, inf_def.arg_types):

--- a/myia/infer/infnode.py
+++ b/myia/infer/infnode.py
@@ -2,6 +2,9 @@
 
 import types
 from dataclasses import dataclass
+from typing import Dict, Sequence, Tuple
+
+from ovld import OvldMC
 
 from myia.ir.node import SEQ
 
@@ -89,12 +92,68 @@ def signature(*arg_types, ret):
         inp_types = []
         for inp in args:
             inp_types.append((yield Require(inp)))
-        assert len(inp_types) == len(arg_types)
+        assert len(inp_types) == len(arg_types), (
+            f"wrong number of arguments, "
+            f"expected {len(arg_types)}, got {len(inp_types)}"
+        )
         for inp_type, expected_type in zip(inp_types, arg_types):
             autils.unify(expected_type, inp_type, U=unif)
         return autils.reify(return_type, unif=unif.canon)
 
     return inference_function(_infer)
+
+
+class InferenceDefinition(metaclass=OvldMC):
+    """Helper class to represent a signature."""
+
+    __slots__ = "arg_types", "ret_type"
+
+    def __init__(self, *arg_types, ret_type):
+        self.arg_types = tuple(
+            _type_to_abstract(arg_type) for arg_type in arg_types
+        )
+        self.ret_type = _type_to_abstract(ret_type)
+
+    @classmethod
+    def without_value(cls, abstract: data.AbstractAtom):
+        """Get pure type from given abstract, without associated value.
+
+        Useful to lookup node abstract in registered signatures.
+        """
+        return data.AbstractAtom({"interface": abstract.tracks.interface})
+
+
+def dispatch_inferences(*signatures: Sequence, default=None):
+    """Create an inference function from many type signatures.
+
+    Arguments:
+        signatures: a sequence of type signatures.
+            Each signature is a sequence of types or abstract values.
+            First sequence values are the argument types.
+            Last sequence value is the return type.
+            Each sequence must contain at least one element (the return type).
+        default: optional default inferrer function to call if
+            input nodes don't match any signature given above.
+    """
+    def_map = {}  # type: Dict[int, Dict[Tuple, InferenceDefinition]]
+    for sig in signatures:
+        if not isinstance(sig, InferenceDefinition):
+            *arg_types, ret_type = sig
+            sig = InferenceDefinition(*arg_types, ret_type=ret_type)
+        def_map.setdefault(len(sig.arg_types), {})[sig.arg_types] = sig
+
+    def inference(node, args, unif):
+        inp_types = []
+        for inp in args:
+            inp_type = yield Require(inp)
+            inp_types.append(InferenceDefinition.without_value(inp_type))
+        inp_types = tuple(inp_types)
+        inf_def = def_map[len(inp_types)][inp_types]
+        for inp_type, expected_type in zip(inp_types, inf_def.arg_types):
+            autils.unify(inp_type, expected_type, U=unif)
+        return autils.reify(inf_def.ret_type, unif=unif.canon)
+
+    return inference_function(inference)
 
 
 class Replace:
@@ -168,9 +227,27 @@ class InferenceEngine:
 
             #     return autils.reify(fn.out, unif=unif.canon)
 
+            # fn type inference don't go through inferrer logic if
+            # node.fn.abstract was already defined
+            # (e.g. if node.fn is a Parameter node).
+            # So, we need additional checks to get inferrer from fn.
+            inf = None
+            partial_types = []
             if isinstance(fn.tracks.interface, InferenceFunction):
-                partial_types = fn.elements
                 inf = fn.tracks.interface.fn
+                partial_types = fn.elements
+            elif (
+                self.is_abstract_type(fn)
+                and (typ := fn.elements[0].tracks.interface) in self.inferrers
+            ):
+                # Got abstract type with type in inferrers.
+                # We may pass here for e.g. if node is a parameter
+                # and inferred parameter type is an abstract type:
+                # def f(param_type, value):
+                #     return param_type(value)
+                inf = self.inferrers[typ].tracks.interface.fn
+
+            if inf:
                 if isinstance(inf, SpecializedGraph):
                     arg_types = yield RequireAll(*node.inputs)
                     inf.commit((*partial_types, *arg_types))
@@ -208,7 +285,17 @@ class InferenceEngine:
                 return (yield Unify(*optnodes))
 
             else:
-                raise TypeError("Unknown function", fn)
+                raise TypeError("Unknown function", fn, node)
+
+    @classmethod
+    def is_abstract_type(cls, fn: data.AbstractValue):
+        """Return True if given abstract is an abstract type."""
+        return (
+            isinstance(fn, data.AbstractStructure)
+            and fn.tracks.interface is type
+            and len(fn.elements) == 1
+            # and isinstance(fn.elements[0], data.AbstractAtom)
+        )
 
 
 def infer_graph(graph, input_types):

--- a/myia/testing/common.py
+++ b/myia/testing/common.py
@@ -38,6 +38,14 @@ def H(*opts):
     )
 
 
+def Ty(element_type):
+    """Convert given argument to an abstract type."""
+    if isinstance(element_type, data.AbstractValue):
+        return data.AbstractStructure([element_type], {"interface": type})
+    assert isinstance(element_type, type), (element_type, type(element_type))
+    return precise_abstract(element_type)
+
+
 def build_node(g, descr, nodeset=set()):
     """Create a node recursively from a tuple of tuples.
 
@@ -70,3 +78,6 @@ def build_graph(descr, params=[]):
     nodeset.add(g.return_)
     nodeset.add(g.return_.fn)
     return g, nodeset
+
+
+Nil = A(None)

--- a/tests/infer/test_infer.py
+++ b/tests/infer/test_infer.py
@@ -4,6 +4,7 @@ from myia.abstract.map import MapError
 from myia.abstract.to_abstract import to_abstract, type_to_abstract
 from myia.infer.infnode import infer_graph, inferrers, signature
 from myia.parser import parse
+from myia.testing.common import Nil, Ty
 from myia.testing.multitest import infer, mt
 from myia.utils.info import enable_debug
 
@@ -99,3 +100,20 @@ def test_constant_branch(x):
 @infer(int, result=int)
 def test_module_function_call(x):
     return operator.neg(x)
+
+
+@mt(
+    # we could not cast to a Nil,
+    infer(Ty(Nil), int, result=Exception("wrong number of arguments")),
+    infer(Ty(bool), bool, result=bool),
+    infer(Ty(bool), int, result=bool),
+    infer(Ty(bool), float, result=bool),
+    infer(Ty(int), bool, result=int),
+    infer(Ty(int), int, result=int),
+    infer(Ty(int), float, result=int),
+    infer(Ty(float), bool, result=float),
+    infer(Ty(float), int, result=float),
+    infer(Ty(float), float, result=float),
+)
+def test_infer_scalar_cast(dtype, value):
+    return dtype(value)


### PR DESCRIPTION
Use case:
```python
def cast(t, x):
    return t(x)
```
In such case, `t` comes with an abstract type and never goes through inference logic (as it's a parameter node, not a constant nor an apply). So, inference for apply `t(x)` won't be able to get inference function for `t`. This PR tries to fix it.

- Check apply's FN node abstract to get either inference function if available, or lookup inference in inferrers if FN has an abstract type.
- Add a utility method dispatch_inferences() to set multiple signatures for an inference.
- use dispatch_inferences() for constructors inferences: bool, int, float.
- Add a test for this case (test_scalar_cast).

Extracted from #421 

@breuleux @abergeron 