### PR TITLE
Build abstract types for arbitrary objects

### DIFF
--- a/myia/abstract/data.py
+++ b/myia/abstract/data.py
@@ -352,3 +352,35 @@ class Placeholder(GenericBase):
 
     def __hrepr_short__(self, H, hrepr):
         return H.atom["myia-placeholder"](f"??{self.id}")
+
+
+###################
+# Other utilities #
+###################
+
+
+class TypedObject:
+    """Interface to a standard Python type, with a list of its fields.
+
+    It is used in the interface track of an AbstractStructure which must contain
+    the types of the fields in the order given.
+    """
+
+    def __init__(self, cls, field_names):
+        self.cls = cls
+        self.field_names = tuple(field_names)
+        self.indexed = dict(zip(self.field_names, range(len(self.field_names))))
+
+    @property
+    def __name__(self):
+        return self.cls.__name__
+
+    def __hash__(self):
+        return hash((self.cls, self.field_names))
+
+    def __eq__(self, other):
+        return (
+            type(other) is type(self)
+            and self.cls == other.cls
+            and self.field_names == other.field_names
+        )

--- a/myia/abstract/map.py
+++ b/myia/abstract/map.py
@@ -223,9 +223,12 @@ def abstract_map(self, x, **kwargs):
             return result
         cls = result.send(None)
         assert cls is not None
-        inst = cls.empty()
-        constructor = _make_constructor(inst)
-        cache[x] = inst
+        if isinstance(cls, type):
+            inst = cls.empty()
+            constructor = _make_constructor(inst)
+            cache[x] = inst
+        else:
+            inst = constructor = cls
         try:
             result.send(constructor)
         except StopIteration as e:

--- a/myia/abstract/to_abstract.py
+++ b/myia/abstract/to_abstract.py
@@ -32,7 +32,18 @@ def to_abstract(self, x: ModuleType):  # noqa: F811
 
 @ovld
 def to_abstract(self, x: object):  # noqa: F811
-    return data.AbstractAtom({"interface": type(x)})
+    try:
+        members = vars(x)
+    except TypeError:
+        members = []
+    if not members:
+        return data.AbstractAtom({"interface": type(x)})
+    else:
+        field_types = tuple(self(x) for x in members.values())
+        return data.AbstractStructure(
+            field_types,
+            {"interface": data.TypedObject(type(x), members.keys())},
+        )
 
 
 @ovld

--- a/tests/abstract/test_to_abstract.py
+++ b/tests/abstract/test_to_abstract.py
@@ -1,5 +1,7 @@
 from myia.abstract import data
-from myia.abstract.to_abstract import from_value, type_to_abstract
+from myia.abstract.to_abstract import from_value, to_abstract, type_to_abstract
+
+from ..common import Point
 
 
 def test_from_value():
@@ -55,4 +57,24 @@ def test_type_to_abstract():
     assert type_to_abstract(int) is data.AbstractAtom({"interface": int})
     assert from_value(int) is data.AbstractStructure(
         [data.AbstractAtom({"interface": int})], {"interface": type}
+    )
+
+
+def test_obj():
+    pt = Point(1, 2)
+    assert to_abstract(pt) is data.AbstractStructure(
+        (type_to_abstract(int), type_to_abstract(int)),
+        {"interface": data.TypedObject(Point, ["x", "y"])},
+    )
+
+    pt = Point(Point(1, 2), 3)
+    assert to_abstract(pt) is data.AbstractStructure(
+        (
+            data.AbstractStructure(
+                (type_to_abstract(int), type_to_abstract(int)),
+                {"interface": data.TypedObject(Point, ["x", "y"])},
+            ),
+            type_to_abstract(int),
+        ),
+        {"interface": data.TypedObject(Point, ["x", "y"])},
     )

--- a/tests/abstract/test_utils.py
+++ b/tests/abstract/test_utils.py
@@ -104,7 +104,6 @@ def _utest(a, b, expected=True, mappings={}):
     if expected is not True:
         assert c == expected
     for entry, canon in mappings.items():
-        print(entry, canon, U.canon[entry])
         assert U.canon[entry] == canon
     return True
 
@@ -167,7 +166,6 @@ def _mtest(a, b, expected=True, mappings={}):
     if expected is not True:
         assert c == expected
     for entry, canon in mappings.items():
-        print(entry, canon, U.canon[entry])
         assert U.canon[entry] == canon
     return True
 
@@ -210,6 +208,8 @@ def test_recursivize():
     rapt3 = recursivize(rapt, parents={}, tagger=tg_p)
     assert rapt is rapt3
 
+    assert str(rapt) == "#1=*Point(*U(*int(), #1=*Point()), *int())"
+
     tri = Trio(Point(1, 2), Point(1.5, 2.5), Point(Point(1, 2), 3))
     atri = to_abstract(tri)
     ratri = recursivize(atri, parents={}, tagger=tg_p)
@@ -247,3 +247,7 @@ def test_recursivize_broaden():
     rapt = recursivize(apt, parents={}, tagger=tg_p)
     rapt2 = recursivize(apt2, parents={}, tagger=tg_p)
     assert rapt is rapt2
+    assert (
+        str(rapt)
+        == "#1=*Point(*U(#2=*int(value ↦ ANYTHING), #1=*Point()), #2=*int())"
+    )

--- a/tests/common.py
+++ b/tests/common.py
@@ -58,3 +58,16 @@ def predictable_placeholders():
         yield
     finally:
         data._id = old_id
+
+
+class Point:
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+
+class Trio:
+    def __init__(self, a, b, c):
+        self.a = a
+        self.b = b
+        self.c = c

--- a/tests/infer/test_infer.py
+++ b/tests/infer/test_infer.py
@@ -117,3 +117,19 @@ def test_module_function_call(x):
 )
 def test_infer_scalar_cast(dtype, value):
     return dtype(value)
+
+
+class Banana:
+    def __init__(self, size):
+        self.size = size
+
+    def bigger(self, obj):
+        return obj <= self.size
+
+
+@mt(
+    infer(Banana(3.5), float, result=bool),
+    infer(Banana("ohno"), float, result=MapError),
+)
+def test_method(b, x):
+    return b.bigger(x)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -37,7 +37,6 @@ def test_bad():
         fact(5.0)
 
 
-@pytest.mark.xfail(reason="Objects are not represented properly yet")
 def test_method():
     b = Banana(7)
     assert b.bigger(4) is True


### PR DESCRIPTION
* `to_abstract` on an arbitrary object generates an `AbstractStructure` with an interface that lists the object's fields, and the types are in the elements.
* `recursivize` generalizes instances into recursive abstract types, e.g. `Cons(int, Cons(int, empty))` => `#1=Cons(int, Union(#1, empty))`. It is not part of the pipeline for the time being.
